### PR TITLE
Fixes problem with multiple, similar abbreviations not parsing correctly

### DIFF
--- a/src/Markdig.Tests/Specs/AbbreviationSpecs.md
+++ b/src/Markdig.Tests/Specs/AbbreviationSpecs.md
@@ -45,3 +45,15 @@ This is a 😃 HTML document
 .
 <p>This is a <abbr title="Hypertext Markup Language">😃 HTML</abbr> document</p>
 ````````````````````````````````
+
+Abbreviations may be similar:
+
+```````````````````````````````` example
+*[1A]: First
+*[1A1]: Second
+*[1A2]: Third
+
+We can abbreviate 1A, 1A1 and 1A2!
+.
+<p>We can abbreviate <abbr title="First">1A</abbr>, <abbr title="Second">1A1</abbr> and <abbr title="Third">1A2</abbr>!</p>
+````````````````````````````````

--- a/src/Markdig.Tests/Specs/Specs.cs
+++ b/src/Markdig.Tests/Specs/Specs.cs
@@ -18227,6 +18227,30 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*[😃 HTML]: Hypertext Markup Language\n\nThis is a 😃 HTML document    ", "<p>This is a <abbr title=\"Hypertext Markup Language\">😃 HTML</abbr> document</p>", "abbreviations|advanced");
         }
     }
+        // Abbreviations may be similar:
+    [TestFixture]
+    public partial class TestExtensionsAbbreviation
+    {
+        [Test]
+        public void Example005()
+        {
+            // Example 5
+            // Section: Extensions Abbreviation
+            //
+            // The following CommonMark:
+            //     *[1A]: First
+            //     *[1A1]: Second
+            //     *[1A2]: Third
+            //     
+            //     We can abbreviate 1A, 1A1 and 1A2!
+            //
+            // Should be rendered as:
+            //     <p>We can abbreviate <abbr title="First">1A</abbr>, <abbr title="Second">1A1</abbr> and <abbr title="Third">1A2</abbr>!</p>
+
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 5, "Extensions Abbreviation");
+			TestParser.TestSpec("*[1A]: First\n*[1A1]: Second\n*[1A2]: Third\n\nWe can abbreviate 1A, 1A1 and 1A2!", "<p>We can abbreviate <abbr title=\"First\">1A</abbr>, <abbr title=\"Second\">1A1</abbr> and <abbr title=\"Third\">1A2</abbr>!</p>", "abbreviations|advanced");
+        }
+    }
         // # Extensions
         //
         // The following additional list items are supported:

--- a/src/Markdig/Helpers/TextMatcher.cs
+++ b/src/Markdig/Helpers/TextMatcher.cs
@@ -53,16 +53,16 @@ namespace Markdig.Helpers
                 CharNode nextNode;
                 if (!node.TryGetValue(c, out nextNode))
                 {
-                    return false;
+                    break;
                 }
                 node = nextNode;
-                if (node.Content != null)
-                {
-                    match = node.Content;
-                    return true;
-                }
                 offset++;
                 length--;
+            }
+            if (node.Content != null)
+            {
+                match = node.Content;
+                return true;
             }
             return false;
         }


### PR DESCRIPTION
When you have multiple, similar (when an abbreviation is a substring of another abbreviation) abbreviations then only the first abbreviation will be applied.
For example:
```md
*[1A]: First
*[1A1]: Second
*[1A2]: Third
We can abbreviate 1A, 1A1 and 1A2!
```
should result in:
```html
<p>We can abbreviate <abbr title="First">1A</abbr>, <abbr title="Second">1A1</abbr> and <abbr title="Third">1A2</abbr>!</p>
```
but instead we get:
```html
<p>We can abbreviate <abbr title="First">1A</abbr>, 1A1 and 1A2!</p>
```