### PR TITLE
Fixes the IsValidAbbreviation method in AbbreviationParser

### DIFF
--- a/src/Markdig.Tests/Specs/AbbreviationSpecs.md
+++ b/src/Markdig.Tests/Specs/AbbreviationSpecs.md
@@ -67,3 +67,13 @@ We should not abbreviate 1.1A or 11A!
 .
 <p>We should not abbreviate 1.1A or 11A!</p>
 ````````````````````````````````
+
+Abbreviations should match whole word only, even if the word is the entire content:
+
+```````````````````````````````` example
+*[1A]: First
+
+1.1A
+.
+<p>1.1A</p>
+````````````````````````````````

--- a/src/Markdig.Tests/Specs/Specs.cs
+++ b/src/Markdig.Tests/Specs/Specs.cs
@@ -18672,6 +18672,28 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*[1A]: First\n\nWe should not abbreviate 1.1A or 11A!", "<p>We should not abbreviate 1.1A or 11A!</p>", "abbreviations|advanced");
         }
     }
+        // Abbreviations should match whole word only, even if the word is the entire content:
+    [TestFixture]
+    public partial class TestExtensionsAbbreviation
+    {
+        [Test]
+        public void Example007()
+        {
+            // Example 7
+            // Section: Extensions Abbreviation
+            //
+            // The following CommonMark:
+            //     *[1A]: First
+            //     
+            //     1.1A
+            //
+            // Should be rendered as:
+            //     <p>1.1A</p>
+
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 7, "Extensions Abbreviation");
+			TestParser.TestSpec("*[1A]: First\n\n1.1A", "<p>1.1A</p>", "abbreviations|advanced");
+        }
+    }
         // # Extensions
         //
         // The following additional list items are supported:

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
@@ -190,7 +190,7 @@ namespace Markdig.Extensions.Abbreviations
         {
             // The word matched must be embraced by punctuation or whitespace or \0.
             var index = matchIndex - 1;
-            while (index > content.Start)
+            while (index >= content.Start)
             {
                 var c = content.PeekCharAbsolute(index);
                 if (!(c == '\0' || c.IsAsciiPunctuation() || c.IsWhitespace()))
@@ -204,7 +204,7 @@ namespace Markdig.Extensions.Abbreviations
                 index--;
             }
             index = matchIndex + match.Length;
-            while (index < content.End)
+            while (index <= content.End)
             {
                 var c = content.PeekCharAbsolute(index);
                 if (!(c == '\0' || c.IsAsciiPunctuation() || c.IsWhitespace()))


### PR DESCRIPTION
I made a schoolboy error in my previous fix for the abbreviation parser.
It works perfectly well for _most_ cases, but has issues where an _almost_ valid abbreviation is the first, last or only value in the correct content block.