### PR TITLE
Use Char.ToUpperInvariant instead of Char.ToUpper

### DIFF
--- a/src/Markdig/Extensions/ListExtras/ListExtraItemParser.cs
+++ b/src/Markdig/Extensions/ListExtras/ListExtraItemParser.cs
@@ -62,7 +62,7 @@ namespace Markdig.Extensions.ListExtras
             {
                 // otherwise we expect a regular alpha lettered list with a single character.
                 var isUpper = c.IsAlphaUpper();
-                result.OrderedStart = (Char.ToUpper(c) - 64).ToString();
+                result.OrderedStart = (Char.ToUpperInvariant(c) - 64).ToString();
                 result.BulletType = isUpper ? 'A' : 'a';
                 result.DefaultOrderedStart = isUpper ? "A" : "a";
                 state.NextChar();

--- a/src/Markdig/Helpers/CharHelper.cs
+++ b/src/Markdig/Helpers/CharHelper.cs
@@ -96,9 +96,9 @@ namespace Markdig.Helpers
             int result = 0;
             for (int i = 0; i < text.Length; i++)
             {
-                var character = Char.ToUpper(text[i]);
+                var character = Char.ToUpperInvariant(text[i]);
                 var candidate = romanMap[character];
-                if (i + 1 < text.Length && candidate < romanMap[Char.ToUpper(text[i + 1])])
+                if (i + 1 < text.Length && candidate < romanMap[Char.ToUpperInvariant(text[i + 1])])
                 {
                     result -= candidate;
                 }


### PR DESCRIPTION
Due to use of Char.ToUpper, ListExtraItemParser fails in cultures like Turkish where uppercase of 'i' is 'İ'. Char.ToUpperInvariant should be used instead.