### PR TITLE
Include digits after first letter in Urilize (for Auto-Identifiers)

### DIFF
--- a/src/Markdig.Tests/Markdig.Tests.csproj
+++ b/src/Markdig.Tests/Markdig.Tests.csproj
@@ -24,6 +24,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -100,6 +101,7 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Markdig.Tests/project.json
+++ b/src/Markdig.Tests/project.json
@@ -18,6 +18,7 @@
     }
   },
   "dependencies": {
-    "NUnit": "3.2.0"
+    "NUnit": "3.2.0",
+    "NUnit3TestAdapter": "3.2.0"
   }
 }

--- a/src/Markdig/Helpers/LinkHelper.cs
+++ b/src/Markdig/Helpers/LinkHelper.cs
@@ -61,6 +61,11 @@ namespace Markdig.Helpers
                         }
                         previousIsSpace = false;
                     }
+                    else if (c.IsDigit())
+                    {
+                        headingBuffer.Append(c);
+                        previousIsSpace = false;
+                    }
                     else if (!previousIsSpace && c.IsWhitespace())
                     {
                         var pc = headingBuffer[headingBuffer.Length - 1];


### PR DESCRIPTION
Feel free to ignore changes to project.json and the .csproj - those are solely for allowing me to utilize the VS Test Runner:
Added dependency in project.json: NUnit3TestAdapter
Disabled "Prefer 32-bit" on Markdig.Tests(.csproj) to accommodate NUnit.