### PR TITLE
Add tests for `ConfigureNewLineExtension`'s `ConfigureNewLine`

### DIFF
--- a/src/Markdig.Tests/Markdig.Tests.csproj
+++ b/src/Markdig.Tests/Markdig.Tests.csproj
@@ -57,6 +57,7 @@
       <DependentUpon>Specs.tt</DependentUpon>
     </Compile>
     <Compile Include="Specs\TestEmphasisPlus.cs" />
+    <Compile Include="TestConfigureNewLine.cs" />
     <Compile Include="TestHtmlAttributes.cs" />
     <Compile Include="TestHtmlHelper.cs" />
     <Compile Include="TestLineReader.cs" />

--- a/src/Markdig.Tests/TestConfigureNewLine.cs
+++ b/src/Markdig.Tests/TestConfigureNewLine.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+
+namespace Markdig.Tests
+{
+    [TestFixture]
+    public class TestConfigureNewLine
+    {
+        [Test]
+        [TestCase(/* newLineForWriting: */ "\n",   /* markdownText: */ "*1*\n*2*\n",     /* expected: */ "<p><em>1</em>\n<em>2</em></p>\n")]
+        [TestCase(/* newLineForWriting: */ "\n",   /* markdownText: */ "*1*\r\n*2*\r\n", /* expected: */ "<p><em>1</em>\n<em>2</em></p>\n")]
+        [TestCase(/* newLineForWriting: */ "\r\n", /* markdownText: */ "*1*\n*2*\n",     /* expected: */ "<p><em>1</em>\r\n<em>2</em></p>\r\n")]
+        [TestCase(/* newLineForWriting: */ "\r\n", /* markdownText: */ "*1*\r\n*2*\r\n", /* expected: */ "<p><em>1</em>\r\n<em>2</em></p>\r\n")]
+        [TestCase(/* newLineForWriting: */ "!!!" , /* markdownText: */ "*1*\n*2*\n",     /* expected: */ "<p><em>1</em>!!!<em>2</em></p>!!!")]
+        [TestCase(/* newLineForWriting: */ "!!!" , /* markdownText: */ "*1*\r\n*2*\r\n", /* expected: */ "<p><em>1</em>!!!<em>2</em></p>!!!")]
+        public void TestHtmlOutputWhenConfiguringNewLine(string newLineForWriting, string markdownText, string expected)
+        {
+            var pipeline = new MarkdownPipelineBuilder()
+                .ConfigureNewLine(newLineForWriting)
+                .Build();
+
+            var actual = Markdown.ToHtml(markdownText, pipeline);
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
Add unit tests for configuring custom line-endings for the generated HTML through `ConfigureNewLineExtension`'s `ConfigureNewLine` introduced in #214