### PR TITLE
Fixes issue where LiteralInlineParser calls PostMatch while processor.Inline is type other than LiteralInline

### DIFF
--- a/src/Markdig/Parsers/Inlines/LiteralInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LiteralInlineParser.cs
@@ -92,9 +92,9 @@ namespace Markdig.Parsers.Inlines
             slice.Start = nextStart;
 
             // Call only PostMatch if necessary
-            if (PostMatch != null)
+            if (processor.Inline is LiteralInline)
             {
-                PostMatch(processor, ref slice);
+                PostMatch?.Invoke(processor, ref slice);
             }
 
             return true;


### PR DESCRIPTION
I've found an odd situation where the `AbbreviationParser` throws a cast exception when `processor.Inline` is not of type `LiteralInline`. See lines 69-90 of `LiteralInlineParser`. In my case the type was `EmphasisDelimiterInline` and the current `StringSlice` was empty.

There are 2 ways I could have gone about this. I have chosen to _assume_ that it is valid to expect the `LiteralInlineParser` to only call the `PostMatch` event when the `processor.Inline` type is `LiteralInline` so have changed the event raising code accordingly.

The alternative is that the consuming code should not make assumptions about the type of inline that the processor is handling and should handle it accordingly. Let me know if you'd rather I went down this route.