### PR TITLE
Add Normalization Support for AutoLinks

### DIFF
--- a/src/Markdig.Tests/TestNormalize.cs
+++ b/src/Markdig.Tests/TestNormalize.cs
@@ -420,6 +420,15 @@ This is a last line";
             AssertNormalizeNoTrim("**Hello World AB-1**");
         }
 
+        [Test]
+        public void AutoLinks()
+        {
+            AssertNormalizeNoTrim("Hello from http://example.com/foo", "Hello from [http://example.com/foo](http://example.com/foo)");
+            AssertNormalizeNoTrim("Hello from www.example.com/foo", "Hello from [www.example.com/foo](http://www.example.com/foo)");
+            AssertNormalizeNoTrim("Hello from ftp://example.com", "Hello from [ftp://example.com](ftp://example.com)");
+            AssertNormalizeNoTrim("Hello from mailto:hello@example.com", "Hello from [mailto:hello@example.com](mailto:hello@example.com)");
+        }
+
         private static void AssertSyntax(string expected, MarkdownObject syntax)
         {
             var writer = new StringWriter();
@@ -450,6 +459,7 @@ This is a last line";
             expected = NormText(expected, trim);
 
             var pipeline = new MarkdownPipelineBuilder()
+                .UseAutoLinks()
                 .UseJiraLinks(new Extensions.JiraLinks.JiraLinkOptions("https://jira.example.com"))
                 .UseTaskLists()
                 .Build();

--- a/src/Markdig.Tests/TestNormalize.cs
+++ b/src/Markdig.Tests/TestNormalize.cs
@@ -423,10 +423,14 @@ This is a last line";
         [Test]
         public void AutoLinks()
         {
-            AssertNormalizeNoTrim("Hello from http://example.com/foo", "Hello from [http://example.com/foo](http://example.com/foo)");
-            AssertNormalizeNoTrim("Hello from www.example.com/foo", "Hello from [www.example.com/foo](http://www.example.com/foo)");
-            AssertNormalizeNoTrim("Hello from ftp://example.com", "Hello from [ftp://example.com](ftp://example.com)");
-            AssertNormalizeNoTrim("Hello from mailto:hello@example.com", "Hello from [mailto:hello@example.com](mailto:hello@example.com)");
+            AssertNormalizeNoTrim("Hello from http://example.com/foo", "Hello from [http://example.com/foo](http://example.com/foo)", new NormalizeOptions() { ExpandAutoLinks = true, });
+            AssertNormalizeNoTrim("Hello from www.example.com/foo", "Hello from [www.example.com/foo](http://www.example.com/foo)", new NormalizeOptions() { ExpandAutoLinks = true, });
+            AssertNormalizeNoTrim("Hello from ftp://example.com", "Hello from [ftp://example.com](ftp://example.com)", new NormalizeOptions() { ExpandAutoLinks = true, });
+            AssertNormalizeNoTrim("Hello from mailto:hello@example.com", "Hello from [mailto:hello@example.com](mailto:hello@example.com)", new NormalizeOptions() { ExpandAutoLinks = true, });
+
+            AssertNormalizeNoTrim("Hello from http://example.com/foo", "Hello from http://example.com/foo", new NormalizeOptions() { ExpandAutoLinks = false, });
+            AssertNormalizeNoTrim("Hello from www.example.com/foo", "Hello from http://www.example.com/foo", new NormalizeOptions() { ExpandAutoLinks = false, });
+            AssertNormalizeNoTrim("Hello from mailto:hello@example.com", "Hello from mailto:hello@example.com", new NormalizeOptions() { ExpandAutoLinks = false, });
         }
 
         private static void AssertSyntax(string expected, MarkdownObject syntax)

--- a/src/Markdig/Extensions/AutoLinks/AutoLinkExtension.cs
+++ b/src/Markdig/Extensions/AutoLinks/AutoLinkExtension.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
 using Markdig.Renderers;
-using Markdig.Syntax.Inlines;
+using Markdig.Renderers.Normalize;
+using Markdig.Renderers.Normalize.Inlines;
 
 namespace Markdig.Extensions.AutoLinks
 {
@@ -24,6 +25,11 @@ namespace Markdig.Extensions.AutoLinks
 
         public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
         {
+            var normalizeRenderer = renderer as NormalizeRenderer;
+            if (normalizeRenderer != null && !normalizeRenderer.ObjectRenderers.Contains<NormalizeAutoLinkRenderer>())
+            {
+                normalizeRenderer.ObjectRenderers.InsertBefore<LinkInlineRenderer>(new NormalizeAutoLinkRenderer());
+            }
         }
     }
 }

--- a/src/Markdig/Extensions/AutoLinks/AutoLinkParser.cs
+++ b/src/Markdig/Extensions/AutoLinks/AutoLinkParser.cs
@@ -158,6 +158,7 @@ namespace Markdig.Extensions.AutoLinks
                 Column = column,
                 Url = c == 'w' ? "http://" + link : link,
                 IsClosed = true,
+                IsAutoLink = true,
             };
             inline.Span.End = inline.Span.Start + link.Length - 1;
             inline.UrlSpan = inline.Span;

--- a/src/Markdig/Extensions/AutoLinks/NormalizeAutoLinkRenderer.cs
+++ b/src/Markdig/Extensions/AutoLinks/NormalizeAutoLinkRenderer.cs
@@ -1,0 +1,29 @@
+using Markdig.Renderers;
+using Markdig.Renderers.Normalize;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+
+namespace Markdig.Extensions.AutoLinks
+{
+    public class NormalizeAutoLinkRenderer : NormalizeObjectRenderer<LinkInline>
+    {
+        public override bool Accept(RendererBase renderer, MarkdownObject obj)
+        {
+            if (base.Accept(renderer, obj))
+            {
+                var normalizeRenderer = renderer as NormalizeRenderer;
+                var link = obj as LinkInline;
+
+                return normalizeRenderer != null && link != null && !normalizeRenderer.Options.ExpandAutoLinks && link.IsAutoLink;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        protected override void Write(NormalizeRenderer renderer, LinkInline obj)
+        {
+            renderer.Write(obj.Url);
+        }
+    }
+}

--- a/src/Markdig/Renderers/Normalize/NormalizeOptions.cs
+++ b/src/Markdig/Renderers/Normalize/NormalizeOptions.cs
@@ -17,6 +17,7 @@ namespace Markdig.Renderers.Normalize
             EmptyLineAfterCodeBlock = true;
             EmptyLineAfterHeading = true;
             EmptyLineAfterThematicBreak = true;
+            ExpandAutoLinks = true;
             ListItemCharacter = null;
         }
 
@@ -44,5 +45,10 @@ namespace Markdig.Renderers.Normalize
         /// The bullet character used for list items. Default is <c>null</c> leaving the original bullet character as-is.
         /// </summary>
         public char? ListItemCharacter { get; set; }
+
+        /// <summary>
+        /// Expands AutoLinks to the normal inline representation. Default is <c>true</c>
+        /// </summary>
+        public bool ExpandAutoLinks { get; set; }
     }
 }

--- a/src/Markdig/Syntax/Inlines/LinkInline.cs
+++ b/src/Markdig/Syntax/Inlines/LinkInline.cs
@@ -70,6 +70,11 @@ namespace Markdig.Syntax.Inlines
         public bool IsShortcut { get; set; }
 
         /// <summary>
+        /// Gets or sets a boolean indicating whether the inline link was parsed using markdown syntax or was automatic recognized.
+        /// </summary>
+        public bool IsAutoLink { get; set; }
+
+        /// <summary>
         /// Gets or sets the reference this link is attached to. May be null.
         /// </summary>
         public LinkReferenceDefinition Reference { get; set; }


### PR DESCRIPTION
Part of #155 

Question here: Are we normalizing auto links to the InlineLink representation OR back to their original form.

If we want to go back to the original form, we need to extend the syntax (IMHO)

I am for normalizing to InlineLinks.