### PR TITLE
Bugfix/cell after colspan

### DIFF
--- a/src/Markdig.Tests/Specs/GridTableSpecs.md
+++ b/src/Markdig.Tests/Specs/GridTableSpecs.md
@@ -70,8 +70,8 @@ A regular row can continue a previous regular row when column separator `|` are 
 +---------+---------+---------+
 | Col1    | Col2    | Col3    |
 | Col1a   | Col2a   | Col3a   |
-| Col12             | Col3b   |
-| Col123                      |
+| Col1b             | Col3b   |
+| Col1c                       |
 .
 <table>
 <col style="width:33.33%">
@@ -87,11 +87,11 @@ Col2a</td>
 Col3a</td>
 </tr>
 <tr>
-<td colspan="2">Col12</td>
-<td></td>
+<td colspan="2">Col1b</td>
+<td>Col3b</td>
 </tr>
 <tr>
-<td colspan="3">Col123</td>
+<td colspan="3">Col1c</td>
 </tr>
 </tbody>
 </table>

--- a/src/Markdig.Tests/Specs/Specs.cs
+++ b/src/Markdig.Tests/Specs/Specs.cs
@@ -17583,7 +17583,7 @@ namespace Markdig.Tests
             //     | Col1    | Col2    | Col3    |
             //     | Col1a   | Col2a   | Col3a   |
             //     | Col1b             | Col3b   |
-            //     | Col12c                      |
+            //     | Col1c                       |
             //
             // Should be rendered as:
             //     <table>

--- a/src/Markdig.Tests/Specs/Specs.cs
+++ b/src/Markdig.Tests/Specs/Specs.cs
@@ -17582,8 +17582,8 @@ namespace Markdig.Tests
             //     +---------+---------+---------+
             //     | Col1    | Col2    | Col3    |
             //     | Col1a   | Col2a   | Col3a   |
-            //     | Col12             | Col3b   |
-            //     | Col123                      |
+            //     | Col1b             | Col3b   |
+            //     | Col12c                      |
             //
             // Should be rendered as:
             //     <table>
@@ -17600,17 +17600,17 @@ namespace Markdig.Tests
             //     Col3a</td>
             //     </tr>
             //     <tr>
-            //     <td colspan="2">Col12</td>
-            //     <td></td>
+            //     <td colspan="2">Col1b</td>
+            //     <td>Col3b</td>
             //     </tr>
             //     <tr>
-            //     <td colspan="3">Col123</td>
+            //     <td colspan="3">Col1c</td>
             //     </tr>
             //     </tbody>
             //     </table>
 
             Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 3, "Extensions Grid Table");
-			TestParser.TestSpec("+---------+---------+---------+\n| Col1    | Col2    | Col3    |\n| Col1a   | Col2a   | Col3a   |\n| Col12             | Col3b   |\n| Col123                      |", "<table>\n<col style=\"width:33.33%\">\n<col style=\"width:33.33%\">\n<col style=\"width:33.33%\">\n<tbody>\n<tr>\n<td>Col1\nCol1a</td>\n<td>Col2\nCol2a</td>\n<td>Col3\nCol3a</td>\n</tr>\n<tr>\n<td colspan=\"2\">Col12</td>\n<td></td>\n</tr>\n<tr>\n<td colspan=\"3\">Col123</td>\n</tr>\n</tbody>\n</table>", "gridtables|advanced");
+			TestParser.TestSpec("+---------+---------+---------+\n| Col1    | Col2    | Col3    |\n| Col1a   | Col2a   | Col3a   |\n| Col1b             | Col3b   |\n| Col1c                       |", "<table>\n<col style=\"width:33.33%\">\n<col style=\"width:33.33%\">\n<col style=\"width:33.33%\">\n<tbody>\n<tr>\n<td>Col1\nCol1a</td>\n<td>Col2\nCol2a</td>\n<td>Col3\nCol3a</td>\n</tr>\n<tr>\n<td colspan=\"2\">Col1b</td>\n<td>Col3b</td>\n</tr>\n<tr>\n<td colspan=\"3\">Col1c</td>\n</tr>\n</tbody>\n</table>", "gridtables|advanced");
         }
     }
         // A row header is separated using `+========+` instead of `+---------+`:

--- a/src/Markdig/Extensions/Tables/GridTableParser.cs
+++ b/src/Markdig/Extensions/Tables/GridTableParser.cs
@@ -131,11 +131,12 @@ namespace Markdig.Extensions.Tables
                     // | ------------- | ------------ | ---------------------------------------- |
                     // Calculate the colspan for the new row
                     int columnIndex = -1;
-                    foreach (var columnSlice in columns)
+                    for (int i = 0; i < columns.Count; i++)
                     {
+                        var columnSlice = columns[i];
                         if (line.PeekCharExtra(columnSlice.Start) == '|')
                         {
-                            columnIndex++;
+                            columnIndex = i;
                         }
                         if (columnIndex >= 0)
                         {
@@ -301,8 +302,9 @@ namespace Markdig.Extensions.Tables
         {
             var columns = tableState.ColumnSlices;
             TableRow currentRow = null;
-            foreach (var columnSlice in columns)
+            for (int i = 0; i < columns.Count; i++)
             {
+                var columnSlice = columns[i];
                 if (columnSlice.CurrentCell != null)
                 {
                     if (currentRow == null)
@@ -332,7 +334,8 @@ namespace Markdig.Extensions.Tables
                     // Else we can create a new cell
                     columnSlice.CurrentCell = new TableCell(this)
                     {
-                        ColumnSpan = columnSlice.CurrentColumnSpan
+                        ColumnSpan = columnSlice.CurrentColumnSpan,
+                        ColumnIndex = i
                     };
 
                     if (columnSlice.BlockProcessor == null)

--- a/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
+++ b/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
@@ -78,10 +78,10 @@ namespace Markdig.Extensions.Tables
                     {
                         renderer.Write($" colspan=\"{cell.ColumnSpan}\"");
                     }
-
-                    if (table.ColumnDefinitions != null && i < table.ColumnDefinitions.Count)
+                    var columnIndex = cell.ColumnIndex == -1 ? i : cell.ColumnIndex;
+                    if (table.ColumnDefinitions != null && columnIndex < table.ColumnDefinitions.Count)
                     {
-                        switch (table.ColumnDefinitions[i].Alignment)
+                        switch (table.ColumnDefinitions[columnIndex].Alignment)
                         {
                             case TableColumnAlign.Center:
                                 renderer.Write(" style=\"text-align: center;\"");

--- a/src/Markdig/Extensions/Tables/TableCell.cs
+++ b/src/Markdig/Extensions/Tables/TableCell.cs
@@ -27,7 +27,13 @@ namespace Markdig.Extensions.Tables
         public TableCell(BlockParser parser) : base(parser)
         {
             ColumnSpan = 1;
+            ColumnIndex = -1;
         }
+
+        /// <summary>
+        /// Gets or sets the index of the column to which this cell belongs.
+        /// </summary>
+        public int ColumnIndex { get; set; }
 
         /// <summary>
         /// Gets or sets the column span this cell is covering. Default is 1.


### PR DESCRIPTION
Example 003 for Grid Tables has a small error in the expected output.
Input:
```
+---------+---------+---------+
| Col1    | Col2    | Col3    |
| Col1a   | Col2a   | Col3a   |
| Col1b             | Col3b   |
| Col1c                       |
```
Should produce:
<table>
<col style="width:33.33%">
<col style="width:33.33%">
<col style="width:33.33%">
<tbody>
<tr>
<td>Col1<br />
Col1a</td>
<td>Col2<br />
Col2a</td>
<td>Col3<br />
Col3a</td>
</tr>
<tr>
<td colspan="2">Col1b</td>
<td>Col3b</td>
</tr>
<tr>
<td colspan="3">Col1c</td>
</tr>
</tbody>
</table>
But the spec expects (and currently passes):
<table>
<col style="width:33.33%">
<col style="width:33.33%">
<col style="width:33.33%">
<tbody>
<tr>
<td>Col1<br />
Col1a</td>
<td>Col2<br />
Col2a</td>
<td>Col3<br />
Col3a</td>
</tr>
<tr>
<td colspan="2">Col1b</td>
<td></td>
</tr>
<tr>
<td colspan="3">Col1c</td>
</tr>
</tbody>
</table>
This hides a small bug when cells follow cells with with a colspan.
I've adjusted the way column span is calculated to correct this.
I've also added a property to `TableCell` called `ColumnIndex` which records which column a cell belongs to, to make sure alignment is correctly inherited. This property is not used for pipe tables.