### PR TITLE
Adding support for rel=nofollow in links

### DIFF
--- a/src/Markdig/Extensions/NoRefLinks/NoFollowLinksExtension.cs
+++ b/src/Markdig/Extensions/NoRefLinks/NoFollowLinksExtension.cs
@@ -7,7 +7,10 @@ using Markdig.Renderers.Html.Inlines;
 
 namespace Markdig.Extensions.NoRefLinks
 {
-    public class NoRefLinksExtension : IMarkdownExtension
+    /// <summary>
+    /// Extension to automatically render rel=nofollow to all links in an HTML output.
+    /// </summary>
+    public class NoFollowLinksExtension : IMarkdownExtension
     {
         public void Setup(MarkdownPipelineBuilder pipeline)
         {

--- a/src/Markdig/Extensions/NoRefLinks/NoRefLinksExtension.cs
+++ b/src/Markdig/Extensions/NoRefLinks/NoRefLinksExtension.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license. 
+// See the license.txt file in the project root for more information.
+
+using Markdig.Parsers.Inlines;
+using Markdig.Renderers;
+using Markdig.Renderers.Html.Inlines;
+
+namespace Markdig.Extensions.NoRefLinks
+{
+    public class NoRefLinksExtension : IMarkdownExtension
+    {
+        public void Setup(MarkdownPipelineBuilder pipeline)
+        {
+        }
+
+        public void Setup(IMarkdownRenderer renderer)
+        {
+            var linkRenderer = renderer.ObjectRenderers.Find<LinkInlineRenderer>();
+            if (linkRenderer != null)
+            {
+                linkRenderer.AutoRelNoFollow = true;
+            }
+
+            var autolinkRenderer = renderer.ObjectRenderers.Find<AutolinkInlineRenderer>();
+            if (autolinkRenderer != null)
+            {
+                autolinkRenderer.AutoRelNoFollow = true;
+            }
+        }
+    }
+}

--- a/src/Markdig/Extensions/NoRefLinks/NoRefLinksExtension.cs
+++ b/src/Markdig/Extensions/NoRefLinks/NoRefLinksExtension.cs
@@ -2,7 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-using Markdig.Parsers.Inlines;
 using Markdig.Renderers;
 using Markdig.Renderers.Html.Inlines;
 

--- a/src/Markdig/MarkdownExtensions.cs
+++ b/src/Markdig/MarkdownExtensions.cs
@@ -20,6 +20,7 @@ using Markdig.Extensions.Hardlines;
 using Markdig.Extensions.ListExtras;
 using Markdig.Extensions.Mathematics;
 using Markdig.Extensions.MediaLinks;
+using Markdig.Extensions.NoRefLinks;
 using Markdig.Extensions.PragmaLines;
 using Markdig.Extensions.SelfPipeline;
 using Markdig.Extensions.SmartyPants;
@@ -59,6 +60,7 @@ namespace Markdig
                 .UseListExtras()
                 .UseTaskLists()
                 .UseDiagrams()
+                .UseNoRefLinks()
                 .UseGenericAttributes(); // Must be last as it is one parser that is modifying other parsers
         }
 
@@ -367,6 +369,17 @@ namespace Markdig
         }
 
         /// <summary>
+        /// Add rel=nofollow to all links rendered to HTML.
+        /// </summary>
+        /// <param name="pipeline"></param>
+        /// <returns></returns>
+        public static MarkdownPipelineBuilder UseNoFollowLinks(this MarkdownPipelineBuilder pipeline)
+        {
+            pipeline.Extensions.AddIfNotAlready<NoFollowLinksExtension>();
+            return pipeline;
+        }
+
+        /// <summary>
         /// This will disable the HTML support in the markdown processor (for constraint/safe parsing).
         /// </summary>
         /// <param name="pipeline">The pipeline.</param>
@@ -471,6 +484,9 @@ namespace Markdig
                         break;
                     case "diagrams":
                         pipeline.UseDiagrams();
+                        break;
+                    case "nofollowlinks":
+                        pipeline.UseNoFollowLinks();
                         break;
                     default:
                         throw new ArgumentException($"Invalid extension `{extension}` from `{extensions}`", nameof(extensions));

--- a/src/Markdig/MarkdownExtensions.cs
+++ b/src/Markdig/MarkdownExtensions.cs
@@ -60,7 +60,6 @@ namespace Markdig
                 .UseListExtras()
                 .UseTaskLists()
                 .UseDiagrams()
-                .UseNoRefLinks()
                 .UseGenericAttributes(); // Must be last as it is one parser that is modifying other parsers
         }
 

--- a/src/Markdig/Renderers/Html/Inlines/AutolinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/AutolinkInlineRenderer.cs
@@ -11,6 +11,11 @@ namespace Markdig.Renderers.Html.Inlines
     /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Syntax.Inlines.AutolinkInline}" />
     public class AutolinkInlineRenderer : HtmlObjectRenderer<AutolinkInline>
     {
+        /// <summary>
+        /// Gets or sets a value indicating whether to always add rel="nofollow" for links or not.
+        /// </summary>
+        public bool AutoRelNoFollow { get; set; }
+
         protected override void Write(HtmlRenderer renderer, AutolinkInline obj)
         {
             if (renderer.EnableHtmlForInline)
@@ -22,6 +27,12 @@ namespace Markdig.Renderers.Html.Inlines
                 }
                 renderer.WriteEscapeUrl(obj.Url);
                 renderer.WriteAttributes(obj);
+
+                if (!obj.IsEmail && AutoRelNoFollow)
+                {
+                    renderer.Write(" rel=\"nofollow\"");
+                }
+
                 renderer.Write("\">");
             }
 

--- a/src/Markdig/Renderers/Html/Inlines/LinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LinkInlineRenderer.cs
@@ -57,13 +57,12 @@ namespace Markdig.Renderers.Html.Inlines
             }
             else
             {
-                if (AutoRelNoFollow)
-                {
-                    renderer.Write(" rel=\"nofollow\"");
-                }
-
                 if (renderer.EnableHtmlForInline)
                 {
+                    if (AutoRelNoFollow)
+                    {
+                        renderer.Write(" rel=\"nofollow\"");
+                    }
                     renderer.Write(">");
                 }
                 renderer.WriteChildren(link);

--- a/src/Markdig/Renderers/Html/Inlines/LinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LinkInlineRenderer.cs
@@ -11,6 +11,11 @@ namespace Markdig.Renderers.Html.Inlines
     /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Syntax.Inlines.LinkInline}" />
     public class LinkInlineRenderer : HtmlObjectRenderer<LinkInline>
     {
+        /// <summary>
+        /// Gets or sets a value indicating whether to always add rel="nofollow" for links or not.
+        /// </summary>
+        public bool AutoRelNoFollow { get; set; }
+
         protected override void Write(HtmlRenderer renderer, LinkInline link)
         {
             if (renderer.EnableHtmlForInline)
@@ -41,6 +46,11 @@ namespace Markdig.Renderers.Html.Inlines
                 renderer.Write(" title=\"");
                 renderer.WriteEscape(link.Title);
                 renderer.Write("\"");
+            }
+
+            if (AutoRelNoFollow)
+            {
+                renderer.Write(" rel=\"nofollow\"");
             }
 
             if (link.IsImage)

--- a/src/Markdig/Renderers/Html/Inlines/LinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LinkInlineRenderer.cs
@@ -48,11 +48,6 @@ namespace Markdig.Renderers.Html.Inlines
                 renderer.Write("\"");
             }
 
-            if (AutoRelNoFollow)
-            {
-                renderer.Write(" rel=\"nofollow\"");
-            }
-
             if (link.IsImage)
             {
                 if (renderer.EnableHtmlForInline)
@@ -62,6 +57,11 @@ namespace Markdig.Renderers.Html.Inlines
             }
             else
             {
+                if (AutoRelNoFollow)
+                {
+                    renderer.Write(" rel=\"nofollow\"");
+                }
+
                 if (renderer.EnableHtmlForInline)
                 {
                     renderer.Write(">");


### PR DESCRIPTION
This PR adds support for automatically adding rel=nofollow to HTML links - this in many times is desired (if not necessary) especially when allowing content that is not necessarily trusted to be published.