### PR TITLE
Upgrade NUnit3TestAdapter from 3.2 to 3.9 

### DIFF
--- a/src/Markdig.Tests/project.json
+++ b/src/Markdig.Tests/project.json
@@ -19,6 +19,6 @@
   },
   "dependencies": {
     "NUnit": "3.2.0",
-    "NUnit3TestAdapter": "3.2.0"
+    "NUnit3TestAdapter": "3.9.0"
   }
 }


### PR DESCRIPTION
to address Resharper test runner problems

The problems with running test in R# is solved by upgrading NUnit3TestAdapter  to latest version.
This is per R# support recommendation and solves issue for me