### PR TITLE
Added yandex.music & ok.ru support to MediaLinkExtension

### DIFF
--- a/src/Markdig.Tests/Specs/MediaSpecs.md
+++ b/src/Markdig.Tests/Specs/MediaSpecs.md
@@ -12,8 +12,11 @@ Allows to embed audio/video links to popular website:
 ![Video2](https://vimeo.com/8607834)
 
 ![Video3](https://sample.com/video.mp4)
+
+![Audio4](https://music.yandex.ru/album/411845/track/4402274)
 .
 <p><iframe src="https://www.youtube.com/embed/mswPy5bt3TQ" width="500" height="281" frameborder="0" allowfullscreen></iframe></p>
 <p><iframe src="https://player.vimeo.com/video/8607834" width="500" height="281" frameborder="0" allowfullscreen></iframe></p>
 <p><video width="500" height="281" controls><source type="video/mp4" src="https://sample.com/video.mp4"></source></video></p>
+<p><iframe src="https://music.yandex.ru/iframe/#track/4402274/411845/" width="500" height="281" frameborder="0"></iframe></p>
 ````````````````````````````````

--- a/src/Markdig.Tests/Specs/MediaSpecs.md
+++ b/src/Markdig.Tests/Specs/MediaSpecs.md
@@ -14,9 +14,12 @@ Allows to embed audio/video links to popular website:
 ![Video3](https://sample.com/video.mp4)
 
 ![Audio4](https://music.yandex.ru/album/411845/track/4402274)
+
+![Video5](https://ok.ru/video/26870090463)
 .
 <p><iframe src="https://www.youtube.com/embed/mswPy5bt3TQ" width="500" height="281" frameborder="0" allowfullscreen></iframe></p>
 <p><iframe src="https://player.vimeo.com/video/8607834" width="500" height="281" frameborder="0" allowfullscreen></iframe></p>
 <p><video width="500" height="281" controls><source type="video/mp4" src="https://sample.com/video.mp4"></source></video></p>
 <p><iframe src="https://music.yandex.ru/iframe/#track/4402274/411845/" width="500" height="281" frameborder="0"></iframe></p>
+<p><iframe src="https://ok.ru/videoembed/26870090463" width="500" height="281" frameborder="0" allowfullscreen></iframe></p>
 ````````````````````````````````

--- a/src/Markdig.Tests/Specs/Specs.cs
+++ b/src/Markdig.Tests/Specs/Specs.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using NUnit.Framework;
 
 namespace Markdig.Tests
@@ -19729,14 +19729,17 @@ namespace Markdig.Tests
             //     ![Video2](https://vimeo.com/8607834)
             //     
             //     ![Video3](https://sample.com/video.mp4)
+            //     
+            //     ![Audio4](https://music.yandex.ru/album/411845/track/4402274)
             //
             // Should be rendered as:
             //     <p><iframe src="https://www.youtube.com/embed/mswPy5bt3TQ" width="500" height="281" frameborder="0" allowfullscreen></iframe></p>
             //     <p><iframe src="https://player.vimeo.com/video/8607834" width="500" height="281" frameborder="0" allowfullscreen></iframe></p>
             //     <p><video width="500" height="281" controls><source type="video/mp4" src="https://sample.com/video.mp4"></source></video></p>
+            //     <p><iframe src="https://music.yandex.ru/iframe/#track/4402274/411845/" width="500" height="281" frameborder="0"></iframe></p>
 
             Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 1, "Extensions Media links");
-			TestParser.TestSpec("![Video1](https://www.youtube.com/watch?v=mswPy5bt3TQ)\n\n![Video2](https://vimeo.com/8607834)\n\n![Video3](https://sample.com/video.mp4)", "<p><iframe src=\"https://www.youtube.com/embed/mswPy5bt3TQ\" width=\"500\" height=\"281\" frameborder=\"0\" allowfullscreen></iframe></p>\n<p><iframe src=\"https://player.vimeo.com/video/8607834\" width=\"500\" height=\"281\" frameborder=\"0\" allowfullscreen></iframe></p>\n<p><video width=\"500\" height=\"281\" controls><source type=\"video/mp4\" src=\"https://sample.com/video.mp4\"></source></video></p>", "medialinks|advanced+medialinks");
+			TestParser.TestSpec("![Video1](https://www.youtube.com/watch?v=mswPy5bt3TQ)\n\n![Video2](https://vimeo.com/8607834)\n\n![Video3](https://sample.com/video.mp4)\n\n![Audio4](https://music.yandex.ru/album/411845/track/4402274)", "<p><iframe src=\"https://www.youtube.com/embed/mswPy5bt3TQ\" width=\"500\" height=\"281\" frameborder=\"0\" allowfullscreen></iframe></p>\n<p><iframe src=\"https://player.vimeo.com/video/8607834\" width=\"500\" height=\"281\" frameborder=\"0\" allowfullscreen></iframe></p>\n<p><video width=\"500\" height=\"281\" controls><source type=\"video/mp4\" src=\"https://sample.com/video.mp4\"></source></video></p>\n<p><iframe src=\"https://music.yandex.ru/iframe/#track/4402274/411845/\" width=\"500\" height=\"281\" frameborder=\"0\"></iframe></p>", "medialinks|advanced+medialinks");
         }
     }
         // # Extensions

--- a/src/Markdig.Tests/Specs/Specs.cs
+++ b/src/Markdig.Tests/Specs/Specs.cs
@@ -19731,15 +19731,18 @@ namespace Markdig.Tests
             //     ![Video3](https://sample.com/video.mp4)
             //     
             //     ![Audio4](https://music.yandex.ru/album/411845/track/4402274)
+            //     
+            //     ![Video5](https://ok.ru/video/26870090463)
             //
             // Should be rendered as:
             //     <p><iframe src="https://www.youtube.com/embed/mswPy5bt3TQ" width="500" height="281" frameborder="0" allowfullscreen></iframe></p>
             //     <p><iframe src="https://player.vimeo.com/video/8607834" width="500" height="281" frameborder="0" allowfullscreen></iframe></p>
             //     <p><video width="500" height="281" controls><source type="video/mp4" src="https://sample.com/video.mp4"></source></video></p>
             //     <p><iframe src="https://music.yandex.ru/iframe/#track/4402274/411845/" width="500" height="281" frameborder="0"></iframe></p>
+            //     <p><iframe src="https://ok.ru/videoembed/26870090463" width="500" height="281" frameborder="0" allowfullscreen></iframe></p>
 
             Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 1, "Extensions Media links");
-			TestParser.TestSpec("![Video1](https://www.youtube.com/watch?v=mswPy5bt3TQ)\n\n![Video2](https://vimeo.com/8607834)\n\n![Video3](https://sample.com/video.mp4)\n\n![Audio4](https://music.yandex.ru/album/411845/track/4402274)", "<p><iframe src=\"https://www.youtube.com/embed/mswPy5bt3TQ\" width=\"500\" height=\"281\" frameborder=\"0\" allowfullscreen></iframe></p>\n<p><iframe src=\"https://player.vimeo.com/video/8607834\" width=\"500\" height=\"281\" frameborder=\"0\" allowfullscreen></iframe></p>\n<p><video width=\"500\" height=\"281\" controls><source type=\"video/mp4\" src=\"https://sample.com/video.mp4\"></source></video></p>\n<p><iframe src=\"https://music.yandex.ru/iframe/#track/4402274/411845/\" width=\"500\" height=\"281\" frameborder=\"0\"></iframe></p>", "medialinks|advanced+medialinks");
+			TestParser.TestSpec("![Video1](https://www.youtube.com/watch?v=mswPy5bt3TQ)\n\n![Video2](https://vimeo.com/8607834)\n\n![Video3](https://sample.com/video.mp4)\n\n![Audio4](https://music.yandex.ru/album/411845/track/4402274)\n\n![Video5](https://ok.ru/video/26870090463)", "<p><iframe src=\"https://www.youtube.com/embed/mswPy5bt3TQ\" width=\"500\" height=\"281\" frameborder=\"0\" allowfullscreen></iframe></p>\n<p><iframe src=\"https://player.vimeo.com/video/8607834\" width=\"500\" height=\"281\" frameborder=\"0\" allowfullscreen></iframe></p>\n<p><video width=\"500\" height=\"281\" controls><source type=\"video/mp4\" src=\"https://sample.com/video.mp4\"></source></video></p>\n<p><iframe src=\"https://music.yandex.ru/iframe/#track/4402274/411845/\" width=\"500\" height=\"281\" frameborder=\"0\"></iframe></p>\n<p><iframe src=\"https://ok.ru/videoembed/26870090463\" width=\"500\" height=\"281\" frameborder=\"0\" allowfullscreen></iframe></p>", "medialinks|advanced+medialinks");
         }
     }
         // # Extensions

--- a/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
+++ b/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
@@ -1,8 +1,10 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 using Markdig.Renderers.Html.Inlines;
@@ -47,81 +49,103 @@ namespace Markdig.Extensions.MediaLinks
 
         private bool TryLinkInlineRenderer(HtmlRenderer renderer, LinkInline linkInline)
         {
-            if (linkInline.IsImage && linkInline.Url != null)
+            if (!linkInline.IsImage || linkInline.Url == null)
             {
-                Uri uri;
-                // Only process absolute Uri
-                if (Uri.TryCreate(linkInline.Url, UriKind.RelativeOrAbsolute, out uri) && uri.IsAbsoluteUri)
+                return false;
+            }
+
+            Uri uri;
+            // Only process absolute Uri
+            if (!Uri.TryCreate(linkInline.Url, UriKind.RelativeOrAbsolute, out uri) || !uri.IsAbsoluteUri)
+            {
+                return false;
+            }
+
+            if (TryRenderIframeFromKnownProviders(uri, renderer, linkInline))
+            {
+                return true;
+            }
+
+            if (TryGuessAudioVideoFile(uri, renderer, linkInline))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static HtmlAttributes GetHtmlAttributes(LinkInline linkInline)
+        {
+            var htmlAttributes = new HtmlAttributes();
+            var fromAttributes = linkInline.TryGetAttributes();
+            if (fromAttributes != null)
+            {
+                fromAttributes.CopyTo(htmlAttributes, false, false);
+            }
+
+            return htmlAttributes;
+        }
+
+        private bool TryGuessAudioVideoFile(Uri uri, HtmlRenderer renderer, LinkInline linkInline)
+        {
+            var path = uri.GetComponents(UriComponents.Path, UriFormat.Unescaped);
+            // Otherwise try to detect if we have an audio/video from the file extension
+            string mimeType;
+            var lastDot = path.LastIndexOf('.');
+            if (lastDot >= 0 &&
+                Options.ExtensionToMimeType.TryGetValue(path.Substring(lastDot), out mimeType))
+            {
+                var htmlAttributes = GetHtmlAttributes(linkInline);
+                var isAudio = mimeType.StartsWith("audio");
+                var tagType = isAudio ? "audio" : "video";
+
+                renderer.Write($"<{tagType}");
+                htmlAttributes.AddPropertyIfNotExist("width", Options.Width);
+                if (!isAudio)
                 {
-                    var htmlAttributes = new HtmlAttributes();
-                    var fromAttributes = linkInline.TryGetAttributes();
-                    if (fromAttributes != null)
-                    {
-                        fromAttributes.CopyTo(htmlAttributes, false, false);
-                    }
-
-                    // TODO: this code is not pluggable, so for now, we handle only the following web providers:
-                    // - youtube
-                    // - vimeo
-                    var path = uri.GetComponents(UriComponents.Path, UriFormat.Unescaped);
-
-                    string iFrameUrl = null;
-                    if (uri.Host.StartsWith("www.youtube.com", StringComparison.OrdinalIgnoreCase))
-                    {
-                        var query = SplitQuery(uri);
-                        if (query.Length > 0 && query[0].StartsWith("v="))
-                        {
-                            iFrameUrl = $"https://www.youtube.com/embed/{query[0].Substring(2)}";
-                        }
-                    }
-                    else if (uri.Host.StartsWith("vimeo.com", StringComparison.OrdinalIgnoreCase))
-                    {
-                        var items = path.Split('/');
-                        if (items.Length > 0)
-                        {
-                            iFrameUrl = $"https://player.vimeo.com/video/{items[items.Length - 1]}";
-                        }
-                    }
-
-                    if (iFrameUrl != null)
-                    {
-                        renderer.Write($"<iframe src=\"{iFrameUrl}\"");
-                        htmlAttributes.AddPropertyIfNotExist("width", Options.Width);
-                        htmlAttributes.AddPropertyIfNotExist("height", Options.Height);
-                        htmlAttributes.AddPropertyIfNotExist("frameborder", "0");
-                        htmlAttributes.AddPropertyIfNotExist("allowfullscreen", null);
-                        renderer.WriteAttributes(htmlAttributes);
-                        renderer.Write("></iframe>");
-                        return true;
-                    }
-                    else
-                    {
-                        // Otherwise try to detect if we have an audio/video from the file extension
-                        string mimeType;
-                        var lastDot = path.LastIndexOf('.');
-                        if (lastDot >= 0 &&
-                            Options.ExtensionToMimeType.TryGetValue(path.Substring(lastDot), out mimeType))
-                        {
-                            var isAudio = mimeType.StartsWith("audio");
-                            var tagType = isAudio ? "audio" : "video";
-
-                            renderer.Write($"<{tagType}");
-                            htmlAttributes.AddPropertyIfNotExist("width", Options.Width);
-                            if (!isAudio)
-                            {
-                                htmlAttributes.AddPropertyIfNotExist("height", Options.Height);
-                            }
-                            htmlAttributes.AddPropertyIfNotExist("controls", null);
-                            renderer.WriteAttributes(htmlAttributes);
-
-                            renderer.Write($"><source type=\"{mimeType}\" src=\"{linkInline.Url}\"></source></{tagType}>");
-
-                            return true;
-                        }
-                    }
+                    htmlAttributes.AddPropertyIfNotExist("height", Options.Height);
                 }
+                htmlAttributes.AddPropertyIfNotExist("controls", null);
+                renderer.WriteAttributes(htmlAttributes);
+
+                renderer.Write($"><source type=\"{mimeType}\" src=\"{linkInline.Url}\"></source></{tagType}>");
+
+                return true;
             }
             return false;
+        }
+
+        #region Known providers
+        private static readonly Dictionary<string, Func<Uri, string>> KnownHosts = new Dictionary<string, Func<Uri, string>>()
+        {
+            {"www.youtube.com", YouTube},
+            {"vimeo.com", Vimeo },
+        };
+
+
+        private bool TryRenderIframeFromKnownProviders(Uri uri, HtmlRenderer renderer, LinkInline linkInline)
+        {
+            var iFrameUrl = 
+                KnownHosts
+                    .Where(pair => uri.Host.StartsWith(pair.Key, StringComparison.OrdinalIgnoreCase))  // when host is match
+                    .Select(pair => pair.Value(uri))                                                   // try to call delegate to get iframeUrl
+                    .FirstOrDefault(iframeSrc => iframeSrc != null);                                   // use first success
+
+            if (iFrameUrl == null)
+            {
+                return false;
+            }
+
+            var htmlAttributes = GetHtmlAttributes(linkInline);
+            renderer.Write($"<iframe src=\"{iFrameUrl}\"");
+            htmlAttributes.AddPropertyIfNotExist("width", Options.Width);
+            htmlAttributes.AddPropertyIfNotExist("height", Options.Height);
+            htmlAttributes.AddPropertyIfNotExist("frameborder", "0");
+            htmlAttributes.AddPropertyIfNotExist("allowfullscreen", null);
+            renderer.WriteAttributes(htmlAttributes);
+            renderer.Write("></iframe>");
+
+            return true;
         }
 
         private static readonly string[] SplitAnd = {"&"};
@@ -130,5 +154,20 @@ namespace Markdig.Extensions.MediaLinks
             var query = uri.Query.Substring(uri.Query.IndexOf('?') + 1);
             return query.Split(SplitAnd, StringSplitOptions.RemoveEmptyEntries);
         }
+
+        private static string YouTube(Uri uri)
+        {
+            var query = SplitQuery(uri);
+            return query.Length > 0 && query[0].StartsWith("v=")
+                ? $"https://www.youtube.com/embed/{query[0].Substring(2)}"
+                : null;
+        }
+
+        private static string Vimeo(Uri uri)
+        {
+            var items = uri.GetComponents(UriComponents.Path, UriFormat.Unescaped).Split('/');
+            return items.Length > 0 ? $"https://player.vimeo.com/video/{items[items.Length - 1]}" : null;
+        }
+        #endregion
     }
 }

--- a/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
+++ b/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
@@ -129,6 +129,7 @@ namespace Markdig.Extensions.MediaLinks
             new KnownProvider {HostPrefix = "www.youtube.com", Delegate = YouTube},
             new KnownProvider {HostPrefix = "vimeo.com", Delegate = Vimeo},
             new KnownProvider {HostPrefix = "music.yandex.ru", Delegate = Yandex, AllowFullScreen = false},
+            new KnownProvider {HostPrefix = "ok.ru", Delegate = Odnoklassniki},
         };
 
 
@@ -185,6 +186,12 @@ namespace Markdig.Extensions.MediaLinks
         {
             var items = uri.GetComponents(UriComponents.Path, UriFormat.Unescaped).Split('/');
             return items.Length > 0 ? $"https://player.vimeo.com/video/{items[items.Length - 1]}" : null;
+        }
+
+        private static string Odnoklassniki(Uri uri)
+        {
+            var items = uri.GetComponents(UriComponents.Path, UriFormat.Unescaped).Split('/');
+            return items.Length > 0 ? $"https://ok.ru/videoembed/{items[items.Length - 1]}" : null;
         }
 
         private static string Yandex(Uri uri)


### PR DESCRIPTION
fixes #187 
* refactored MediaLinkExtensions to make it pluggable
* add support for yandex.music (audio)
* add support for ok.ru (video)
* failed to add support for vk.ru (need to supply hash that could not be guessed from URI)
* failed to add support for soundcloud (same reason)
  
  