### PR TITLE
Fix Link and Footnote reference definitions in syntax tree

### DIFF
--- a/src/Markdig.Tests/TestSourcePosition.cs
+++ b/src/Markdig.Tests/TestSourcePosition.cs
@@ -156,11 +156,26 @@ literal      ( 0, 6)  6-7
         }
 
         [Test]
-        public void TestLinkReferenceDefinition()
+        public void TestLinkReferenceDefinition1()
+        {
+            //                         0         1
+            //                         0123456789012345
+            var link = Markdown.Parse("[234]: /56 'yo' ", new MarkdownPipelineBuilder().UsePreciseSourceLocation().Build()).Descendants().OfType<LinkReferenceDefinition>().FirstOrDefault();
+            Assert.NotNull(link);
+
+            Assert.AreEqual(0, link.Line);
+            Assert.AreEqual(new SourceSpan(0, 14), link.Span);
+            Assert.AreEqual(new SourceSpan(1, 3), link.LabelSpan);
+            Assert.AreEqual(new SourceSpan(7, 9), link.UrlSpan);
+            Assert.AreEqual(new SourceSpan(11, 14), link.TitleSpan);
+        }
+
+        [Test]
+        public void TestLinkReferenceDefinition2()
         {
             //                         0          1
-            //                         01 2 3456789012345678
-            var link = Markdown.Parse("0\n\n [234]: /56 'yo'", new MarkdownPipelineBuilder().UsePreciseSourceLocation().Build()).Descendants().OfType<LinkReferenceDefinition>().FirstOrDefault();
+            //                         01 2 34567890123456789
+            var link = Markdown.Parse("0\n\n [234]: /56 'yo' ", new MarkdownPipelineBuilder().UsePreciseSourceLocation().Build()).Descendants().OfType<LinkReferenceDefinition>().FirstOrDefault();
             Assert.NotNull(link);
 
             Assert.AreEqual(2, link.Line);

--- a/src/Markdig.Tests/TestSourcePosition.cs
+++ b/src/Markdig.Tests/TestSourcePosition.cs
@@ -156,6 +156,21 @@ literal      ( 0, 6)  6-7
         }
 
         [Test]
+        public void TestLinkReferenceDefinition()
+        {
+            //                         0          1
+            //                         01 2 3456789012345678
+            var link = Markdown.Parse("0\n\n [234]: /56 'yo'", new MarkdownPipelineBuilder().UsePreciseSourceLocation().Build()).Descendants().OfType<LinkReferenceDefinition>().FirstOrDefault();
+            Assert.NotNull(link);
+
+            Assert.AreEqual(2, link.Line);
+            Assert.AreEqual(new SourceSpan(4, 18), link.Span);
+            Assert.AreEqual(new SourceSpan(5, 7), link.LabelSpan);
+            Assert.AreEqual(new SourceSpan(11, 13), link.UrlSpan);
+            Assert.AreEqual(new SourceSpan(15, 18), link.TitleSpan);
+        }
+
+        [Test]
         public void TestCodeSpan()
         {
             //     012345678

--- a/src/Markdig.Tests/TestSourcePosition.cs
+++ b/src/Markdig.Tests/TestSourcePosition.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Markdig.Extensions.Footnotes;
 using Markdig.Helpers;
 using Markdig.Renderers.Html;
 using Markdig.Syntax;
@@ -140,6 +141,18 @@ literal      ( 0, 2)  2-3
 emphasis     ( 0, 4)  4-9
 literal      ( 0, 6)  6-7
 ");
+        }
+
+        [Test]
+        public void TestFootnoteLinkReferenceDefinition()
+        {
+            //                             01 2 345678
+            var footnote = Markdown.Parse("0\n\n [^1]:", new MarkdownPipelineBuilder().UsePreciseSourceLocation().UseFootnotes().Build()).Descendants().OfType<FootnoteLinkReferenceDefinition>().FirstOrDefault();
+            Assert.NotNull(footnote);
+
+            Assert.AreEqual(2, footnote.Line);
+            Assert.AreEqual(new SourceSpan(4, 7), footnote.Span);
+            Assert.AreEqual(new SourceSpan(5, 6), footnote.LabelSpan);
         }
 
         [Test]

--- a/src/Markdig/Extensions/Footnotes/FootnoteParser.cs
+++ b/src/Markdig/Extensions/Footnotes/FootnoteParser.cs
@@ -75,7 +75,11 @@ namespace Markdig.Extensions.Footnotes
             var linkRef = new FootnoteLinkReferenceDefinition()
             {
                 Footnote = footnote,
-                CreateLinkInline = CreateLinkToFootnote
+                CreateLinkInline = CreateLinkToFootnote,
+                Line = processor.LineIndex,
+                Span = new SourceSpan(start, processor.Start - 2), // account for ]:
+                LabelSpan = labelSpan,
+                Label = label
             };
             processor.Document.SetLinkReferenceDefinition(footnote.Label, linkRef);
             processor.NewBlocks.Push(footnote);

--- a/src/Markdig/MarkdownPipelineBuilder.cs
+++ b/src/Markdig/MarkdownPipelineBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 using System;
@@ -116,9 +116,16 @@ namespace Markdig
                 extension.Setup(this);
             }
 
-            pipeline = new MarkdownPipeline(new OrderedList<IMarkdownExtension>(Extensions),
-                new BlockParserList(BlockParsers), new InlineParserList(InlineParsers), StringBuilderCache, DebugLog,
-                GetDocumentProcessed) {PreciseSourceLocation = PreciseSourceLocation};
+            pipeline = new MarkdownPipeline(
+                new OrderedList<IMarkdownExtension>(Extensions),
+                new BlockParserList(BlockParsers),
+                new InlineParserList(InlineParsers),
+                StringBuilderCache,
+                DebugLog,
+                GetDocumentProcessed)
+            {
+                PreciseSourceLocation = PreciseSourceLocation
+            };
             return pipeline;
         }
     }

--- a/src/Markdig/Parsers/ParagraphBlockParser.cs
+++ b/src/Markdig/Parsers/ParagraphBlockParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 using Markdig.Helpers;
@@ -9,7 +9,7 @@ namespace Markdig.Parsers
     /// <summary>
     /// Block parser for a <see cref="ParagraphBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.BlockParser" />
+    /// <seealso cref="BlockParser" />
     public class ParagraphBlockParser : BlockParser
     {
         public override BlockState TryOpen(BlockProcessor processor)
@@ -152,14 +152,19 @@ namespace Markdig.Parsers
             {
                 // If we have found a LinkReferenceDefinition, we can discard the previous paragraph
                 var iterator = lines.ToCharIterator();
-                LinkReferenceDefinition linkReferenceDefinition;
-                if (LinkReferenceDefinition.TryParse(ref iterator, out linkReferenceDefinition))
+                if (LinkReferenceDefinition.TryParse(ref iterator, out LinkReferenceDefinition linkReferenceDefinition))
                 {
-                    if (!state.Document.ContainsLinkReferenceDefinition(linkReferenceDefinition.Label))
-                    {
-                        state.Document.SetLinkReferenceDefinition(linkReferenceDefinition.Label, linkReferenceDefinition);
-                    }
+                    state.Document.SetLinkReferenceDefinition(linkReferenceDefinition.Label, linkReferenceDefinition);
                     atLeastOneFound = true;
+
+                    // Correct the locations of each field
+                    linkReferenceDefinition.Line = lines.Lines[0].Line;
+                    int lineStartPosition = lines.Lines[0].Position + 1;
+
+                    linkReferenceDefinition.Span        = linkReferenceDefinition.Span      .MoveForward(lineStartPosition);
+                    linkReferenceDefinition.LabelSpan   = linkReferenceDefinition.LabelSpan .MoveForward(lineStartPosition);
+                    linkReferenceDefinition.UrlSpan     = linkReferenceDefinition.UrlSpan   .MoveForward(lineStartPosition);
+                    linkReferenceDefinition.TitleSpan   = linkReferenceDefinition.TitleSpan .MoveForward(lineStartPosition);
 
                     // Remove lines that have been matched
                     if (iterator.Start > iterator.End)

--- a/src/Markdig/Parsers/ParagraphBlockParser.cs
+++ b/src/Markdig/Parsers/ParagraphBlockParser.cs
@@ -159,12 +159,12 @@ namespace Markdig.Parsers
 
                     // Correct the locations of each field
                     linkReferenceDefinition.Line = lines.Lines[0].Line;
-                    int lineStartPosition = lines.Lines[0].Position + 1;
+                    int startPosition = lines.Lines[0].Slice.Start;
 
-                    linkReferenceDefinition.Span        = linkReferenceDefinition.Span      .MoveForward(lineStartPosition);
-                    linkReferenceDefinition.LabelSpan   = linkReferenceDefinition.LabelSpan .MoveForward(lineStartPosition);
-                    linkReferenceDefinition.UrlSpan     = linkReferenceDefinition.UrlSpan   .MoveForward(lineStartPosition);
-                    linkReferenceDefinition.TitleSpan   = linkReferenceDefinition.TitleSpan .MoveForward(lineStartPosition);
+                    linkReferenceDefinition.Span        = linkReferenceDefinition.Span      .MoveForward(startPosition);
+                    linkReferenceDefinition.LabelSpan   = linkReferenceDefinition.LabelSpan .MoveForward(startPosition);
+                    linkReferenceDefinition.UrlSpan     = linkReferenceDefinition.UrlSpan   .MoveForward(startPosition);
+                    linkReferenceDefinition.TitleSpan   = linkReferenceDefinition.TitleSpan .MoveForward(startPosition);
 
                     // Remove lines that have been matched
                     if (iterator.Start > iterator.End)

--- a/src/Markdig/Syntax/LinkReferenceDefinitionGroup.cs
+++ b/src/Markdig/Syntax/LinkReferenceDefinitionGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
@@ -29,10 +29,13 @@ namespace Markdig.Syntax
         public void Set(string label, LinkReferenceDefinition link)
         {
             if (link == null) throw new ArgumentNullException(nameof(link));
-            Links[label] = link;
             if (!Contains(link))
             {
                 Add(link);
+                if (!Links.ContainsKey(label))
+                {
+                    Links[label] = link;
+                }
             }
         }
 

--- a/src/Markdig/Syntax/SourceSpan.cs
+++ b/src/Markdig/Syntax/SourceSpan.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
@@ -42,6 +42,11 @@ namespace Markdig.Syntax
         public int Length => End - Start + 1;
 
         public bool IsEmpty => Start > End;
+
+        public SourceSpan MoveForward(int count)
+        {
+            return new SourceSpan(Start + count, End + count);
+        }
 
         public bool Equals(SourceSpan other)
         {


### PR DESCRIPTION
This does not affect HTML rendering at all, it merely exposes more information to the syntax tree:
- Keep all LinkReferenceDefinitions (doesn't overwrite same-named ones)
- Sets the correct lines and spans for them
- Sets the content and source locations for FootnoteLinkReferenceDefinitions