### PR TITLE
Fixes issue where trailing text after an inline math block is both included in the math block and appended after the math block.

### DIFF
--- a/src/Markdig.Tests/Specs/MathSpecs.md
+++ b/src/Markdig.Tests/Specs/MathSpecs.md
@@ -68,6 +68,13 @@ This is a $$$math block$$$
 <p>This is a <span class="math">$math block$</span></p>
 ````````````````````````````````
 
+Regular text can come both before and after the math inline
+
+```````````````````````````````` example
+This is a $math block$ with text on both sides.
+.
+<p>This is a <span class="math">math block</span> with text on both sides.</p>
+````````````````````````````````
 A mathematic block takes precedence over standard emphasis `*` `_`:
 
 ```````````````````````````````` example

--- a/src/Markdig.Tests/Specs/Specs.cs
+++ b/src/Markdig.Tests/Specs/Specs.cs
@@ -18662,7 +18662,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a $$$math block$$$", "<p>This is a <span class=\"math\">$math block$</span></p>", "mathematics|advanced");
         }
     }
-        // A mathematic block takes precedence over standard emphasis `*` `_`:
+        // Regular text can come both before and after the math inline
     [TestFixture]
     public partial class TestExtensionsMathInline
     {
@@ -18673,12 +18673,32 @@ namespace Markdig.Tests
             // Section: Extensions Math Inline
             //
             // The following CommonMark:
+            //     This is a $math block$ with text on both sides.
+            //
+            // Should be rendered as:
+            //     <p>This is a <span class="math">math block</span> with text on both sides.</p>
+
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 9, "Extensions Math Inline");
+			TestParser.TestSpec("This is a $math block$ with text on both sides.", "<p>This is a <span class=\"math\">math block</span> with text on both sides.</p>", "mathematics|advanced");
+        }
+    }
+        // A mathematic block takes precedence over standard emphasis `*` `_`:
+    [TestFixture]
+    public partial class TestExtensionsMathInline
+    {
+        [Test]
+        public void Example010()
+        {
+            // Example 10
+            // Section: Extensions Math Inline
+            //
+            // The following CommonMark:
             //     This is *a $math* block$
             //
             // Should be rendered as:
             //     <p>This is *a <span class="math">math* block</span></p>
 
-            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 9, "Extensions Math Inline");
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 10, "Extensions Math Inline");
 			TestParser.TestSpec("This is *a $math* block$", "<p>This is *a <span class=\"math\">math* block</span></p>", "mathematics|advanced");
         }
     }
@@ -18690,9 +18710,9 @@ namespace Markdig.Tests
     public partial class TestExtensionsMathBlock
     {
         [Test]
-        public void Example010()
+        public void Example011()
         {
-            // Example 10
+            // Example 11
             // Section: Extensions Math Block
             //
             // The following CommonMark:
@@ -18710,7 +18730,7 @@ namespace Markdig.Tests
             //     \end{equation}
             //     </div>
 
-            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 10, "Extensions Math Block");
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 11, "Extensions Math Block");
 			TestParser.TestSpec("$$\n\\begin{equation}\n  \\int_0^\\infty \\frac{x^3}{e^x-1}\\,dx = \\frac{\\pi^4}{15}\n  \\label{eq:sample}\n\\end{equation}\n$$", "<div class=\"math\">\\begin{equation}\n  \\int_0^\\infty \\frac{x^3}{e^x-1}\\,dx = \\frac{\\pi^4}{15}\n  \\label{eq:sample}\n\\end{equation}\n</div>", "mathematics|advanced");
         }
     }

--- a/src/Markdig/Extensions/Mathematics/MathInlineParser.cs
+++ b/src/Markdig/Extensions/Mathematics/MathInlineParser.cs
@@ -63,6 +63,7 @@ namespace Markdig.Extensions.Mathematics
             int closeDollars = 0;
 
             var start = slice.Start;
+            var end = 0;
             pc = match;
             while (c != '\0')
             {
@@ -101,7 +102,7 @@ namespace Markdig.Extensions.Mathematics
                 {
                     return false;
                 }
-
+                end = slice.Start - 1;
                 // Create a new MathInline
                 int line;
                 int column;
@@ -116,7 +117,7 @@ namespace Markdig.Extensions.Mathematics
                 };
                 inline.Content.Start = start;
                 // We substract the end to the number of opening $ to keep inside the block the additionals $
-                inline.Content.End = inline.Content.End - openDollars;
+                inline.Content.End = end - openDollars;
 
                 // Add the default class if necessary
                 if (DefaultClass != null)


### PR DESCRIPTION
I found an issue where inline math with trailing text both included the text _inside_ the maths block and _outside_ the maths block.

For example:
```
This is a $math block$ with text on both sides.
````

Should render as
```html
<p>This is a <span class="math">math block</span> with text on both sides.</p>
```

But instead we get
```html
<p>This is a <span class="math">math block$ with text on both sides.</span> with text on both sides.</p>
```