### PR TITLE
Adds support for rowspans in grid tables

### DIFF
--- a/src/Markdig.Tests/Specs/GridTableSpecs.md
+++ b/src/Markdig.Tests/Specs/GridTableSpecs.md
@@ -184,3 +184,92 @@ Alignment might be specified on the first row using the character `:`:
 </tbody>
 </table>
 ````````````````````````````````
+
+ A grid table may have cells spanning both columns and rows:
+
+```````````````````````````````` example
++---+---+---+
+| AAAAA | B |
++---+---+ B +
+| D | E | B |
++ D +---+---+
+| D | CCCCC |
++---+---+---+
+.
+<table>
+<col style="width:33.33%">
+<col style="width:33.33%">
+<col style="width:33.33%">
+<tbody>
+<tr>
+<td colspan="2">AAAAA</td>
+<td rowspan="2">B
+B
+B</td>
+</tr>
+<tr>
+<td rowspan="2">D
+D
+D</td>
+<td>E</td>
+</tr>
+<tr>
+<td colspan="2">CCCCC</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+A grid table may have cells with both colspan and rowspan:
+
+```````````````````````````````` example
++---+---+---+
+| AAAAA | B |
++ AAAAA +---+
+| AAAAA | C |
++---+---+---+
+| D | E | F |
++---+---+---+
+.
+<table>
+<col style="width:33.33%">
+<col style="width:33.33%">
+<col style="width:33.33%">
+<tbody>
+<tr>
+<td colspan="2" rowspan="2">AAAAA
+AAAAA
+AAAAA</td>
+<td>B</td>
+</tr>
+<tr>
+<td>C</td>
+</tr>
+<tr>
+<td>D</td>
+<td>E</td>
+<td>F</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+A grid table may not have irregularly shaped cells:
+
+```````````````````````````````` example
++---+---+---+
+| AAAAA | B |
++ A +---+ B +
+| A | C | B |
++---+---+---+
+| DDDDD | E |
++---+---+---+
+.
+<p>+---+---+---+
+| AAAAA | B |
++ A +---+ B +
+| A | C | B |
++---+---+---+
+| DDDDD | E |
++---+---+---+</p>
+````````````````````````````````

--- a/src/Markdig.Tests/Specs/Specs.cs
+++ b/src/Markdig.Tests/Specs/Specs.cs
@@ -17699,6 +17699,131 @@ namespace Markdig.Tests
 			TestParser.TestSpec("+-----+:---:+-----+\n|  A  |  B  |  C  |\n+-----+-----+-----+", "<table>\n<col style=\"width:33.33%\">\n<col style=\"width:33.33%\">\n<col style=\"width:33.33%\">\n<tbody>\n<tr>\n<td>A</td>\n<td style=\"text-align: center;\">B</td>\n<td>C</td>\n</tr>\n</tbody>\n</table>", "gridtables|advanced");
         }
     }
+        // A grid table may have cells spanning both columns and rows:
+    [TestFixture]
+    public partial class TestExtensionsGridTable
+    {
+        [Test]
+        public void Example008()
+        {
+            // Example 8
+            // Section: Extensions Grid Table
+            //
+            // The following CommonMark:
+            //     +---+---+---+
+            //     | AAAAA | B |
+            //     +---+---+ B +
+            //     | D | E | B |
+            //     + D +---+---+
+            //     | D | CCCCC |
+            //     +---+---+---+
+            //
+            // Should be rendered as:
+            //     <table>
+            //     <col style="width:33.33%">
+            //     <col style="width:33.33%">
+            //     <col style="width:33.33%">
+            //     <tbody>
+            //     <tr>
+            //     <td colspan="2">AAAAA</td>
+            //     <td rowspan="2">B
+            //     B
+            //     B</td>
+            //     </tr>
+            //     <tr>
+            //     <td rowspan="2">D
+            //     D
+            //     D</td>
+            //     <td>E</td>
+            //     </tr>
+            //     <tr>
+            //     <td colspan="2">CCCCC</td>
+            //     </tr>
+            //     </tbody>
+            //     </table>
+
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 8, "Extensions Grid Table");
+			TestParser.TestSpec("+---+---+---+\n| AAAAA | B |\n+---+---+ B +\n| D | E | B |\n+ D +---+---+\n| D | CCCCC |\n+---+---+---+", "<table>\n<col style=\"width:33.33%\">\n<col style=\"width:33.33%\">\n<col style=\"width:33.33%\">\n<tbody>\n<tr>\n<td colspan=\"2\">AAAAA</td>\n<td rowspan=\"2\">B\nB\nB</td>\n</tr>\n<tr>\n<td rowspan=\"2\">D\nD\nD</td>\n<td>E</td>\n</tr>\n<tr>\n<td colspan=\"2\">CCCCC</td>\n</tr>\n</tbody>\n</table>", "gridtables|advanced");
+        }
+    }
+        // A grid table may have cells with both colspan and rowspan:
+    [TestFixture]
+    public partial class TestExtensionsGridTable
+    {
+        [Test]
+        public void Example009()
+        {
+            // Example 9
+            // Section: Extensions Grid Table
+            //
+            // The following CommonMark:
+            //     +---+---+---+
+            //     | AAAAA | B |
+            //     + AAAAA +---+
+            //     | AAAAA | C |
+            //     +---+---+---+
+            //     | D | E | F |
+            //     +---+---+---+
+            //
+            // Should be rendered as:
+            //     <table>
+            //     <col style="width:33.33%">
+            //     <col style="width:33.33%">
+            //     <col style="width:33.33%">
+            //     <tbody>
+            //     <tr>
+            //     <td colspan="2" rowspan="2">AAAAA
+            //     AAAAA
+            //     AAAAA</td>
+            //     <td>B</td>
+            //     </tr>
+            //     <tr>
+            //     <td>C</td>
+            //     </tr>
+            //     <tr>
+            //     <td>D</td>
+            //     <td>E</td>
+            //     <td>F</td>
+            //     </tr>
+            //     </tbody>
+            //     </table>
+
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 9, "Extensions Grid Table");
+			TestParser.TestSpec("+---+---+---+\n| AAAAA | B |\n+ AAAAA +---+\n| AAAAA | C |\n+---+---+---+\n| D | E | F |\n+---+---+---+", "<table>\n<col style=\"width:33.33%\">\n<col style=\"width:33.33%\">\n<col style=\"width:33.33%\">\n<tbody>\n<tr>\n<td colspan=\"2\" rowspan=\"2\">AAAAA\nAAAAA\nAAAAA</td>\n<td>B</td>\n</tr>\n<tr>\n<td>C</td>\n</tr>\n<tr>\n<td>D</td>\n<td>E</td>\n<td>F</td>\n</tr>\n</tbody>\n</table>", "gridtables|advanced");
+        }
+    }
+        // A grid table may not have irregularly shaped cells:
+    [TestFixture]
+    public partial class TestExtensionsGridTable
+    {
+        [Test]
+        public void Example010()
+        {
+            // Example 10
+            // Section: Extensions Grid Table
+            //
+            // The following CommonMark:
+            //     +---+---+---+
+            //     | AAAAA | B |
+            //     + A +---+ B +
+            //     | A | C | B |
+            //     +---+---+---+
+            //     | DDDDD | E |
+            //     +---+---+---+
+            //
+            // Should be rendered as:
+            //     <p>+---+---+---+
+            //     | AAAAA | B |
+            //     + A +---+ B +
+            //     | A | C | B |
+            //     +---+---+---+
+            //     | DDDDD | E |
+            //     +---+---+---+</p>
+
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 10, "Extensions Grid Table");
+			TestParser.TestSpec("+---+---+---+\n| AAAAA | B |\n+ A +---+ B +\n| A | C | B |\n+---+---+---+\n| DDDDD | E |\n+---+---+---+", "<p>+---+---+---+\n| AAAAA | B |\n+ A +---+ B +\n| A | C | B |\n+---+---+---+\n| DDDDD | E |\n+---+---+---+</p>", "gridtables|advanced");
+        }
+    }
         // # Extensions
         //
         // This section describes the different extensions supported:

--- a/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
+++ b/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
@@ -81,6 +81,10 @@ namespace Markdig.Extensions.Tables
                     {
                         renderer.Write($" colspan=\"{cell.ColumnSpan}\"");
                     }
+                    if (cell.RowSpan != 1)
+                    {
+                        renderer.Write($" rowspan=\"{cell.RowSpan}\"");
+                    }
                     var columnIndex = cell.ColumnIndex == -1 ? i : cell.ColumnIndex;
                     if (table.ColumnDefinitions != null && columnIndex < table.ColumnDefinitions.Count)
                     {
@@ -104,7 +108,7 @@ namespace Markdig.Extensions.Tables
                     }
                     renderer.Write(cell);
                     renderer.ImplicitParagraph = previousImplicitParagraph;
-                    
+
                     renderer.WriteLine(row.IsHeader ? "</th>" : "</td>");
                 }
                 renderer.WriteLine("</tr>");

--- a/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
+++ b/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
@@ -85,9 +85,9 @@ namespace Markdig.Extensions.Tables
                     {
                         renderer.Write($" rowspan=\"{cell.RowSpan}\"");
                     }
-                    var columnIndex = cell.ColumnIndex == -1 ? i : cell.ColumnIndex;
-                    if (table.ColumnDefinitions != null && columnIndex < table.ColumnDefinitions.Count)
+                    if (table.ColumnDefinitions != null)
                     {
+                        var columnIndex = cell.ColumnIndex == -1 || cell.ColumnIndex > table.ColumnDefinitions.Count ? i : cell.ColumnIndex;
                         switch (table.ColumnDefinitions[columnIndex].Alignment)
                         {
                             case TableColumnAlign.Center:

--- a/src/Markdig/Extensions/Tables/Table.cs
+++ b/src/Markdig/Extensions/Tables/Table.cs
@@ -34,5 +34,40 @@ namespace Markdig.Extensions.Tables
         /// Gets or sets the column alignments. May be null.
         /// </summary>
         public List<TableColumnDefinition> ColumnDefinitions { get; private set; }
+
+        /// <summary>
+        /// Checks if the table structure is valid.
+        /// </summary>
+        /// <returns><c>True</c> if the table has rows and the number of cells per row is correct, other wise <c>false</c>.</returns>
+        public bool IsValid()
+        {
+            // A table with no rows is not valid.
+            if (Count == 0)
+            {
+                return false;
+            }
+            var columnCount = ColumnDefinitions.Count;
+            var rows = new int[Count];
+            for (int i = 0; i < Count; i++)
+            {
+                var row = (TableRow)this[i];
+                for (int j = 0; j < row.Count; j++)
+                {
+                    var cell = (TableCell)row[j];
+                    rows[i] += cell.ColumnSpan;
+                    var rowSpan = cell.RowSpan - 1;
+                    while (rowSpan > 0)
+                    {
+                        rows[i + rowSpan] += cell.ColumnSpan;
+                        rowSpan--;
+                    }
+                }
+                if (rows[i] > columnCount)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
     }
 }

--- a/src/Markdig/Extensions/Tables/TableCell.cs
+++ b/src/Markdig/Extensions/Tables/TableCell.cs
@@ -26,8 +26,10 @@ namespace Markdig.Extensions.Tables
         /// <param name="parser">The parser used to create this block.</param>
         public TableCell(BlockParser parser) : base(parser)
         {
+            AllowClose = true;
             ColumnSpan = 1;
             ColumnIndex = -1;
+            RowSpan = 1;
         }
 
         /// <summary>
@@ -39,5 +41,15 @@ namespace Markdig.Extensions.Tables
         /// Gets or sets the column span this cell is covering. Default is 1.
         /// </summary>
         public int ColumnSpan { get; set; }
+
+        /// <summary>
+        /// Gets or sets the row span this cell is covering. Default is 1.
+        /// </summary>
+        public int RowSpan { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether this cell can be closed.
+        /// </summary>
+        public bool AllowClose { get; set; }
     }
 }


### PR DESCRIPTION
I'm afraid I changed the `Grid Table Parser` quite a bit here.
Feel free to wrap my knuckles and suggest better changes though!

This adds support for cells spanning rows, in addition to columns.