### PR TITLE
Add alternative `Use` extension method to `MarkdownPipelineBuilder` that receives an object instance

### DIFF
--- a/src/Markdig/MarkdownExtensions.cs
+++ b/src/Markdig/MarkdownExtensions.cs
@@ -52,6 +52,19 @@ namespace Markdig
         }
 
         /// <summary>
+        /// Adds the specified extension instance to the extensions collection.
+        /// </summary>
+        /// <param name="pipeline">The pipeline.</param>
+        /// <param name="extension">The instance of the extension to be added.</param>
+        /// <typeparam name="TExtension">The type of the extension.</typeparam>
+        /// <returns>The modified pipeline</returns>
+        public static MarkdownPipelineBuilder Use<TExtension>(this MarkdownPipelineBuilder pipeline, TExtension extension) where TExtension : class, IMarkdownExtension
+        {
+            pipeline.Extensions.AddIfNotAlready(extension);
+            return pipeline;
+        }
+
+        /// <summary>
         /// Uses all extensions except the BootStrap, Emoji, SmartyPants and soft line as hard line breaks extensions.
         /// </summary>
         /// <param name="pipeline">The pipeline.</param>


### PR DESCRIPTION
This PR adds an overload of the `MarkdownPipelineBuilder.Use<T>` method that receives an instance of an `IMarkdownExtension`, for the cases where the extension has a constructor requiring parameters and cannot be instantiated by the existing `Use<T>` method.

Syntax looks like:

```csharp
var pipeline = new MarkdownPipelineBuilder()
	.Use(new MyAwesomeExtension("param1", "param2")) // <== this
	.UseAdvancedExtensions()
	.Build();
```