### PR TITLE
Fixes issue where punctuation forms part of word, so abbreviation is not valid

### DIFF
--- a/src/Markdig.Tests/Specs/AbbreviationSpecs.md
+++ b/src/Markdig.Tests/Specs/AbbreviationSpecs.md
@@ -57,3 +57,13 @@ We can abbreviate 1A, 1A1 and 1A2!
 .
 <p>We can abbreviate <abbr title="First">1A</abbr>, <abbr title="Second">1A1</abbr> and <abbr title="Third">1A2</abbr>!</p>
 ````````````````````````````````
+
+Abbreviations should match whole word only:
+
+```````````````````````````````` example
+*[1A]: First
+
+We should not abbreviate 1.1A or 11A!
+.
+<p>We should not abbreviate 1.1A or 11A!</p>
+````````````````````````````````

--- a/src/Markdig.Tests/Specs/Specs.cs
+++ b/src/Markdig.Tests/Specs/Specs.cs
@@ -18584,6 +18584,28 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*[1A]: First\n*[1A1]: Second\n*[1A2]: Third\n\nWe can abbreviate 1A, 1A1 and 1A2!", "<p>We can abbreviate <abbr title=\"First\">1A</abbr>, <abbr title=\"Second\">1A1</abbr> and <abbr title=\"Third\">1A2</abbr>!</p>", "abbreviations|advanced");
         }
     }
+        // Abbreviations should match whole word only:
+    [TestFixture]
+    public partial class TestExtensionsAbbreviation
+    {
+        [Test]
+        public void Example006()
+        {
+            // Example 6
+            // Section: Extensions Abbreviation
+            //
+            // The following CommonMark:
+            //     *[1A]: First
+            //     
+            //     We should not abbreviate 1.1A or 11A!
+            //
+            // Should be rendered as:
+            //     <p>We should not abbreviate 1.1A or 11A!</p>
+
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 6, "Extensions Abbreviation");
+			TestParser.TestSpec("*[1A]: First\n\nWe should not abbreviate 1.1A or 11A!", "<p>We should not abbreviate 1.1A or 11A!</p>", "abbreviations|advanced");
+        }
+    }
         // # Extensions
         //
         // The following additional list items are supported:

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
@@ -101,20 +101,9 @@ namespace Markdig.Extensions.Abbreviations
                 for (int i = content.Start; i < content.End; i++)
                 {
                     string match;
-                    if (matcher.TryMatch(text, i, content.End - i + 1, out match))
+                    if (matcher.TryMatch(text, i, content.End - i + 1, out match) && IsValidAbbreviation(match, content, i))
                     {
-                        // The word matched must be embraced by punctuation or whitespace or \0.
-                        var c = content.PeekCharAbsolute(i - 1);
-                        if (!(c == '\0' || c.IsAsciiPunctuation() || c.IsWhitespace()))
-                        {
-                            continue;
-                        }
                         var indexAfterMatch = i + match.Length;
-                        c = content.PeekCharAbsolute(indexAfterMatch);
-                        if (!(c == '\0' || c.IsAsciiPunctuation() || c.IsWhitespace()))
-                        {
-                            continue;
-                        }
 
                         // We should have a match, but in case...
                         Abbreviation abbr;
@@ -195,6 +184,40 @@ namespace Markdig.Extensions.Abbreviations
                     processor.Inline = container;
                 }
             };
+        }
+
+        private static bool IsValidAbbreviation(string match, StringSlice content, int matchIndex)
+        {
+            // The word matched must be embraced by punctuation or whitespace or \0.
+            var index = matchIndex - 1;
+            while (index > content.Start)
+            {
+                var c = content.PeekCharAbsolute(index);
+                if (!(c == '\0' || c.IsAsciiPunctuation() || c.IsWhitespace()))
+                {
+                    return false;
+                }
+                if (!c.IsAsciiPunctuation())
+                {
+                    break;
+                }
+                index--;
+            }
+            index = matchIndex + match.Length;
+            while (index < content.End)
+            {
+                var c = content.PeekCharAbsolute(index);
+                if (!(c == '\0' || c.IsAsciiPunctuation() || c.IsWhitespace()))
+                {
+                    return false;
+                }
+                if (!c.IsAsciiPunctuation())
+                {
+                    break;
+                }
+                index++;
+            }
+            return true;
         }
     }
 }


### PR DESCRIPTION
I've had an issue where abbreviations are being created for words that contain punctuation.
Example:
```md
*[1A]: First
We should not abbreviate 1.1A
```
Is rendered as:
```html
<p>We should not abbreviate 1.<abbr title="First">1A</abbr></p>
```

I've adjusted the `AbbreviationParser` to allow punctuation to embrace matches only if they are further embraced by \0 or whitespace.