### PR TITLE
Treat trailing full stop after a URL as not being part of the URL

### DIFF
--- a/src/Markdig.Tests/TestLinkHelper.cs
+++ b/src/Markdig.Tests/TestLinkHelper.cs
@@ -31,6 +31,16 @@ namespace Markdig.Tests
         }
 
         [Test]
+        public void TestUrlTrailingFullStop()
+        {
+            var text = new StringSlice("http://google.com.");
+            string link;
+            Assert.True(LinkHelper.TryParseUrl(ref text, out link));
+            Assert.AreEqual("http://google.com", link);
+            Assert.AreEqual('.', text.CurrentChar);
+        }
+
+        [Test]
         public void TestUrlNestedParenthesis()
         {
             var text = new StringSlice("(toto)tutu(tata) nooo");

--- a/src/Markdig.Tests/TestLinkHelper.cs
+++ b/src/Markdig.Tests/TestLinkHelper.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
+using System.Security;
 using NUnit.Framework;
 using Markdig.Helpers;
 using Markdig.Syntax;
@@ -31,9 +33,11 @@ namespace Markdig.Tests
         }
 
         [Test]
-        public void TestUrlTrailingFullStop()
+        [TestCase("http://google.com.")]
+        [TestCase("http://google.com. ")]
+        public void TestUrlTrailingFullStop(string uri)
         {
-            var text = new StringSlice("http://google.com.");
+            var text = new StringSlice(uri);
             string link;
             Assert.True(LinkHelper.TryParseUrl(ref text, out link));
             Assert.AreEqual("http://google.com", link);

--- a/src/Markdig/Helpers/ICharIterator.cs
+++ b/src/Markdig/Helpers/ICharIterator.cs
@@ -32,6 +32,12 @@ namespace Markdig.Helpers
         char NextChar();
 
         /// <summary>
+        /// Peeks at the next character, without incrementing the <see cref="Start"/> position.
+        /// </summary>
+        /// <returns>The next character. `\0` is end of the iteration.</returns>
+        char PeekChar();
+
+        /// <summary>
         /// Gets a value indicating whether this instance is empty.
         /// </summary>
         bool IsEmpty { get; }

--- a/src/Markdig/Helpers/LinkHelper.cs
+++ b/src/Markdig/Helpers/LinkHelper.cs
@@ -116,6 +116,7 @@ namespace Markdig.Helpers
             // An absolute URI, for these purposes, consists of a scheme followed by a colon (:) 
             // followed by zero or more characters other than ASCII whitespace and control characters, <, and >. 
             // If the URI includes these characters, they must be percent-encoded (e.g. %20 for a space).
+            // A URI that would end with a full stop (.) is treated instead as ending immediately before the full stop.
 
             // a scheme is any sequence of 2–32 characters 
             // beginning with an ASCII letter 
@@ -595,7 +596,13 @@ namespace Markdig.Helpers
 
                     hasEscape = false;
 
-                    if (c == '\0' || c.IsSpaceOrTab() || c.IsControl()) // TODO: specs unclear. space is strict or relaxed? (includes tabs?)
+                    if (IsEndOfUri(c))
+                    {
+                        isValid = true;
+                        break;
+                    }
+
+                    if (c == '.' && IsEndOfUri(text.PeekChar()))
                     {
                         isValid = true;
                         break;
@@ -610,6 +617,11 @@ namespace Markdig.Helpers
             link = isValid ? buffer.ToString() : null;
             buffer.Length = 0;
             return isValid;
+        }
+
+        private static bool IsEndOfUri(char c)
+        {
+            return c == '\0' || c.IsSpaceOrTab() || c.IsControl(); // TODO: specs unclear. space is strict or relaxed? (includes tabs?)
         }
 
         public static bool TryParseLinkReferenceDefinition<T>(T text, out string label, out string url,

--- a/src/Markdig/Helpers/StringLineGroup.cs
+++ b/src/Markdig/Helpers/StringLineGroup.cs
@@ -253,6 +253,22 @@ namespace Markdig.Helpers
                 return CurrentChar;
             }
 
+            public char PeekChar()
+            {
+                if (Start + 1 > End)
+                {
+                    return '\0';
+                }
+
+                var slice = (StringSlice)lines.Lines[SliceIndex];
+                if (offset + 1 >= slice.Length)
+                {
+                    return '\n';
+                }
+
+                return slice[slice.Start + offset + 1];
+            }
+
             public bool TrimStart()
             {
                 var c = CurrentChar;

--- a/src/Markdig/Helpers/StringSlice.cs
+++ b/src/Markdig/Helpers/StringSlice.cs
@@ -113,6 +113,17 @@ namespace Markdig.Helpers
         }
 
         /// <summary>
+        /// Peeks the character immediately after the current <see cref="Start"/> position
+        /// or returns `\0` if after the <see cref="End"/> position.
+        /// </summary>
+        /// <returns>The next character, returns `\0` if none.</returns>
+        [MethodImpl(MethodImplOptionPortable.AggressiveInlining)]
+        public char PeekChar()
+        {
+            return PeekChar(1);
+        }
+
+        /// <summary>
         /// Peeks a character at the specified offset from the current beginning of the string, without taking into account <see cref="Start"/> and <see cref="End"/>
         /// </summary>
         /// <returns>The character at offset, returns `\0` if none.</returns>


### PR DESCRIPTION
A bare URL in a markdown file is interpreted as a URL and rendered accordingly in HTML. However, if the URL is followed by a full stop (.) that full stop is interpreted as being part of the URL. For example consider the URL www.google.com. Because there was a full stop immediately after the URL, Markdig would render this in HTML as `<a href="www.google.com.">www.google.com.</a>`.

This behaviour does not seem terribly unreasonable, given that the trailing dot may constitute a valid URI (see e.g. http://webmasters.stackexchange.com/questions/73934/how-can-urls-have-a-dot-at-the-end-e-g-www-bla-de). However, it's rather inconvenient, and other markdown parsers (such as GitHub's) do not behave this way - see the rendering of the www.google.com link in this comment, above.

I've had a go at implementing this "fix" in Markdig. It's my first look at this source code so I may have done something unpleasant by mistake, but all the tests pass. Basic approach:

* Add a lookahead (`PeekChar`) feature to `ICharIterator`
* If we find a "." while parsing a URL, peek ahead and if that "." would be the end of the URL, terminate parsing now without including the "."

I chose to implement a single-char peek function, partly because that's all we need, partly because it felt most natural in `ICharIterator`, and partly because although `StringSlice` already has an arbitrary-offset peek it looked rather fiddly to implement the equivalent in `StringLineGroup.Iterator`.

Feedback welcomed! I'm happy to have a go at implementing any further improvements necessary, if you agree with the basic premise but have concerns over the implementation.