### PR TITLE
 Expose line start indexes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 - Add support for RTL ([(PR #239)](https://github.com/lunet-io/markdig/pull/239))
 - Add MarkdownDocument.LineCount ([(PR #241)](https://github.com/lunet-io/markdig/pull/241))
 - Fix source positions for link definitions ([(PR #243)](https://github.com/lunet-io/markdig/pull/243))
+- Add ListItemBlock.Order ([(PR #244)](https://github.com/lunet-io/markdig/pull/244))
+- Add MarkdownDocument.LineStartIndexes ([(PR #247)](https://github.com/lunet-io/markdig/pull/247))
 
 ## 0.15.2 (21 Aug 2018)
 - Fix footnotes parsing when they are defined after a container that has been closed in the meantime (#223)

--- a/src/Markdig/Parsers/BlockProcessor.cs
+++ b/src/Markdig/Parsers/BlockProcessor.cs
@@ -444,6 +444,8 @@ namespace Markdig.Parsers
         {
             CurrentLineStartPosition = newLine.Start;
 
+            Document.LineStartIndexes?.Add(CurrentLineStartPosition);
+
             ContinueProcessingLine = true;
 
             ResetLine(newLine);

--- a/src/Markdig/Parsers/MarkdownParser.cs
+++ b/src/Markdig/Parsers/MarkdownParser.cs
@@ -85,6 +85,9 @@ namespace Markdig.Parsers
         /// <returns>A document instance</returns>
         private MarkdownDocument Parse()
         {
+            if (preciseSourceLocation)
+                document.LineStartIndexes = new List<int>();
+
             ProcessBlocks();
             ProcessInlines();
 

--- a/src/Markdig/Syntax/MarkdownDocument.cs
+++ b/src/Markdig/Syntax/MarkdownDocument.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+using System.Collections.Generic;
+
 namespace Markdig.Syntax
 {
     /// <summary>
@@ -20,5 +22,11 @@ namespace Markdig.Syntax
         /// Gets the number of lines in this <see cref="MarkdownDocument"/>
         /// </summary>
         public int LineCount;
+
+        /// <summary>
+        /// Gets a list of zero-based indexes of line beginnings in the source span
+        /// <para>Available if <see cref="MarkdownPipelineBuilder.PreciseSourceLocation"/> is used, otherwise null</para>
+        /// </summary>
+        public List<int> LineStartIndexes;
     }
 }


### PR DESCRIPTION
This makes precise source locations much more reliable since it removes the need to ferry around two line and column numbers alongside the span. Sample location algorithm made possible by this:
https://github.com/MihaZupan/MarkdownValidator/blob/master/src/MarkdownValidator/Warnings/WarningLocation.cs#L54-L73
I think it being available only when PreciseSourceLocation is set is fitting.