### PR TITLE
Fix spelling in package description

### DIFF
--- a/src/Markdig/Markdig.csproj
+++ b/src/Markdig/Markdig.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>A fast, powerfull, CommonMark compliant, extensible Markdown processor for .NET with 20+ builtin extensions (pipetables, footnotes, definition lists... etc.)</Description>
+    <Description>A fast, powerful, CommonMark compliant, extensible Markdown processor for .NET with 20+ builtin extensions (pipetables, footnotes, definition lists... etc.)</Description>
     <Copyright>Alexandre Mutel</Copyright>
     <AssemblyTitle>Markdig</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>


### PR DESCRIPTION
Wicktionary [marks](https://en.wiktionary.org/wiki/powerfull) "powerfull" as an "archaic form of powerful", so I suppose it could be fixed?