### PR TITLE
Fix issue in GenericAttributesParser causing inline elements to be sk…

### DIFF
--- a/src/Markdig.Tests/TestPlayParser.cs
+++ b/src/Markdig.Tests/TestPlayParser.cs
@@ -157,6 +157,40 @@ Paragraph
 </table>", "advanced");
         }
 
+        [Test]
+        public void TestGridTableWithCustomAttributes() {
+
+            var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+
+            var input = @"
+{.table}
++---+---+
+| a | b |
++===+===+
+| 1 | 2 |
++---+---+
+";
+
+            var expected = @"<table class=""table"">
+<col style=""width:50%"">
+<col style=""width:50%"">
+<thead>
+<tr>
+<th>a</th>
+<th>b</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td>2</td>
+</tr>
+</tbody>
+</table>
+";
+            var result = Markdown.ToHtml(input, pipeline);
+            Assert.AreEqual(result, expected);
+        }
 
         [Test]
         public void TestSamePipelineAllExtensions()

--- a/src/Markdig/Extensions/GenericAttributes/GenericAttributesParser.cs
+++ b/src/Markdig/Extensions/GenericAttributes/GenericAttributesParser.cs
@@ -59,7 +59,7 @@ namespace Markdig.Extensions.GenericAttributes
                     {
                         objectToAttach = parent[indexOfParagraph + 1];
                         // We can remove the paragraph as it is empty
-                        parent.RemoveAt(indexOfParagraph);
+                        paragraph.RemoveAfterProcessInlines = true;
                     }
                 }
 


### PR DESCRIPTION
…ipped

When attempting to apply classes to a table, I found all the text within the table was missing.  The line I changed was causing the table element to be skipped because the container is modified while MarkdownParser.ProcessInlines() is looping over the container items.
