### PR TITLE
Checks if paragraph block is closed when deciding if continuation list is allowable with character other than '1.'

### DIFF
--- a/src/Markdig.Tests/Specs/ListExtraSpecs.md
+++ b/src/Markdig.Tests/Specs/ListExtraSpecs.md
@@ -105,3 +105,21 @@ iii. Second item
 <li>Second item</li>
 </ol>
 ````````````````````````````````
+
+Lists can be restarted, specifying the start point.
+
+```````````````````````````````` example
+1.   First item
+
+Some text
+
+2.   Second item
+.
+<ol>
+<li>First item</li>
+</ol>
+<p>Some text</p>
+<ol start="2">
+<li>Second item</li>
+</ol>
+````````````````````````````````

--- a/src/Markdig.Tests/Specs/Specs.cs
+++ b/src/Markdig.Tests/Specs/Specs.cs
@@ -18419,6 +18419,36 @@ namespace Markdig.Tests
 			TestParser.TestSpec("ii. First item\niii. Second item", "<ol type=\"i\" start=\"2\">\n<li>First item</li>\n<li>Second item</li>\n</ol>", "listextras|advanced");
         }
     }
+        // Lists can be restarted, specifying the start point.
+    [TestFixture]
+    public partial class TestExtensionsOrderedlistwithromanletter
+    {
+        [Test]
+        public void Example008()
+        {
+            // Example 8
+            // Section: Extensions Ordered list with roman letter
+            //
+            // The following CommonMark:
+            //     1.   First item
+            //     
+            //     Some text
+            //     
+            //     2.   Second item
+            //
+            // Should be rendered as:
+            //     <ol>
+            //     <li>First item</li>
+            //     </ol>
+            //     <p>Some text</p>
+            //     <ol start="2">
+            //     <li>Second item</li>
+            //     </ol>
+
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 8, "Extensions Ordered list with roman letter");
+			TestParser.TestSpec("1.   First item\n\nSome text\n\n2.   Second item", "<ol>\n<li>First item</li>\n</ol>\n<p>Some text</p>\n<ol start=\"2\">\n<li>Second item</li>\n</ol>", "listextras|advanced");
+        }
+    }
         // # Extensions
         //
         // The following the figure extension:

--- a/src/Markdig/Parsers/BlockProcessor.cs
+++ b/src/Markdig/Parsers/BlockProcessor.cs
@@ -401,6 +401,11 @@ namespace Markdig.Parsers
             parserStateCache.Release(this);
         }
 
+        internal bool IsOpen(Block block)
+        {
+            return OpenedBlocks.Contains(block);
+        }
+
         /// <summary>
         /// Closes a block at the specified index.
         /// </summary>

--- a/src/Markdig/Parsers/ListBlockParser.cs
+++ b/src/Markdig/Parsers/ListBlockParser.cs
@@ -253,10 +253,14 @@ namespace Markdig.Parsers
             // - an empty list item follows a paragraph
             // - an ordered list is not starting by '1'
             var isPreviousParagraph = (block ?? state.LastBlock) is ParagraphBlock;
-            if (isPreviousParagraph && (state.IsBlankLine || (listInfo.BulletType == '1' && listInfo.OrderedStart != "1")))
+            if (isPreviousParagraph)
             {
-                state.GoToColumn(initColumn);
-                return BlockState.None;
+                var isOpen = state.IsOpen(block ?? state.LastBlock);
+                if (state.IsBlankLine || (isOpen && listInfo.BulletType == '1' && listInfo.OrderedStart != "1"))
+                {
+                    state.GoToColumn(initColumn);
+                    return BlockState.None;
+                }
             }
 
             var newListItem = new ListItemBlock(this)


### PR DESCRIPTION
This fixes #54.
Due to the way `IBlock.IsOpen` is used, it wasn't possible to just check that property, so I have added an internal method to `BlockProcesser` to check if the block is still contained in the `OpenedBlocks` collection.