### PR TITLE
Expose the number of lines in a document

### DIFF
--- a/src/Markdig/Parsers/MarkdownParser.cs
+++ b/src/Markdig/Parsers/MarkdownParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
@@ -87,6 +87,9 @@ namespace Markdig.Parsers
         {
             ProcessBlocks();
             ProcessInlines();
+
+            // At this point the LineIndex is the same as the number of lines in the document
+            document.LineCount = blockProcessor.LineIndex;
             
             // Allow to call a hook after processing a document
             documentProcessed?.Invoke(document);
@@ -146,8 +149,7 @@ namespace Markdig.Parsers
                 for (; item.Index < container.Count; item.Index++)
                 {
                     var block = container[item.Index];
-                    var leafBlock = block as LeafBlock;
-                    if (leafBlock != null)
+                    if (block is LeafBlock leafBlock)
                     {
                         leafBlock.OnProcessInlinesBegin(inlineProcessor);
                         if (leafBlock.ProcessInlines)

--- a/src/Markdig/Syntax/MarkdownDocument.cs
+++ b/src/Markdig/Syntax/MarkdownDocument.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 namespace Markdig.Syntax
@@ -15,5 +15,10 @@ namespace Markdig.Syntax
         public MarkdownDocument() : base(null)
         {
         }
+
+        /// <summary>
+        /// Gets the number of lines in this <see cref="MarkdownDocument"/>
+        /// </summary>
+        public int LineCount;
     }
 }


### PR DESCRIPTION
I think this would be a nice feature to have (I know I need it).

I've tried to do it by using a block parser just to count lines, but, while it worked, it seemed overkill considering the value is already known, just hidden.
```csharp
private class LineCounter : BlockParser
{
    public int Count => _count + 1;
    private int _count = -1;
    public override BlockState TryOpen(BlockProcessor processor)
    {
        _count = processor.LineIndex;
        return BlockState.None;
    }
}
```