### PR TITLE
Add `ConfigureNewLineExtension` markdown extension

### DIFF
--- a/src/Markdig/Extensions/TextRenderer/ConfigureNewLineExtension.cs
+++ b/src/Markdig/Extensions/TextRenderer/ConfigureNewLineExtension.cs
@@ -1,0 +1,34 @@
+using Markdig.Renderers;
+
+namespace Markdig.Extensions.TextRenderer
+{
+    /// <summary>
+    /// Extension that allows setting line-endings for any IMarkdownRenderer
+    /// that inherits from <see cref="Markdig.Renderers.TextRendererBase"/>
+    /// </summary>
+    /// <seealso cref="Markdig.IMarkdownExtension" />
+    public class ConfigureNewLineExtension : IMarkdownExtension
+    {
+        private readonly string newLine;
+
+        public ConfigureNewLineExtension(string newLine)
+        {
+            this.newLine = newLine;
+        }
+
+        public void Setup(MarkdownPipelineBuilder pipeline)
+        {
+        }
+
+        public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
+        {
+            var textRenderer = renderer as TextRendererBase;
+            if (textRenderer == null)
+            {
+                return;
+            }
+
+            textRenderer.Writer.NewLine = newLine;
+        }
+    }
+}

--- a/src/Markdig/MarkdownExtensions.cs
+++ b/src/Markdig/MarkdownExtensions.cs
@@ -29,6 +29,7 @@ using Markdig.Extensions.SmartyPants;
 using Markdig.Extensions.NonAsciiNoEscape;
 using Markdig.Extensions.Tables;
 using Markdig.Extensions.TaskLists;
+using Markdig.Extensions.TextRenderer;
 using Markdig.Extensions.Yaml;
 using Markdig.Parsers;
 using Markdig.Parsers.Inlines;
@@ -586,6 +587,18 @@ namespace Markdig
                         throw new ArgumentException($"Invalid extension `{extension}` from `{extensions}`", nameof(extensions));
                 }
             }
+            return pipeline;
+        }
+
+        /// <summary>
+        /// Configures the string to be used for line-endings, when writing.
+        /// </summary>
+        /// <param name="pipeline">The pipeline.</param>
+        /// <param name="newLine">The string to be used for line-endings.</param>
+        /// <returns>The modified pipeline</returns>
+        public static MarkdownPipelineBuilder ConfigureNewLine(this MarkdownPipelineBuilder pipeline, string newLine)
+        {
+            pipeline.Use(new ConfigureNewLineExtension(newLine));
             return pipeline;
         }
     }


### PR DESCRIPTION
This PR adds an extension which allows devs to define what string to use for line-endings when writing.

As per my comment in #211, [`Markdig` always uses `\n` for line-breaks](https://github.com/lunet-io/markdig/blob/master/src/Markdig/Renderers/TextRendererBase.cs#L32). This extension exposes an easy way to override the default behavior when defining the pipeline.

Below is an example on how to define that line-endings should use `Environment.NewLine`:

```csharp
var pipeline = new MarkdownPipelineBuilder()
	.ConfigureNewLine(Environment.NewLine)
	.UseAdvancedExtensions()
	.Build();
```

---

ps: This PR builds on #213, which should be merged first.