### PR TITLE
Fix bug in LinkHelper.UrilizeAsGfm

### DIFF
--- a/src/Markdig.Tests/TestLinkHelper.cs
+++ b/src/Markdig.Tests/TestLinkHelper.cs
@@ -409,5 +409,13 @@ namespace Markdig.Tests
         {
             Assert.AreEqual(expectedResult, LinkHelper.Urilize(input, false));
         }
+
+        [TestCase(".bc", "bc")]
+        [TestCase("a-.-", "a--")]
+        [TestCase("_a_", "a")]
+        public void TestUrilizeAsGfm_Simple(string input, string expectedResult)
+        {
+            Assert.AreEqual(expectedResult, LinkHelper.UrilizeAsGfm(input));
+        }
     }
 }

--- a/src/Markdig/Helpers/LinkHelper.cs
+++ b/src/Markdig/Helpers/LinkHelper.cs
@@ -104,7 +104,7 @@ namespace Markdig.Helpers
             for (int i = 0; i < headingText.Length; i++)
             {
                 var c = char.ToLowerInvariant(headingText[i]);
-                if (char.IsLetterOrDigit(c) || c == ' ' || c == '-' || c == '_')
+                if (char.IsLetterOrDigit(c) || c == ' ' || c == '-')
                 {
                     headingBuffer.Append(c == ' ' ? '-' : c);
                 }


### PR DESCRIPTION
The heading id of `# _a_` should be `a` instead of `_a_` in GFM. See https://babelmark.github.io/?text=%23+_a_