### PR TITLE
Media link extension to support MP3 by default

### DIFF
--- a/src/Markdig/Extensions/MediaLinks/MediaOptions.cs
+++ b/src/Markdig/Extensions/MediaLinks/MediaOptions.cs
@@ -68,6 +68,7 @@ namespace Markdig.Extensions.MediaLinks
                 {".wma", "audio/x-ms-wma"},
                 {".wax", "audio/x-ms-wax"},
                 {".mid", "audio/midi"},
+                {".mp3", "audio/mpeg"},
                 {".mpga", "audio/mpeg"},
                 {".mp4a", "audio/mp4"},
                 {".ecelp4800", "audio/vnd.nuera.ecelp4800"},


### PR DESCRIPTION
I presume MP3 wasn't intentionally left out this list?