### PR TITLE
Update HtmlAttributes CopyTo logic

### DIFF
--- a/src/Markdig.Tests/Markdig.Tests.csproj
+++ b/src/Markdig.Tests/Markdig.Tests.csproj
@@ -54,6 +54,7 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Renderers\Html\HtmlAttributesTests.cs" />
     <Compile Include="Specs\Specs.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/Markdig.Tests/Renderers/Html/HtmlAttributesTests.cs
+++ b/src/Markdig.Tests/Renderers/Html/HtmlAttributesTests.cs
@@ -1,0 +1,32 @@
+﻿using Markdig.Renderers.Html;
+using NUnit.Framework;
+
+namespace Markdig.Tests.Renderers.Html
+{
+    [TestFixture]
+    public class HtmlAttributesTests
+    {
+        public class CopyTo : HtmlAttributesTests
+        {
+            [Test]
+            public void ShouldNotThrowExceptionWhenSharedIsFalseAndClassesIsNull()
+            {
+                var sut = new HtmlAttributes();
+
+                Assert.Null(sut.Classes);
+
+                Assert.DoesNotThrow(() => sut.CopyTo(new HtmlAttributes(), shared: false));
+            }
+
+            [Test]
+            public void ShouldNotThrowExceptionWhenSharedIsFalseAndPropertiesIsNull()
+            {
+                var sut = new HtmlAttributes();
+
+                Assert.Null(sut.Properties);
+
+                Assert.DoesNotThrow(() => sut.CopyTo(new HtmlAttributes(), shared: false));
+            }
+        }
+    }
+}

--- a/src/Markdig/Renderers/Html/HtmlAttributes.cs
+++ b/src/Markdig/Renderers/Html/HtmlAttributes.cs
@@ -118,7 +118,9 @@ namespace Markdig.Renderers.Html
             }
             if (htmlAttributes.Classes == null)
             {
-                htmlAttributes.Classes = shared ? Classes : new List<string>(Classes);
+                htmlAttributes.Classes = shared
+                    ? Classes
+                    : new List<string>(Classes ?? new List<string>());
             }
             else if (Classes != null)
             {
@@ -127,7 +129,10 @@ namespace Markdig.Renderers.Html
 
             if (htmlAttributes.Properties == null)
             {
-                htmlAttributes.Properties = shared ? Properties : new List<KeyValuePair<string, string>>(Properties);
+                htmlAttributes.Properties = shared
+                    ? Properties
+                    : new List<KeyValuePair<string, string>>(
+                        Properties ?? new List<KeyValuePair<string, string>>());
             }
             else if (Properties != null)
             {


### PR DESCRIPTION
New behavior does an additional check on the `Classes` and `Properties` properties to make sure null-values are not passed to their respective List<T> constructors.
Previous behavior would throw an exception is the former was true and the `share`-parameter was `false`.

Ref. https://github.com/lunet-io/markdig/issues/23.