### PR TITLE
Fix abbreviation at start of paragraphs

### DIFF
--- a/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
@@ -145,10 +145,12 @@ namespace Markdig.Extensions.Abbreviations
                                 container.AppendChild(literal);
                             }
 
-                            literal.Span.End = abbrInline.Span.Start - 1;
-                            // Truncate it before the abbreviation
-                            literal.Content.End = i - 1;
+                            
                         }
+                        literal.Span.End = abbrInline.Span.Start - 1;
+                        // Truncate it before the abbreviation
+                        literal.Content.End = i - 1;
+
 
                         // Appned the abbreviation
                         container.AppendChild(abbrInline);


### PR DESCRIPTION
There was an issue with an abbreviation term being at the start of the paragraph, in which the index does not update and therefore words can be repeated. This fixes it!