### PR TITLE
Fixes issue when using colon (among others) on lines with abbreviations

### DIFF
--- a/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
@@ -126,12 +126,13 @@ namespace Markdig.Extensions.Abbreviations
                         // If we don't have a container, create a new one
                         if (container == null)
                         {
-                            container = new ContainerInline()
-                            {
-                                Span = originalLiteral.Span,
-                                Line = originalLiteral.Line,
-                                Column = originalLiteral.Column,
-                            };
+                            container = literal.Parent ??
+                                new ContainerInline
+                                {
+                                    Span = originalLiteral.Span,
+                                    Line = originalLiteral.Line,
+                                    Column = originalLiteral.Column,
+                                };
                         }
 
                         int line;
@@ -150,7 +151,10 @@ namespace Markdig.Extensions.Abbreviations
                         // Append the previous literal
                         if (i > content.Start)
                         {
-                            container.AppendChild(literal);
+                            if (literal.Parent == null)
+                            {
+                                container.AppendChild(literal);
+                            }
 
                             literal.Span.End = abbrInline.Span.Start - 1;
                             // Truncate it before the abbreviation

--- a/src/Markdig/Parsers/InlineProcessor.cs
+++ b/src/Markdig/Parsers/InlineProcessor.cs
@@ -238,7 +238,11 @@ namespace Markdig.Parsers
                     if (nextInline.Parent == null)
                     {
                         // Get deepest container
-                        FindLastContainer().AppendChild(nextInline);
+                        var lastContainer = FindLastContainer();
+                        if (!ReferenceEquals(lastContainer, nextInline))
+                        {
+                            lastContainer.AppendChild(nextInline);
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
I discovered a very strange issue when using abbreviations inline after a _potential_ delimiter (in my case, a colon).
The code would throw an `ArgumentException` from line 54 of `ContainerInline.cs`.
Example:
```md
Some abbreviations: HTML, WWW
*[HTML]: Hypertext Markup Language
*[WWW]: World Wide Web
```

This is due to the processor storing the first part of the content in a `LiteralInline` while it tries to validate the character as a valid delimiter. When this fails it returns and continues with the rest of the inline, including the first section. This means that when the `AbbreviationParser` finds a valid abbreviation during the post match, the `LiteralInline` already has a parent, which throws the exception.

The solution involves using the existing `LiteralInline` parent as the container (if it exists) instead of creating a new `ContainerInline` and checking that the parent is null before the call to `ContainerInline.AppendChild`.
There is also a check in `InlineProcessor`, when adding an inline without a parent as a child of the last container that this is not already the last container. This would mean at some point the parent is not being assigned when it ought to have been (I haven't found this yet though), but the check is poss