### PR TITLE
Fix abbreviation matching

### DIFF
--- a/src/Markdig.Tests/Specs/AbbreviationSpecs.md
+++ b/src/Markdig.Tests/Specs/AbbreviationSpecs.md
@@ -77,3 +77,24 @@ Abbreviations should match whole word only, even if the word is the entire conte
 .
 <p>1.1A</p>
 ````````````````````````````````
+
+Abbreviations should match whole word only, even if there is another glossary term:
+
+```````````````````````````````` example
+*[SCO]: First
+*[SCOM]: Second
+
+SCOM
+.
+<p><abbr title="Second">SCOM</abbr></p>
+````````````````````````````````
+
+Abbreviations should only match when surrounded by whitespace:
+
+```````````````````````````````` example
+*[PR]: Pull Request
+
+PRAA
+.
+<p>PRAA</p>
+````````````````````````````````

--- a/src/Markdig.Tests/Specs/Specs.cs
+++ b/src/Markdig.Tests/Specs/Specs.cs
@@ -18760,6 +18760,51 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*[1A]: First\n\n1.1A", "<p>1.1A</p>", "abbreviations|advanced");
         }
     }
+        // Abbreviations should match whole word only, even if there is another glossary term:
+    [TestFixture]
+    public partial class TestExtensionsAbbreviation
+    {
+        [Test]
+        public void Example008()
+        {
+            // Example 8
+            // Section: Extensions Abbreviation
+            //
+            // The following CommonMark:
+            //     *[SCO]: First
+            //     *[SCOM]: Second
+            //     
+            //     SCOM
+            //
+            // Should be rendered as:
+            //     <p><abbr title="Second">SCOM</abbr></p>
+
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 8, "Extensions Abbreviation");
+			TestParser.TestSpec("*[SCO]: First\n*[SCOM]: Second\n\nSCOM", "<p><abbr title=\"Second\">SCOM</abbr></p>", "abbreviations|advanced");
+        }
+    }
+        // Abbreviations should only match when surrounded by whitespace:
+    [TestFixture]
+    public partial class TestExtensionsAbbreviation
+    {
+        [Test]
+        public void Example009()
+        {
+            // Example 9
+            // Section: Extensions Abbreviation
+            //
+            // The following CommonMark:
+            //     *[PR]: Pull Request
+            //     
+            //     PRAA
+            //
+            // Should be rendered as:
+            //     <p>PRAA</p>
+
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 9, "Extensions Abbreviation");
+			TestParser.TestSpec("*[PR]: Pull Request\n\nPRAA", "<p>PRAA</p>", "abbreviations|advanced");
+        }
+    }
         // # Extensions
         //
         // The following additional list items are supported:

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
@@ -211,6 +211,8 @@ namespace Markdig.Extensions.Abbreviations
                 }
                 index--;
             }
+
+            // This will check if the next char at the end of the StringSlice is whitespace, punctuation or \0.
             var contentNew = content;
             contentNew.End = content.End + 1;
             index = matchIndex + match.Length;

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
@@ -192,23 +192,47 @@ namespace Markdig.Extensions.Abbreviations
         {
             // The word matched must be embraced by punctuation or whitespace or \0.
             var index = matchIndex - 1;
-            var c = content.PeekCharAbsolute(index);
-
-            //if the character before the match is not punctuation or whitespace
-            if (!(c == '\n' || c.IsAsciiPunctuation() || c.IsWhitespace() || c == '\0'))
+            while (index >= content.Start)
             {
-                return false;
+                var c = content.PeekCharAbsolute(index);
+                if (!(c == '\0' || c.IsWhitespace() || c.IsAsciiPunctuation()))
+                {
+                    return false;
+                }
+
+                if (c.IsAlphaNumeric())
+                {
+                    return false;
+                }
+
+                if (!c.IsAsciiPunctuation() || c.IsWhitespace())
+                {
+                    break;
+                }
+                index--;
             }
-            
+            var contentNew = content;
+            contentNew.End = content.End + 1;
             index = matchIndex + match.Length;
-            var ch = content.PeekCharAbsolute(index);
-
-            //if the character after the match is not punctuation or whitespace
-            if (!(ch == '\n' || ch.IsAsciiPunctuation() || ch.IsWhitespace() || ch == '\0'))
+            while (index <= contentNew.End)
             {
-                return false;
-            }
+                var c = contentNew.PeekCharAbsolute(index);
+                if (!(c == '\0' || c.IsWhitespace() || c.IsAsciiPunctuation()))
+                {
+                    return false;
+                }
 
+                if (c.IsAlphaNumeric())
+                {
+                    return false;
+                }
+
+                if (c.IsWhitespace())
+                {
+                    break;
+                }
+                index++;
+            }
             return true;
         }
     }

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
@@ -20,7 +20,7 @@ namespace Markdig.Extensions.Abbreviations
         /// </summary>
         public AbbreviationParser()
         {
-            OpeningCharacters = new[] {'*'};
+            OpeningCharacters = new[] { '*' };
         }
 
         public override BlockState TryOpen(BlockProcessor processor)
@@ -90,7 +90,7 @@ namespace Markdig.Extensions.Abbreviations
 
             inlineProcessor.LiteralInlineParser.PostMatch += (InlineProcessor processor, ref StringSlice slice) =>
             {
-                var literal = (LiteralInline) processor.Inline;
+                var literal = (LiteralInline)processor.Inline;
                 var originalLiteral = literal;
 
                 ContainerInline container = null;
@@ -145,8 +145,8 @@ namespace Markdig.Extensions.Abbreviations
                                 container.AppendChild(literal);
                             }
 
-                            
                         }
+
                         literal.Span.End = abbrInline.Span.Start - 1;
                         // Truncate it before the abbreviation
                         literal.Content.End = i - 1;
@@ -192,33 +192,23 @@ namespace Markdig.Extensions.Abbreviations
         {
             // The word matched must be embraced by punctuation or whitespace or \0.
             var index = matchIndex - 1;
-            while (index >= content.Start)
+            var c = content.PeekCharAbsolute(index);
+
+            //if the character before the match is not punctuation or whitespace
+            if (!(c == '\n' || c.IsAsciiPunctuation() || c.IsWhitespace() || c == '\0'))
             {
-                var c = content.PeekCharAbsolute(index);
-                if (!(c == '\0' || c.IsAsciiPunctuation() || c.IsWhitespace()))
-                {
-                    return false;
-                }
-                if (!c.IsAsciiPunctuation())
-                {
-                    break;
-                }
-                index--;
+                return false;
             }
+            
             index = matchIndex + match.Length;
-            while (index <= content.End)
+            var ch = content.PeekCharAbsolute(index);
+
+            //if the character after the match is not punctuation or whitespace
+            if (!(ch == '\n' || ch.IsAsciiPunctuation() || ch.IsWhitespace() || ch == '\0'))
             {
-                var c = content.PeekCharAbsolute(index);
-                if (!(c == '\0' || c.IsAsciiPunctuation() || c.IsWhitespace()))
-                {
-                    return false;
-                }
-                if (!c.IsAsciiPunctuation())
-                {
-                    break;
-                }
-                index++;
+                return false;
             }
+
             return true;
         }
     }


### PR DESCRIPTION
There was an issue with abbreviations matching on a section of a word. For example: PR was matching on PRAA. 