### PR TITLE
Fixes issue where multiple definition lists are created when they are nested in a list item.

### DIFF
--- a/src/Markdig.Tests/Specs/DefinitionListSpecs.md
+++ b/src/Markdig.Tests/Specs/DefinitionListSpecs.md
@@ -105,3 +105,28 @@ Term 1
 <pre><code>: Not valid
 </code></pre>
 ````````````````````````````````
+
+Definition lists can be nested inside list items
+
+```````````````````````````````` example
+1.  First
+    
+2.  Second
+    
+    Term 1
+    :   Definition
+    
+    Term 2
+    :   Second Definition
+.
+<ol>
+<li><p>First</p></li>
+<li><p>Second</p>
+<dl>
+<dt>Term 1</dt>
+<dd>Definition</dd>
+<dt>Term 2</dt>
+<dd>Second Definition</dd>
+</dl></li>
+</ol>
+````````````````````````````````

--- a/src/Markdig.Tests/Specs/Specs.cs
+++ b/src/Markdig.Tests/Specs/Specs.cs
@@ -18085,6 +18085,43 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Term 1\n\n    : Not valid", "<p>Term 1</p>\n<pre><code>: Not valid\n</code></pre>", "definitionlists+attributes|advanced");
         }
     }
+        // Definition lists can be nested inside list items
+    [TestFixture]
+    public partial class TestExtensionsDefinitionlists
+    {
+        [Test]
+        public void Example006()
+        {
+            // Example 6
+            // Section: Extensions Definition lists
+            //
+            // The following CommonMark:
+            //     1.  First
+            //         
+            //     2.  Second
+            //         
+            //         Term 1
+            //         :   Definition
+            //         
+            //         Term 2
+            //         :   Second Definition
+            //
+            // Should be rendered as:
+            //     <ol>
+            //     <li><p>First</p></li>
+            //     <li><p>Second</p>
+            //     <dl>
+            //     <dt>Term 1</dt>
+            //     <dd>Definition</dd>
+            //     <dt>Term 2</dt>
+            //     <dd>Second Definition</dd>
+            //     </dl></li>
+            //     </ol>
+
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 6, "Extensions Definition lists");
+			TestParser.TestSpec("1.  First\n    \n2.  Second\n    \n    Term 1\n    :   Definition\n    \n    Term 2\n    :   Second Definition", "<ol>\n<li><p>First</p></li>\n<li><p>Second</p>\n<dl>\n<dt>Term 1</dt>\n<dd>Definition</dd>\n<dt>Term 2</dt>\n<dd>Second Definition</dd>\n</dl></li>\n</ol>", "definitionlists+attributes|advanced");
+        }
+    }
         // # Extensions
         //
         // This section describes the different extensions supported:

--- a/src/Markdig/Extensions/DefinitionLists/DefinitionListParser.cs
+++ b/src/Markdig/Extensions/DefinitionLists/DefinitionListParser.cs
@@ -51,8 +51,7 @@ namespace Markdig.Extensions.DefinitionLists
             }
 
             var previousParent = paragraphBlock.Parent;
-            var indexOfParagraph = previousParent.IndexOf(paragraphBlock);
-            var currentDefinitionList = indexOfParagraph - 1 >= 0 ? previousParent[indexOfParagraph - 1] as DefinitionList : null;
+            var currentDefinitionList = GetCurrentDefinitionList(paragraphBlock, previousParent);
 
             processor.Discard(paragraphBlock);
 
@@ -101,6 +100,18 @@ namespace Markdig.Extensions.DefinitionLists
             currentDefinitionList.UpdateSpanEnd(processor.Line.End);
 
             return BlockState.Continue;
+        }
+
+        private static DefinitionList GetCurrentDefinitionList(ParagraphBlock paragraphBlock, ContainerBlock previousParent)
+        {
+            var index = previousParent.IndexOf(paragraphBlock) - 1;
+            if (index < 0) return null;
+            var lastBlock = previousParent[index];
+            if (lastBlock is BlankLineBlock)
+            {
+                lastBlock = previousParent[index - 1];
+            }
+            return lastBlock as DefinitionList;
         }
 
         public override BlockState TryContinue(BlockProcessor processor, Block block)

--- a/src/Markdig/Extensions/DefinitionLists/DefinitionListParser.cs
+++ b/src/Markdig/Extensions/DefinitionLists/DefinitionListParser.cs
@@ -110,6 +110,7 @@ namespace Markdig.Extensions.DefinitionLists
             if (lastBlock is BlankLineBlock)
             {
                 lastBlock = previousParent[index - 1];
+                previousParent.RemoveAt(index);
             }
             return lastBlock as DefinitionList;
         }


### PR DESCRIPTION
I've experienced an issue where a nested definition list outputs multiple definition lists, instead of one list with multiple terms.
The following markdown:
```md
1.  Item One
    
2.  Item Two
    
    Term One
    :   Description One
    
    Term Two
    :   Description Two
    
    Term Three
    :   Description Three
    
3.  Item Three
```
is rendered as:
```html
<ol>
<li><p>Item One</p></li>
<li><p>Item Two</p>
<dl>
<dt>Term One</dt>
<dd>Description One</dd>
</dl>
<dl>
<dt>Term Two</dt>
<dd>Description Two</dd>
</dl>
<dl>
<dt>Term Three</dt>
<dd>Description Three</dd>
</dl>
</li>
<li><p>Item Three</p></li>
</ol>
```
instead of:
```html
<ol>
<li><p>Item One</p></li>
<li><p>Item Two</p>
<dl>
<dt>Term One</dt>
<dd>Description One</dd>
<dt>Term Two</dt>
<dd>Description Two</dd>
<dt>Term Three</dt>
<dd>Description Three</dd>
</dl>
</li>
<li><p>Item Three</p></li>
</ol>
```

I've tracked this down to the way the `DefinitionListParser` will look for the item _before_ the last `ParagraphBlock` for an existing `DefinitionList` but, when the `DefinitionList` is nested in a `ListItem`, there will be an additional `BlankItemBlock` between them.