### PR TITLE
Convert relative URLs to absolute

### DIFF
--- a/src/Markdig.Tests/Markdig.Tests.csproj
+++ b/src/Markdig.Tests/Markdig.Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="TestOrderedList.cs" />
     <Compile Include="TestPlainText.cs" />
     <Compile Include="TestPragmaLines.cs" />
+    <Compile Include="TestRelativeUrlReplacement.cs" />
     <Compile Include="TestSourcePosition.cs" />
     <Compile Include="TestStringSliceList.cs" />
     <Compile Include="TestPlayParser.cs" />

--- a/src/Markdig.Tests/TestRelativeUrlReplacement.cs
+++ b/src/Markdig.Tests/TestRelativeUrlReplacement.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using Markdig.Parsers;
+using Markdig.Renderers;
+using NUnit.Framework;
+
+namespace Markdig.Tests
+{
+    public class TestRelativeUrlReplacement
+    {
+        [Test]
+        public void ReplacesRelativeLinks()
+        {
+            TestSpec("https://example.com", "Link: [hello](/relative.jpg)", "https://example.com/relative.jpg");
+            TestSpec("https://example.com", "Link: [hello](relative.jpg)", "https://example.com/relative.jpg");
+            TestSpec("https://example.com/", "Link: [hello](/relative.jpg?a=b)", "https://example.com/relative.jpg?a=b");
+            TestSpec("https://example.com/", "Link: [hello](relative.jpg#x)", "https://example.com/relative.jpg#x");
+            TestSpec(null, "Link: [hello](relative.jpg)", "relative.jpg");
+            TestSpec(null, "Link: [hello](/relative.jpg)", "/relative.jpg");
+            TestSpec("https://example.com", "Link: [hello](/relative.jpg)", "https://example.com/relative.jpg");
+        }
+
+        [Test]
+        public void ReplacesRelativeImageSources()
+        {
+            TestSpec("https://example.com", "Image: ![alt text](/image.jpg)", "https://example.com/image.jpg");
+            TestSpec("https://example.com", "Image: ![alt text](image.jpg \"title\")", "https://example.com/image.jpg");
+            TestSpec(null, "Image: ![alt text](/image.jpg)", "/image.jpg");
+        }
+
+        public static void TestSpec(string baseUrl, string markdown, string expectedLink)
+        {
+            var pipeline = new MarkdownPipelineBuilder().Build();
+
+            var writer = new StringWriter();
+            var renderer = new HtmlRenderer(writer);
+            if (baseUrl != null)
+                renderer.BaseUrl = new Uri(baseUrl);
+            pipeline.Setup(renderer);
+
+            var document = MarkdownParser.Parse(markdown, pipeline);
+            renderer.Render(document);
+            writer.Flush();
+
+            Assert.That(writer.ToString(), Contains.Substring("=\"" + expectedLink + "\""));
+        }
+    }
+}

--- a/src/Markdig/Renderers/HtmlRenderer.cs
+++ b/src/Markdig/Renderers/HtmlRenderer.cs
@@ -76,6 +76,11 @@ namespace Markdig.Renderers
         public bool UseNonAsciiNoEscape { get; set; }
 
         /// <summary>
+        /// Gets a value to use as the base url for all relative links
+        /// </summary>
+        public Uri BaseUrl { get; set; }
+
+        /// <summary>
         /// Writes the content escaped for HTML.
         /// </summary>
         /// <param name="content">The content.</param>
@@ -191,6 +196,11 @@ namespace Markdig.Renderers
         {
             if (content == null)
                 return this;
+
+            if (BaseUrl != null && !Uri.TryCreate(content, UriKind.Absolute, out Uri _))
+            {
+                content = new Uri(BaseUrl, content).AbsoluteUri;
+            }
 
             int previousPosition = 0;
             int length = content.Length;


### PR DESCRIPTION
HTML renderer supports converting relative URLs on links and images to absolute #143

Doesn't touch links inside HTML blocks, just markdown defined blocks

Added a few basic unit tests. 

