### PR TITLE
GenericAttributes: The first character of the second boolean attribute is skipped

### DIFF
--- a/src/Markdig.Tests/Specs/GenericAttributesSpecs.md
+++ b/src/Markdig.Tests/Specs/GenericAttributesSpecs.md
@@ -27,13 +27,13 @@ The following shows that attributes is attached to the current block or the prev
 This is a heading{#heading-link2}
 -----------------
 
-This is a paragraph with an attached attributes {#myparagraph attached-bool-property}
+This is a paragraph with an attached attributes {#myparagraph attached-bool-property attached-bool-property2}
 .
 <h1 id="heading-link">This is a heading with an an attribute</h1>
 <h1 id="heading-link2">This is a heading</h1>
 <p><a href="http://google.com" id="a-link" class="myclass" data-lang="fr" data-value="This is a value">This is a link</a></p>
 <h2 id="heading-link2">This is a heading</h2>
-<p id="myparagraph" attached-bool-property>This is a paragraph with an attached attributes </p>
+<p id="myparagraph" attached-bool-property attached-bool-property2>This is a paragraph with an attached attributes </p>
 ````````````````````````````````
 
 The following shows that attributes can be attached to the next block if they are used inside a single line just preceding the block (and preceded by a blank line or beginning of a block container):

--- a/src/Markdig.Tests/Specs/Specs.cs
+++ b/src/Markdig.Tests/Specs/Specs.cs
@@ -17465,17 +17465,17 @@ namespace Markdig.Tests
             //     This is a heading{#heading-link2}
             //     -----------------
             //     
-            //     This is a paragraph with an attached attributes {#myparagraph attached-bool-property}
+            //     This is a paragraph with an attached attributes {#myparagraph attached-bool-property attached-bool-property2}
             //
             // Should be rendered as:
             //     <h1 id="heading-link">This is a heading with an an attribute</h1>
             //     <h1 id="heading-link2">This is a heading</h1>
             //     <p><a href="http://google.com" id="a-link" class="myclass" data-lang="fr" data-value="This is a value">This is a link</a></p>
             //     <h2 id="heading-link2">This is a heading</h2>
-            //     <p id="myparagraph" attached-bool-property>This is a paragraph with an attached attributes </p>
+            //     <p id="myparagraph" attached-bool-property attached-bool-property2>This is a paragraph with an attached attributes </p>
 
             Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 1, "Extensions Generic Attributes");
-			TestParser.TestSpec("# This is a heading with an an attribute{#heading-link}\n\n# This is a heading # {#heading-link2}\n\n[This is a link](http://google.com){#a-link .myclass data-lang=fr data-value=\"This is a value\"}\n\nThis is a heading{#heading-link2}\n-----------------\n\nThis is a paragraph with an attached attributes {#myparagraph attached-bool-property}", "<h1 id=\"heading-link\">This is a heading with an an attribute</h1>\n<h1 id=\"heading-link2\">This is a heading</h1>\n<p><a href=\"http://google.com\" id=\"a-link\" class=\"myclass\" data-lang=\"fr\" data-value=\"This is a value\">This is a link</a></p>\n<h2 id=\"heading-link2\">This is a heading</h2>\n<p id=\"myparagraph\" attached-bool-property>This is a paragraph with an attached attributes </p>", "attributes|advanced");
+			TestParser.TestSpec("# This is a heading with an an attribute{#heading-link}\n\n# This is a heading # {#heading-link2}\n\n[This is a link](http://google.com){#a-link .myclass data-lang=fr data-value=\"This is a value\"}\n\nThis is a heading{#heading-link2}\n-----------------\n\nThis is a paragraph with an attached attributes {#myparagraph attached-bool-property attached-bool-property2}", "<h1 id=\"heading-link\">This is a heading with an an attribute</h1>\n<h1 id=\"heading-link2\">This is a heading</h1>\n<p><a href=\"http://google.com\" id=\"a-link\" class=\"myclass\" data-lang=\"fr\" data-value=\"This is a value\">This is a link</a></p>\n<h2 id=\"heading-link2\">This is a heading</h2>\n<p id=\"myparagraph\" attached-bool-property attached-bool-property2>This is a paragraph with an attached attributes </p>", "attributes|advanced");
         }
     }
         // The following shows that attributes can be attached to the next block if they are used inside a single line just preceding the block (and preceded by a blank line or beginning of a block container):

--- a/src/Markdig/Extensions/GenericAttributes/GenericAttributesParser.cs
+++ b/src/Markdig/Extensions/GenericAttributes/GenericAttributesParser.cs
@@ -171,9 +171,10 @@ namespace Markdig.Extensions.GenericAttributes
 
                     // Skip any whitespaces
                     line.TrimStart();
+                    c = line.CurrentChar;
 
                     // Handle boolean properties that are not followed by = 
-                    if ((hasSpace && (line.CurrentChar == '.' || line.CurrentChar == '#' || IsStartAttributeName(line.CurrentChar))) || line.CurrentChar == '}')
+                    if ((hasSpace && (c == '.' || c == '#' || IsStartAttributeName(c))) || c == '}')
                     {
                         if (properties == null)
                         {


### PR DESCRIPTION
The following markdown:
````md
# Heading{prop1 prop2}
````
output:
````html
<h1 prop1 rop2>Heading</h1>
````

The second attribute `prop2` is not correctly added to the output.