### PR TITLE
Adds exceptions to allow certain punctuation characters to behave as inline delimiters

### DIFF
--- a/src/Markdig.Tests/Specs/EmphasisExtraSpecs.md
+++ b/src/Markdig.Tests/Specs/EmphasisExtraSpecs.md
@@ -21,6 +21,17 @@ H~2~O is a liquid. 2^10^ is 1024
 .
 <p>H<sub>2</sub>O is a liquid. 2<sup>10</sup> is 1024</p>
 ````````````````````````````````
+ 
+Certain punctuation characters are exempted from the rule forbidding them within inline delimiters
+
+```````````````````````````````` example
+One quintillionth can be expressed as 10^-18^
+
+Daggers^†^ and double-daggers^‡^ can be used to denote notes.
+.
+<p>One quintillionth can be expressed as 10<sup>-18</sup></p>
+<p>Daggers<sup>†</sup> and double-daggers<sup>‡</sup> can be used to denote notes.</p>
+````````````````````````````````
 
 ## Inserted
 

--- a/src/Markdig.Tests/Specs/Specs.cs
+++ b/src/Markdig.Tests/Specs/Specs.cs
@@ -17358,6 +17358,29 @@ namespace Markdig.Tests
 			TestParser.TestSpec("H~2~O is a liquid. 2^10^ is 1024", "<p>H<sub>2</sub>O is a liquid. 2<sup>10</sup> is 1024</p>", "emphasisextras|advanced");
         }
     }
+        // Certain punctuation characters are exempted from the rule forbidding them within inline delimiters
+    [TestFixture]
+    public partial class TestExtensionsSuperscriptandSubscript
+    {
+        [Test]
+        public void Example003()
+        {
+            // Example 3
+            // Section: Extensions Superscript and Subscript
+            //
+            // The following CommonMark:
+            //     One quintillionth can be expressed as 10^-18^
+            //     
+            //     Daggers^†^ and double-daggers^‡^ can be used to denote notes.
+            //
+            // Should be rendered as:
+            //     <p>One quintillionth can be expressed as 10<sup>-18</sup></p>
+            //     <p>Daggers<sup>†</sup> and double-daggers<sup>‡</sup> can be used to denote notes.</p>
+
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 3, "Extensions Superscript and Subscript");
+			TestParser.TestSpec("One quintillionth can be expressed as 10^-18^\n\nDaggers^†^ and double-daggers^‡^ can be used to denote notes.", "<p>One quintillionth can be expressed as 10<sup>-18</sup></p>\n<p>Daggers<sup>†</sup> and double-daggers<sup>‡</sup> can be used to denote notes.</p>", "emphasisextras|advanced");
+        }
+    }
         // ## Inserted
         //
         // Inserted text can be used to specify that a text has been added to a document.  The semantic used for the generated HTML is the tag `<ins>`.
@@ -17365,9 +17388,9 @@ namespace Markdig.Tests
     public partial class TestExtensionsInserted
     {
         [Test]
-        public void Example003()
+        public void Example004()
         {
-            // Example 3
+            // Example 4
             // Section: Extensions Inserted
             //
             // The following CommonMark:
@@ -17376,7 +17399,7 @@ namespace Markdig.Tests
             // Should be rendered as:
             //     <p><ins>Inserted text</ins></p>
 
-            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 3, "Extensions Inserted");
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 4, "Extensions Inserted");
 			TestParser.TestSpec("++Inserted text++", "<p><ins>Inserted text</ins></p>", "emphasisextras|advanced");
         }
     }
@@ -17387,9 +17410,9 @@ namespace Markdig.Tests
     public partial class TestExtensionsMarked
     {
         [Test]
-        public void Example004()
+        public void Example005()
         {
-            // Example 4
+            // Example 5
             // Section: Extensions Marked
             //
             // The following CommonMark:
@@ -17398,7 +17421,7 @@ namespace Markdig.Tests
             // Should be rendered as:
             //     <p><mark>Marked text</mark></p>
 
-            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 4, "Extensions Marked");
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 5, "Extensions Marked");
 			TestParser.TestSpec("==Marked text==", "<p><mark>Marked text</mark></p>", "emphasisextras|advanced");
         }
     }

--- a/src/Markdig/Helpers/CharHelper.cs
+++ b/src/Markdig/Helpers/CharHelper.cs
@@ -23,6 +23,8 @@ namespace Markdig.Helpers
         // We don't support LCDM
         private static IDictionary<char, int> romanMap = new Dictionary<char, int> { { 'I', 1 }, { 'V', 5 }, { 'X', 10 } };
 
+        private static readonly char[] punctuationExceptions = { '−', '-', '†', '‡' };
+
         public static void CheckOpenCloseDelimiter(char pc, char c, bool enableWithinWord, out bool canOpen, out bool canClose)
         {
             // A left-flanking delimiter run is a delimiter run that is 
@@ -37,8 +39,11 @@ namespace Markdig.Helpers
             pc.CheckUnicodeCategory(out prevIsWhiteSpace, out prevIsPunctuation);
             c.CheckUnicodeCategory(out nextIsWhiteSpace, out nextIsPunctuation);
 
+            var prevIsExcepted = prevIsPunctuation && punctuationExceptions.Contains(pc);
+            var nextIsExcepted = nextIsPunctuation && punctuationExceptions.Contains(c);
+
             canOpen = !nextIsWhiteSpace &&
-                           (!nextIsPunctuation || prevIsWhiteSpace || prevIsPunctuation);
+                           ((!nextIsPunctuation || nextIsExcepted) || prevIsWhiteSpace || prevIsPunctuation);
 
 
             // A right-flanking delimiter run is a delimiter run that is 
@@ -47,7 +52,7 @@ namespace Markdig.Helpers
             // or a punctuation character. 
             // For purposes of this definition, the beginning and the end of the line count as Unicode whitespace.
             canClose = !prevIsWhiteSpace &&
-                            (!prevIsPunctuation || nextIsWhiteSpace || nextIsPunctuation);
+                            ((!prevIsPunctuation || prevIsExcepted) || nextIsWhiteSpace || nextIsPunctuation);
 
             if (!enableWithinWord)
             {


### PR DESCRIPTION
I'm not sure how you'll feel about this one.

The CommonMark spec identifies when whitespace and punctuation can be used as left- and right-flanking delimiter runs. This logic is also used for the extra emphasis extension.
There are cases where certain puntuation characters _should_(?) be allowed.

For example, the minus symbol (or it's more commonly used lookalike, the dash) ought to be allowed as the start of a superscript span:
>
```md
One quintillionth can be expressed as 10^-18^
```
```html
<p>One quintillionth can be expressed as 10<sup>-18</sup></p>
```
><p>One quintillionth can be expressed as 10<sup>-18</sup></p>

Similarly the dagger and double-dagger are commonly used as localised note markers (followed by §, || and #) so should be allowed as the sole contents of a superscript span:
>
```md
Daggers^†^ and double-daggers^‡^ can be used to denote notes.
```
```html
<p>Daggers<sup>†</sup> and double-daggers<sup>‡</sup> can be used to denote notes.</p>
```
><p>Daggers<sup>†</sup> and double-daggers<sup>‡</sup> can be used to denote notes.</p>

**Note 1:** this is implemented as a broad exception for these characters (plus dash, as it is more likely to be used than the actual minus). There is no check for the _type_ of delimiter it is to be used for.

**Note 2:** i have only added the dagger and double dagger to the exceptions. To extend it to include section, parallels and hash would need a small logic change, as parallels uses 2 characters.
