### PR TITLE
Changes List Extra to output valid integer for start attribute, instead of roman or latin character.

### DIFF
--- a/src/Markdig.Tests/Specs/ListExtraSpecs.md
+++ b/src/Markdig.Tests/Specs/ListExtraSpecs.md
@@ -38,7 +38,7 @@ Like for numbered list, a list can start with a different letter
 b. First item
 c. Second item
 .
-<ol type="a" start="b">
+<ol type="a" start="2">
 <li>First item</li>
 <li>Second item</li>
 </ol>
@@ -100,7 +100,7 @@ Like for numbered list, a list can start with a different letter
 ii. First item
 iii. Second item
 .
-<ol type="i" start="ii">
+<ol type="i" start="2">
 <li>First item</li>
 <li>Second item</li>
 </ol>

--- a/src/Markdig.Tests/Specs/Specs.cs
+++ b/src/Markdig.Tests/Specs/Specs.cs
@@ -18300,13 +18300,13 @@ namespace Markdig.Tests
             //     c. Second item
             //
             // Should be rendered as:
-            //     <ol type="a" start="b">
+            //     <ol type="a" start="2">
             //     <li>First item</li>
             //     <li>Second item</li>
             //     </ol>
 
             Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 3, "Extensions Ordered list with alpha letter");
-			TestParser.TestSpec("b. First item\nc. Second item", "<ol type=\"a\" start=\"b\">\n<li>First item</li>\n<li>Second item</li>\n</ol>", "listextras|advanced");
+			TestParser.TestSpec("b. First item\nc. Second item", "<ol type=\"a\" start=\"2\">\n<li>First item</li>\n<li>Second item</li>\n</ol>", "listextras|advanced");
         }
     }
         // A different type of list will break the existing list:
@@ -18410,13 +18410,13 @@ namespace Markdig.Tests
             //     iii. Second item
             //
             // Should be rendered as:
-            //     <ol type="i" start="ii">
+            //     <ol type="i" start="2">
             //     <li>First item</li>
             //     <li>Second item</li>
             //     </ol>
 
             Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 7, "Extensions Ordered list with roman letter");
-			TestParser.TestSpec("ii. First item\niii. Second item", "<ol type=\"i\" start=\"ii\">\n<li>First item</li>\n<li>Second item</li>\n</ol>", "listextras|advanced");
+			TestParser.TestSpec("ii. First item\niii. Second item", "<ol type=\"i\" start=\"2\">\n<li>First item</li>\n<li>Second item</li>\n</ol>", "listextras|advanced");
         }
     }
         // # Extensions

--- a/src/Markdig/Extensions/ListExtras/ListExtraItemParser.cs
+++ b/src/Markdig/Extensions/ListExtras/ListExtraItemParser.cs
@@ -7,6 +7,8 @@ using Markdig.Parsers;
 
 namespace Markdig.Extensions.ListExtras
 {
+    using System;
+
     /// <summary>
     /// Parser that adds supports for parsing alpha/roman list items (e.g: `a)` or `a.` or `ii.` or `II.`)
     /// </summary>
@@ -52,7 +54,7 @@ namespace Markdig.Extensions.ListExtras
                     c = state.NextChar();
                 }
 
-                result.OrderedStart = state.Line.Text.Substring(startChar, endChar - startChar + 1);
+                result.OrderedStart = CharHelper.RomanToArabic(state.Line.Text.Substring(startChar, endChar - startChar + 1)).ToString();
                 result.BulletType = isRomanLow ? 'i' : 'I';
                 result.DefaultOrderedStart = isRomanLow ? "i" : "I";
             }
@@ -60,7 +62,7 @@ namespace Markdig.Extensions.ListExtras
             {
                 // otherwise we expect a regular alpha lettered list with a single character.
                 var isUpper = c.IsAlphaUpper();
-                result.OrderedStart = c.ToString();
+                result.OrderedStart = (Char.ToUpper(c) - 64).ToString();
                 result.BulletType = isUpper ? 'A' : 'a';
                 result.DefaultOrderedStart = isUpper ? "A" : "a";
                 state.NextChar();

--- a/src/Markdig/Helpers/CharHelper.cs
+++ b/src/Markdig/Helpers/CharHelper.cs
@@ -7,6 +7,8 @@ using System.Runtime.CompilerServices;
 
 namespace Markdig.Helpers
 {
+    using System.Collections.Generic;
+
     /// <summary>
     /// Helper class for handling characters.
     /// </summary>
@@ -17,6 +19,9 @@ namespace Markdig.Helpers
         public const char ZeroSafeChar = '\uFFFD';
 
         public const string ZeroSafeString = "\uFFFD";
+
+        // We don't support LCDM
+        private static IDictionary<char, int> romanMap = new Dictionary<char, int> { { 'I', 1 }, { 'V', 5 }, { 'X', 10 } };
 
         public static void CheckOpenCloseDelimiter(char pc, char c, bool enableWithinWord, out bool canOpen, out bool canClose)
         {
@@ -78,6 +83,26 @@ namespace Markdig.Helpers
         {
             // We don't support LCDM
             return c == 'I' || c == 'V' || c == 'X';
+        }
+
+        [MethodImpl(MethodImplOptionPortable.AggressiveInlining)]
+        public static int RomanToArabic(string text)
+        {
+            int result = 0;
+            for (int i = 0; i < text.Length; i++)
+            {
+                var character = Char.ToUpper(text[i]);
+                var candidate = romanMap[character];
+                if (i + 1 < text.Length && candidate < romanMap[Char.ToUpper(text[i + 1])])
+                {
+                    result -= candidate;
+                }
+                else
+                {
+                    result += candidate;
+                }
+            }
+            return result;
         }
 
         [MethodImpl(MethodImplOptionPortable.AggressiveInlining)]

--- a/src/Markdig/Renderers/Html/ListRenderer.cs
+++ b/src/Markdig/Renderers/Html/ListRenderer.cs
@@ -23,7 +23,7 @@ namespace Markdig.Renderers.Html
                     renderer.Write(" type=\"").Write(listBlock.BulletType).Write("\"");
                 }
 
-                if (listBlock.OrderedStart != null && (listBlock.DefaultOrderedStart != listBlock.OrderedStart))
+                if (listBlock.OrderedStart != null && (listBlock.OrderedStart != "1"))
                 {
                     renderer.Write(" start=\"").Write(listBlock.OrderedStart).Write("\"");
                 }


### PR DESCRIPTION
The List Extra extension currently outputs whatever the next value is when continuing lists, which may not be a valid integer.
I've changed it so it converts latin and roman characters to the appropriate number for the start attribute.