### PR TITLE
MediaLinkExtension: Remove unexpected closing tag

### DIFF
--- a/src/Markdig.Tests/Specs/MediaSpecs.md
+++ b/src/Markdig.Tests/Specs/MediaSpecs.md
@@ -10,7 +10,10 @@ Allows to embed audio/video links to popular website:
 ![Video1](https://www.youtube.com/watch?v=mswPy5bt3TQ)
 
 ![Video2](https://vimeo.com/8607834)
+
+![Video3](https://sample.com/video.mp4)
 .
 <p><iframe src="https://www.youtube.com/embed/mswPy5bt3TQ" width="500" height="281" frameborder="0" allowfullscreen></iframe></p>
 <p><iframe src="https://player.vimeo.com/video/8607834" width="500" height="281" frameborder="0" allowfullscreen></iframe></p>
+<p><video width="500" height="281" controls><source type="video/mp4" src="https://sample.com/video.mp4"></source></video></p>
 ````````````````````````````````

--- a/src/Markdig.Tests/Specs/Specs.cs
+++ b/src/Markdig.Tests/Specs/Specs.cs
@@ -19545,13 +19545,16 @@ namespace Markdig.Tests
             //     ![Video1](https://www.youtube.com/watch?v=mswPy5bt3TQ)
             //     
             //     ![Video2](https://vimeo.com/8607834)
+            //     
+            //     ![Video3](https://sample.com/video.mp4)
             //
             // Should be rendered as:
             //     <p><iframe src="https://www.youtube.com/embed/mswPy5bt3TQ" width="500" height="281" frameborder="0" allowfullscreen></iframe></p>
             //     <p><iframe src="https://player.vimeo.com/video/8607834" width="500" height="281" frameborder="0" allowfullscreen></iframe></p>
+            //     <p><video width="500" height="281" controls><source type="video/mp4" src="https://sample.com/video.mp4"></source></video></p>
 
             Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 1, "Extensions Media links");
-			TestParser.TestSpec("![Video1](https://www.youtube.com/watch?v=mswPy5bt3TQ)\n\n![Video2](https://vimeo.com/8607834)", "<p><iframe src=\"https://www.youtube.com/embed/mswPy5bt3TQ\" width=\"500\" height=\"281\" frameborder=\"0\" allowfullscreen></iframe></p>\n<p><iframe src=\"https://player.vimeo.com/video/8607834\" width=\"500\" height=\"281\" frameborder=\"0\" allowfullscreen></iframe></p>", "medialinks|advanced+medialinks");
+			TestParser.TestSpec("![Video1](https://www.youtube.com/watch?v=mswPy5bt3TQ)\n\n![Video2](https://vimeo.com/8607834)\n\n![Video3](https://sample.com/video.mp4)", "<p><iframe src=\"https://www.youtube.com/embed/mswPy5bt3TQ\" width=\"500\" height=\"281\" frameborder=\"0\" allowfullscreen></iframe></p>\n<p><iframe src=\"https://player.vimeo.com/video/8607834\" width=\"500\" height=\"281\" frameborder=\"0\" allowfullscreen></iframe></p>\n<p><video width=\"500\" height=\"281\" controls><source type=\"video/mp4\" src=\"https://sample.com/video.mp4\"></source></video></p>", "medialinks|advanced+medialinks");
         }
     }
         // # Extensions

--- a/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
+++ b/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
@@ -115,7 +115,6 @@ namespace Markdig.Extensions.MediaLinks
                             renderer.WriteAttributes(htmlAttributes);
 
                             renderer.Write($"><source type=\"{mimeType}\" src=\"{linkInline.Url}\"></source></{tagType}>");
-                            renderer.Write("</iframe>");
 
                             return true;
                         }


### PR DESCRIPTION
The following markdown:
````
![Video3](https://sample.com/video.mp4)
````
Ouputs:

````html
<p><video width="500" height="281" controls><source type="video/mp4" src="https://sample.com/video.mp4"></source></video></iframe></p>
````

The `</iframe>` is unexpected as there is no opening tag.