### PR TITLE
Autolink domain name validation

### DIFF
--- a/src/Markdig.Tests/Specs/AutoLinks.md
+++ b/src/Markdig.Tests/Specs/AutoLinks.md
@@ -1,4 +1,4 @@
-# Extensions
+﻿# Extensions
 
 This section describes the different extensions supported:
 
@@ -77,6 +77,14 @@ Check **http://www.a.com** or __http://www.b.com__
 <p>Check <strong><a href="http://www.a.com">http://www.a.com</a></strong> or <strong><a href="http://www.b.com">http://www.b.com</a></strong></p>
 ````````````````````````````````
 
+It is not mentioned by the spec, but empty emails won't be matched (only a subset of [RFC2368](https://tools.ietf.org/html/rfc2368) is supported by auto links):
+
+```````````````````````````````` example
+mailto:email@test.com is okay, but mailto:@test.com is not
+.
+<p><a href="mailto:email@test.com">email@test.com</a> is okay, but mailto:@test.com is not</p>
+````````````````````````````````
+
 ### GFM Support
 
 Extract from [GFM Autolinks extensions specs](https://github.github.com/gfm/#autolinks-extension-)
@@ -139,4 +147,76 @@ Anonymous FTP is available at ftp://foo.bar.baz.
 <p><a href="http://commonmark.org">http://commonmark.org</a></p>
 <p>(Visit <a href="https://encrypted.google.com/search?q=Markup+(business)">https://encrypted.google.com/search?q=Markup+(business)</a>)</p>
 <p>Anonymous FTP is available at <a href="ftp://foo.bar.baz">ftp://foo.bar.baz</a>.</p>
+````````````````````````````````
+
+### Valid Domain Tests
+
+Domain names that have empty segments won't be matched
+
+```````````````````````````````` example
+www..
+www..com
+http://test.
+http://.test
+http://.
+http://..
+ftp://test.
+ftp://.test
+mailto:email@test.
+mailto:email@.test
+.
+<p>www..
+www..com
+http://test.
+http://.test
+http://.
+http://..
+ftp://test.
+ftp://.test
+mailto:email@test.
+mailto:email@.test</p>
+````````````````````````````````
+
+Domain names with too few segments won't be matched
+
+```````````````````````````````` example
+www
+www.com
+http://test
+ftp://test
+mailto:email@test
+.
+<p>www
+www.com
+http://test
+ftp://test
+mailto:email@test</p>
+````````````````````````````````
+
+Domain names that contain an underscores in the last two segments won't be matched
+
+```````````````````````````````` example
+www._test.foo.bar is okay, but www._test.foo is not
+
+http://te_st.foo.bar is okay, as is http://test.foo_.bar.foo
+
+But http://te_st.foo, http://test.foo_.bar and http://test._foo are not
+
+ftp://test_.foo.bar is okay, but ftp://test.fo_o is not
+
+mailto:email@_test.foo.bar is okay, but mailto:email@_test.foo is not
+.
+<p><a href="http://www._test.foo.bar">www._test.foo.bar</a> is okay, but www._test.foo is not</p>
+<p><a href="http://te_st.foo.bar">http://te_st.foo.bar</a> is okay, as is <a href="http://test.foo_.bar.foo">http://test.foo_.bar.foo</a></p>
+<p>But http://te_st.foo, http://test.foo_.bar and http://test._foo are not</p>
+<p><a href="ftp://test_.foo.bar">ftp://test_.foo.bar</a> is okay, but ftp://test.fo_o is not</p>
+<p><a href="mailto:email@_test.foo.bar">email@_test.foo.bar</a> is okay, but mailto:email@_test.foo is not</p>
+````````````````````````````````
+
+Domain names that contain invalid characters (not AlphaNumberic, -, _ or .) won't be matched
+
+```````````````````````````````` example
+https://[your-domain]/api
+.
+<p>https://[your-domain]/api</p>
 ````````````````````````````````

--- a/src/Markdig.Tests/Specs/Specs.cs
+++ b/src/Markdig.Tests/Specs/Specs.cs
@@ -1,357 +1,719 @@
-﻿// Generated the 08/28/2018 16:28:47
+﻿
+
+
+
+
+
+
+
+
+
+
+
+
+// Generated the 10/06/2018 17:15:07
 using System;
 using NUnit.Framework;
 
 namespace Markdig.Tests
 {
+
         // ---
+
         // title: CommonMark Spec
+
         // author: John MacFarlane
+
         // version: 0.28
+
         // date: '2017-08-01'
+
         // license: '[CC-BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/)'
+
         // ...
+
         //
+
         // # Introduction
+
         //
+
         // ## What is Markdown?
+
         //
+
         // Markdown is a plain text format for writing structured documents,
+
         // based on conventions for indicating formatting in email
+
         // and usenet posts.  It was developed by John Gruber (with
+
         // help from Aaron Swartz) and released in 2004 in the form of a
+
         // [syntax description](http://daringfireball.net/projects/markdown/syntax)
+
         // and a Perl script (`Markdown.pl`) for converting Markdown to
+
         // HTML.  In the next decade, dozens of implementations were
+
         // developed in many languages.  Some extended the original
+
         // Markdown syntax with conventions for footnotes, tables, and
+
         // other document elements.  Some allowed Markdown documents to be
+
         // rendered in formats other than HTML.  Websites like Reddit,
+
         // StackOverflow, and GitHub had millions of people using Markdown.
+
         // And Markdown started to be used beyond the web, to author books,
+
         // articles, slide shows, letters, and lecture notes.
+
         //
+
         // What distinguishes Markdown from many other lightweight markup
+
         // syntaxes, which are often easier to write, is its readability.
+
         // As Gruber writes:
+
         //
+
         // > The overriding design goal for Markdown's formatting syntax is
+
         // > to make it as readable as possible. The idea is that a
+
         // > Markdown-formatted document should be publishable as-is, as
+
         // > plain text, without looking like it's been marked up with tags
+
         // > or formatting instructions.
+
         // > (<http://daringfireball.net/projects/markdown/>)
+
         //
+
         // The point can be illustrated by comparing a sample of
+
         // [AsciiDoc](http://www.methods.co.nz/asciidoc/) with
+
         // an equivalent sample of Markdown.  Here is a sample of
+
         // AsciiDoc from the AsciiDoc manual:
+
         //
+
         // ```
+
         // 1. List item one.
+
         // +
+
         // List item one continued with a second paragraph followed by an
+
         // Indented block.
+
         // +
+
         // .................
+
         // $ ls *.sh
+
         // $ mv *.sh ~/tmp
+
         // .................
+
         // +
+
         // List item continued with a third paragraph.
+
         //
+
         // 2. List item two continued with an open block.
+
         // +
+
         // --
+
         // This paragraph is part of the preceding list item.
+
         //
+
         // a. This list is nested and does not require explicit item
+
         // continuation.
+
         // +
+
         // This paragraph is part of the preceding list item.
+
         //
+
         // b. List item b.
+
         //
+
         // This paragraph belongs to item two of the outer list.
+
         // --
+
         // ```
+
         //
+
         // And here is the equivalent in Markdown:
+
         // ```
+
         // 1.  List item one.
+
         //
+
         // List item one continued with a second paragraph followed by an
+
         // Indented block.
+
         //
+
         // $ ls *.sh
+
         // $ mv *.sh ~/tmp
+
         //
+
         // List item continued with a third paragraph.
+
         //
+
         // 2.  List item two continued with an open block.
+
         //
+
         // This paragraph is part of the preceding list item.
+
         //
+
         // 1. This list is nested and does not require explicit item continuation.
+
         //
+
         // This paragraph is part of the preceding list item.
+
         //
+
         // 2. List item b.
+
         //
+
         // This paragraph belongs to item two of the outer list.
+
         // ```
+
         //
+
         // The AsciiDoc version is, arguably, easier to write. You don't need
+
         // to worry about indentation.  But the Markdown version is much easier
+
         // to read.  The nesting of list items is apparent to the eye in the
+
         // source, not just in the processed document.
+
         //
+
         // ## Why is a spec needed?
+
         //
+
         // John Gruber's [canonical description of Markdown's
+
         // syntax](http://daringfireball.net/projects/markdown/syntax)
+
         // does not specify the syntax unambiguously.  Here are some examples of
+
         // questions it does not answer:
+
         //
+
         // 1.  How much indentation is needed for a sublist?  The spec says that
+
         // continuation paragraphs need to be indented four spaces, but is
+
         // not fully explicit about sublists.  It is natural to think that
+
         // they, too, must be indented four spaces, but `Markdown.pl` does
+
         // not require that.  This is hardly a "corner case," and divergences
+
         // between implementations on this issue often lead to surprises for
+
         // users in real documents. (See [this comment by John
+
         // Gruber](http://article.gmane.org/gmane.text.markdown.general/1997).)
+
         //
+
         // 2.  Is a blank line needed before a block quote or heading?
+
         // Most implementations do not require the blank line.  However,
+
         // this can lead to unexpected results in hard-wrapped text, and
+
         // also to ambiguities in parsing (note that some implementations
+
         // put the heading inside the blockquote, while others do not).
+
         // (John Gruber has also spoken [in favor of requiring the blank
+
         // lines](http://article.gmane.org/gmane.text.markdown.general/2146).)
+
         //
+
         // 3.  Is a blank line needed before an indented code block?
+
         // (`Markdown.pl` requires it, but this is not mentioned in the
+
         // documentation, and some implementations do not require it.)
+
         //
+
         // ``` markdown
+
         // paragraph
+
         // code?
+
         // ```
+
         //
+
         // 4.  What is the exact rule for determining when list items get
+
         // wrapped in `<p>` tags?  Can a list be partially "loose" and partially
+
         // "tight"?  What should we do with a list like this?
+
         //
+
         // ``` markdown
+
         // 1. one
+
         //
+
         // 2. two
+
         // 3. three
+
         // ```
+
         //
+
         // Or this?
+
         //
+
         // ``` markdown
+
         // 1.  one
+
         // - a
+
         //
+
         // - b
+
         // 2.  two
+
         // ```
+
         //
+
         // (There are some relevant comments by John Gruber
+
         // [here](http://article.gmane.org/gmane.text.markdown.general/2554).)
+
         //
+
         // 5.  Can list markers be indented?  Can ordered list markers be right-aligned?
+
         //
+
         // ``` markdown
+
         // 8. item 1
+
         // 9. item 2
+
         // 10. item 2a
+
         // ```
+
         //
+
         // 6.  Is this one list with a thematic break in its second item,
+
         // or two lists separated by a thematic break?
+
         //
+
         // ``` markdown
+
         // * a
+
         // * * * * *
+
         // * b
+
         // ```
+
         //
+
         // 7.  When list markers change from numbers to bullets, do we have
+
         // two lists or one?  (The Markdown syntax description suggests two,
+
         // but the perl scripts and many other implementations produce one.)
+
         //
+
         // ``` markdown
+
         // 1. fee
+
         // 2. fie
+
         // -  foe
+
         // -  fum
+
         // ```
+
         //
+
         // 8.  What are the precedence rules for the markers of inline structure?
+
         // For example, is the following a valid link, or does the code span
+
         // take precedence ?
+
         //
+
         // ``` markdown
+
         // [a backtick (`)](/url) and [another backtick (`)](/url).
+
         // ```
+
         //
+
         // 9.  What are the precedence rules for markers of emphasis and strong
+
         // emphasis?  For example, how should the following be parsed?
+
         //
+
         // ``` markdown
+
         // *foo *bar* baz*
+
         // ```
+
         //
+
         // 10. What are the precedence rules between block-level and inline-level
+
         // structure?  For example, how should the following be parsed?
+
         //
+
         // ``` markdown
+
         // - `a long code span can contain a hyphen like this
+
         // - and it can screw things up`
+
         // ```
+
         //
+
         // 11. Can list items include section headings?  (`Markdown.pl` does not
+
         // allow this, but does allow blockquotes to include headings.)
+
         //
+
         // ``` markdown
+
         // - # Heading
+
         // ```
+
         //
+
         // 12. Can list items be empty?
+
         //
+
         // ``` markdown
+
         // * a
+
         // *
+
         // * b
+
         // ```
+
         //
+
         // 13. Can link references be defined inside block quotes or list items?
+
         //
+
         // ``` markdown
+
         // > Blockquote [foo].
+
         // >
+
         // > [foo]: /url
+
         // ```
+
         //
+
         // 14. If there are multiple definitions for the same reference, which takes
+
         // precedence?
+
         //
+
         // ``` markdown
+
         // [foo]: /url1
+
         // [foo]: /url2
+
         //
+
         // [foo][]
+
         // ```
+
         //
+
         // In the absence of a spec, early implementers consulted `Markdown.pl`
+
         // to resolve these ambiguities.  But `Markdown.pl` was quite buggy, and
+
         // gave manifestly bad results in many cases, so it was not a
+
         // satisfactory replacement for a spec.
+
         //
+
         // Because there is no unambiguous spec, implementations have diverged
+
         // considerably.  As a result, users are often surprised to find that
+
         // a document that renders one way on one system (say, a github wiki)
+
         // renders differently on another (say, converting to docbook using
+
         // pandoc).  To make matters worse, because nothing in Markdown counts
+
         // as a "syntax error," the divergence often isn't discovered right away.
+
         //
+
         // ## About this document
+
         //
+
         // This document attempts to specify Markdown syntax unambiguously.
+
         // It contains many examples with side-by-side Markdown and
+
         // HTML.  These are intended to double as conformance tests.  An
+
         // accompanying script `spec_tests.py` can be used to run the tests
+
         // against any Markdown program:
+
         //
+
         // python test/spec_tests.py --spec spec.txt --program PROGRAM
+
         //
+
         // Since this document describes how Markdown is to be parsed into
+
         // an abstract syntax tree, it would have made sense to use an abstract
+
         // representation of the syntax tree instead of HTML.  But HTML is capable
+
         // of representing the structural distinctions we need to make, and the
+
         // choice of HTML for the tests makes it possible to run the tests against
+
         // an implementation without writing an abstract syntax tree renderer.
+
         //
+
         // This document is generated from a text file, `spec.txt`, written
+
         // in Markdown with a small extension for the side-by-side tests.
+
         // The script `tools/makespec.py` can be used to convert `spec.txt` into
+
         // HTML or CommonMark (which can then be converted into other formats).
+
         //
+
         // In the examples, the `→` character is used to represent tabs.
+
         //
+
         // # Preliminaries
+
         //
+
         // ## Characters and lines
+
         //
+
         // Any sequence of [characters] is a valid CommonMark
+
         // document.
+
         //
+
         // A [character](@) is a Unicode code point.  Although some
+
         // code points (for example, combining accents) do not correspond to
+
         // characters in an intuitive sense, all code points count as characters
+
         // for purposes of this spec.
+
         //
+
         // This spec does not specify an encoding; it thinks of lines as composed
+
         // of [characters] rather than bytes.  A conforming parser may be limited
+
         // to a certain encoding.
+
         //
+
         // A [line](@) is a sequence of zero or more [characters]
+
         // other than newline (`U+000A`) or carriage return (`U+000D`),
+
         // followed by a [line ending] or by the end of file.
+
         //
+
         // A [line ending](@) is a newline (`U+000A`), a carriage return
+
         // (`U+000D`) not followed by a newline, or a carriage return and a
+
         // following newline.
+
         //
+
         // A line containing no characters, or a line containing only spaces
+
         // (`U+0020`) or tabs (`U+0009`), is called a [blank line](@).
+
         //
+
         // The following definitions of character classes will be used in this spec:
+
         //
+
         // A [whitespace character](@) is a space
+
         // (`U+0020`), tab (`U+0009`), newline (`U+000A`), line tabulation (`U+000B`),
+
         // form feed (`U+000C`), or carriage return (`U+000D`).
+
         //
+
         // [Whitespace](@) is a sequence of one or more [whitespace
+
         // characters].
+
         //
+
         // A [Unicode whitespace character](@) is
+
         // any code point in the Unicode `Zs` general category, or a tab (`U+0009`),
+
         // carriage return (`U+000D`), newline (`U+000A`), or form feed
+
         // (`U+000C`).
+
         //
+
         // [Unicode whitespace](@) is a sequence of one
+
         // or more [Unicode whitespace characters].
+
         //
+
         // A [space](@) is `U+0020`.
+
         //
+
         // A [non-whitespace character](@) is any character
+
         // that is not a [whitespace character].
+
         //
+
         // An [ASCII punctuation character](@)
+
         // is `!`, `"`, `#`, `$`, `%`, `&`, `'`, `(`, `)`,
+
         // `*`, `+`, `,`, `-`, `.`, `/`, `:`, `;`, `<`, `=`, `>`, `?`, `@`,
+
         // `[`, `\`, `]`, `^`, `_`, `` ` ``, `{`, `|`, `}`, or `~`.
+
         //
+
         // A [punctuation character](@) is an [ASCII
+
         // punctuation character] or anything in
+
         // the general Unicode categories  `Pc`, `Pd`, `Pe`, `Pf`, `Pi`, `Po`, or `Ps`.
+
         //
+
         // ## Tabs
+
         //
+
         // Tabs in lines are not expanded to [spaces].  However,
+
         // in contexts where whitespace helps to define block structure,
+
         // tabs behave as if they were replaced by spaces with a tab stop
+
         // of 4 characters.
+
         //
+
         // Thus, for example, a tab can be used instead of four spaces
+
         // in an indented code block.  (Note, however, that internal
+
         // tabs are passed through as literal tabs, not expanded to
+
         // spaces.)
+
     [TestFixture]
     public partial class TestPreliminariesTabs
     {
@@ -372,6 +734,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("\tfoo\tbaz\t\tbim", "<pre><code>foo\tbaz\t\tbim\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestPreliminariesTabs
     {
@@ -392,6 +755,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("  \tfoo\tbaz\t\tbim", "<pre><code>foo\tbaz\t\tbim\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestPreliminariesTabs
     {
@@ -414,9 +778,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    a\ta\n    ὐ\ta", "<pre><code>a\ta\nὐ\ta\n</code></pre>", "");
         }
     }
+
         // In the following example, a continuation paragraph of a list
+
         // item is indented with a tab; this has exactly the same effect
+
         // as indentation with four spaces would:
+
     [TestFixture]
     public partial class TestPreliminariesTabs
     {
@@ -443,6 +811,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("  - foo\n\n\tbar", "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>", "");
         }
     }
+
     [TestFixture]
     public partial class TestPreliminariesTabs
     {
@@ -470,14 +839,23 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- foo\n\n\t\tbar", "<ul>\n<li>\n<p>foo</p>\n<pre><code>  bar\n</code></pre>\n</li>\n</ul>", "");
         }
     }
+
         // Normally the `>` that begins a block quote may be followed
+
         // optionally by a space, which is not considered part of the
+
         // content.  In the following case `>` is followed by a tab,
+
         // which is treated as if it were expanded into three spaces.
+
         // Since one of these spaces is considered part of the
+
         // delimiter, `foo` is considered to be indented six spaces
+
         // inside the block quote context, so we get an indented
+
         // code block starting with two spaces.
+
     [TestFixture]
     public partial class TestPreliminariesTabs
     {
@@ -500,6 +878,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec(">\t\tfoo", "<blockquote>\n<pre><code>  foo\n</code></pre>\n</blockquote>", "");
         }
     }
+
     [TestFixture]
     public partial class TestPreliminariesTabs
     {
@@ -524,6 +903,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("-\t\tfoo", "<ul>\n<li>\n<pre><code>  foo\n</code></pre>\n</li>\n</ul>", "");
         }
     }
+
     [TestFixture]
     public partial class TestPreliminariesTabs
     {
@@ -546,6 +926,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    foo\n\tbar", "<pre><code>foo\nbar\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestPreliminariesTabs
     {
@@ -577,6 +958,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec(" - foo\n   - bar\n\t - baz", "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>", "");
         }
     }
+
     [TestFixture]
     public partial class TestPreliminariesTabs
     {
@@ -596,6 +978,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("#\tFoo", "<h1>Foo</h1>", "");
         }
     }
+
     [TestFixture]
     public partial class TestPreliminariesTabs
     {
@@ -615,25 +998,45 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*\t*\t*\t", "<hr />", "");
         }
     }
+
         // ## Insecure characters
+
         //
+
         // For security reasons, the Unicode character `U+0000` must be replaced
+
         // with the REPLACEMENT CHARACTER (`U+FFFD`).
+
         //
+
         // # Blocks and inlines
+
         //
+
         // We can think of a document as a sequence of
+
         // [blocks](@)---structural elements like paragraphs, block
+
         // quotations, lists, headings, rules, and code blocks.  Some blocks (like
+
         // block quotes and list items) contain other blocks; others (like
+
         // headings and paragraphs) contain [inline](@) content---text,
+
         // links, emphasized text, images, code spans, and so on.
+
         //
+
         // ## Precedence
+
         //
+
         // Indicators of block structure always take precedence over indicators
+
         // of inline structure.  So, for example, the following is a list with
+
         // two items, not a list with one item containing a code span:
+
     [TestFixture]
     public partial class TestBlocksandinlinesPrecedence
     {
@@ -657,33 +1060,61 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- `one\n- two`", "<ul>\n<li>`one</li>\n<li>two`</li>\n</ul>", "");
         }
     }
+
         // This means that parsing can proceed in two steps:  first, the block
+
         // structure of the document can be discerned; second, text lines inside
+
         // paragraphs, headings, and other block constructs can be parsed for inline
+
         // structure.  The second step requires information about link reference
+
         // definitions that will be available only at the end of the first
+
         // step.  Note that the first step requires processing lines in sequence,
+
         // but the second can be parallelized, since the inline parsing of
+
         // one block element does not affect the inline parsing of any other.
+
         //
+
         // ## Container blocks and leaf blocks
+
         //
+
         // We can divide blocks into two types:
+
         // [container block](@)s,
+
         // which can contain other blocks, and [leaf block](@)s,
+
         // which cannot.
+
         //
+
         // # Leaf blocks
+
         //
+
         // This section describes the different kinds of leaf block that make up a
+
         // Markdown document.
+
         //
+
         // ## Thematic breaks
+
         //
+
         // A line consisting of 0-3 spaces of indentation, followed by a sequence
+
         // of three or more matching `-`, `_`, or `*` characters, each followed
+
         // optionally by any number of spaces, forms a
+
         // [thematic break](@).
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -707,7 +1138,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("***\n---\n___", "<hr />\n<hr />\n<hr />", "");
         }
     }
+
         // Wrong characters:
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -727,6 +1160,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("+++", "<p>+++</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -746,7 +1180,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("===", "<p>===</p>", "");
         }
     }
+
         // Not enough characters:
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -770,7 +1206,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("--\n**\n__", "<p>--\n**\n__</p>", "");
         }
     }
+
         // One to three spaces indent are allowed:
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -794,7 +1232,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec(" ***\n  ***\n   ***", "<hr />\n<hr />\n<hr />", "");
         }
     }
+
         // Four spaces is too many:
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -815,6 +1255,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    ***", "<pre><code>***\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -836,7 +1277,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo\n    ***", "<p>Foo\n***</p>", "");
         }
     }
+
         // More than three characters may be used:
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -856,7 +1299,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_____________________________________", "<hr />", "");
         }
     }
+
         // Spaces are allowed between the characters:
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -876,6 +1321,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec(" - - -", "<hr />", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -895,6 +1341,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec(" **  * ** * ** * **", "<hr />", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -914,7 +1361,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("-     -      -      -", "<hr />", "");
         }
     }
+
         // Spaces are allowed at the end:
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -934,7 +1383,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- - - -    ", "<hr />", "");
         }
     }
+
         // However, no other characters may occur in the line:
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -960,8 +1411,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_ _ _ _ a\n\na------\n\n---a---", "<p>_ _ _ _ a</p>\n<p>a------</p>\n<p>---a---</p>", "");
         }
     }
+
         // It is required that all of the [non-whitespace characters] be the same.
+
         // So, this is not a thematic break:
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -981,7 +1435,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec(" *-*", "<p><em>-</em></p>", "");
         }
     }
+
         // Thematic breaks do not need blank lines before or after:
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -1009,7 +1465,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- foo\n***\n- bar", "<ul>\n<li>foo</li>\n</ul>\n<hr />\n<ul>\n<li>bar</li>\n</ul>", "");
         }
     }
+
         // Thematic breaks can interrupt a paragraph:
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -1033,11 +1491,17 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo\n***\nbar", "<p>Foo</p>\n<hr />\n<p>bar</p>", "");
         }
     }
+
         // If a line of dashes that meets the above conditions for being a
+
         // thematic break could also be interpreted as the underline of a [setext
+
         // heading], the interpretation as a
+
         // [setext heading] takes precedence. Thus, for example,
+
         // this is a setext heading, not a paragraph followed by a thematic break:
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -1060,8 +1524,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo\n---\nbar", "<h2>Foo</h2>\n<p>bar</p>", "");
         }
     }
+
         // When both a thematic break and a list item are possible
+
         // interpretations of a line, the thematic break takes precedence:
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -1089,7 +1556,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("* Foo\n* * *\n* Bar", "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n<ul>\n<li>Bar</li>\n</ul>", "");
         }
     }
+
         // If you want a thematic break in a list item, use a different bullet:
+
     [TestFixture]
     public partial class TestLeafblocksThematicbreaks
     {
@@ -1115,21 +1584,37 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- Foo\n- * * *", "<ul>\n<li>Foo</li>\n<li>\n<hr />\n</li>\n</ul>", "");
         }
     }
+
         // ## ATX headings
+
         //
+
         // An [ATX heading](@)
+
         // consists of a string of characters, parsed as inline content, between an
+
         // opening sequence of 1--6 unescaped `#` characters and an optional
+
         // closing sequence of any number of unescaped `#` characters.
+
         // The opening sequence of `#` characters must be followed by a
+
         // [space] or by the end of line. The optional closing sequence of `#`s must be
+
         // preceded by a [space] and may be followed by spaces only.  The opening
+
         // `#` character may be indented 0-3 spaces.  The raw contents of the
+
         // heading are stripped of leading and trailing spaces before being parsed
+
         // as inline content.  The heading level is equal to the number of `#`
+
         // characters in the opening sequence.
+
         //
+
         // Simple headings:
+
     [TestFixture]
     public partial class TestLeafblocksATXheadings
     {
@@ -1159,7 +1644,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("# foo\n## foo\n### foo\n#### foo\n##### foo\n###### foo", "<h1>foo</h1>\n<h2>foo</h2>\n<h3>foo</h3>\n<h4>foo</h4>\n<h5>foo</h5>\n<h6>foo</h6>", "");
         }
     }
+
         // More than six `#` characters is not a heading:
+
     [TestFixture]
     public partial class TestLeafblocksATXheadings
     {
@@ -1179,13 +1666,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("####### foo", "<p>####### foo</p>", "");
         }
     }
+
         // At least one space is required between the `#` characters and the
+
         // heading's contents, unless the heading is empty.  Note that many
+
         // implementations currently do not require the space.  However, the
+
         // space was required by the
+
         // [original ATX implementation](http://www.aaronsw.com/2002/atx/atx.py),
+
         // and it helps prevent things like the following from being parsed as
+
         // headings:
+
     [TestFixture]
     public partial class TestLeafblocksATXheadings
     {
@@ -1208,7 +1703,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("#5 bolt\n\n#hashtag", "<p>#5 bolt</p>\n<p>#hashtag</p>", "");
         }
     }
+
         // This is not a heading, because the first `#` is escaped:
+
     [TestFixture]
     public partial class TestLeafblocksATXheadings
     {
@@ -1228,7 +1725,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("\\## foo", "<p>## foo</p>", "");
         }
     }
+
         // Contents are parsed as inlines:
+
     [TestFixture]
     public partial class TestLeafblocksATXheadings
     {
@@ -1248,7 +1747,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("# foo *bar* \\*baz\\*", "<h1>foo <em>bar</em> *baz*</h1>", "");
         }
     }
+
         // Leading and trailing blanks are ignored in parsing inline content:
+
     [TestFixture]
     public partial class TestLeafblocksATXheadings
     {
@@ -1268,7 +1769,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("#                  foo                     ", "<h1>foo</h1>", "");
         }
     }
+
         // One to three spaces indentation are allowed:
+
     [TestFixture]
     public partial class TestLeafblocksATXheadings
     {
@@ -1292,7 +1795,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec(" ### foo\n  ## foo\n   # foo", "<h3>foo</h3>\n<h2>foo</h2>\n<h1>foo</h1>", "");
         }
     }
+
         // Four spaces are too much:
+
     [TestFixture]
     public partial class TestLeafblocksATXheadings
     {
@@ -1313,6 +1818,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    # foo", "<pre><code># foo\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksATXheadings
     {
@@ -1334,7 +1840,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo\n    # bar", "<p>foo\n# bar</p>", "");
         }
     }
+
         // A closing sequence of `#` characters is optional:
+
     [TestFixture]
     public partial class TestLeafblocksATXheadings
     {
@@ -1356,7 +1864,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("## foo ##\n  ###   bar    ###", "<h2>foo</h2>\n<h3>bar</h3>", "");
         }
     }
+
         // It need not be the same length as the opening sequence:
+
     [TestFixture]
     public partial class TestLeafblocksATXheadings
     {
@@ -1378,7 +1888,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("# foo ##################################\n##### foo ##", "<h1>foo</h1>\n<h5>foo</h5>", "");
         }
     }
+
         // Spaces are allowed after the closing sequence:
+
     [TestFixture]
     public partial class TestLeafblocksATXheadings
     {
@@ -1398,9 +1910,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("### foo ###     ", "<h3>foo</h3>", "");
         }
     }
+
         // A sequence of `#` characters with anything but [spaces] following it
+
         // is not a closing sequence, but counts as part of the contents of the
+
         // heading:
+
     [TestFixture]
     public partial class TestLeafblocksATXheadings
     {
@@ -1420,7 +1936,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("### foo ### b", "<h3>foo ### b</h3>", "");
         }
     }
+
         // The closing sequence must be preceded by a space:
+
     [TestFixture]
     public partial class TestLeafblocksATXheadings
     {
@@ -1440,8 +1958,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("# foo#", "<h1>foo#</h1>", "");
         }
     }
+
         // Backslash-escaped `#` characters do not count as part
+
         // of the closing sequence:
+
     [TestFixture]
     public partial class TestLeafblocksATXheadings
     {
@@ -1465,8 +1986,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("### foo \\###\n## foo #\\##\n# foo \\#", "<h3>foo ###</h3>\n<h2>foo ###</h2>\n<h1>foo #</h1>", "");
         }
     }
+
         // ATX headings need not be separated from surrounding content by blank
+
         // lines, and they can interrupt paragraphs:
+
     [TestFixture]
     public partial class TestLeafblocksATXheadings
     {
@@ -1490,6 +2014,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("****\n## foo\n****", "<hr />\n<h2>foo</h2>\n<hr />", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksATXheadings
     {
@@ -1513,7 +2038,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo bar\n# baz\nBar foo", "<p>Foo bar</p>\n<h1>baz</h1>\n<p>Bar foo</p>", "");
         }
     }
+
         // ATX headings can be empty:
+
     [TestFixture]
     public partial class TestLeafblocksATXheadings
     {
@@ -1537,37 +2064,69 @@ namespace Markdig.Tests
 			TestParser.TestSpec("## \n#\n### ###", "<h2></h2>\n<h1></h1>\n<h3></h3>", "");
         }
     }
+
         // ## Setext headings
+
         //
+
         // A [setext heading](@) consists of one or more
+
         // lines of text, each containing at least one [non-whitespace
+
         // character], with no more than 3 spaces indentation, followed by
+
         // a [setext heading underline].  The lines of text must be such
+
         // that, were they not followed by the setext heading underline,
+
         // they would be interpreted as a paragraph:  they cannot be
+
         // interpretable as a [code fence], [ATX heading][ATX headings],
+
         // [block quote][block quotes], [thematic break][thematic breaks],
+
         // [list item][list items], or [HTML block][HTML blocks].
+
         //
+
         // A [setext heading underline](@) is a sequence of
+
         // `=` characters or a sequence of `-` characters, with no more than 3
+
         // spaces indentation and any number of trailing spaces.  If a line
+
         // containing a single `-` can be interpreted as an
+
         // empty [list items], it should be interpreted this way
+
         // and not as a [setext heading underline].
+
         //
+
         // The heading is a level 1 heading if `=` characters are used in
+
         // the [setext heading underline], and a level 2 heading if `-`
+
         // characters are used.  The contents of the heading are the result
+
         // of parsing the preceding lines of text as CommonMark inline
+
         // content.
+
         //
+
         // In general, a setext heading need not be preceded or followed by a
+
         // blank line.  However, it cannot interrupt a paragraph, so when a
+
         // setext heading comes after a paragraph, a blank line is needed between
+
         // them.
+
         //
+
         // Simple examples:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -1592,7 +2151,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo *bar*\n=========\n\nFoo *bar*\n---------", "<h1>Foo <em>bar</em></h1>\n<h2>Foo <em>bar</em></h2>", "");
         }
     }
+
         // The content of the header may span more than one line:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -1615,7 +2176,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo *bar\nbaz*\n====", "<h1>Foo <em>bar\nbaz</em></h1>", "");
         }
     }
+
         // The underlining can be any length:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -1640,8 +2203,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo\n-------------------------\n\nFoo\n=", "<h2>Foo</h2>\n<h1>Foo</h1>", "");
         }
     }
+
         // The heading content can be indented up to three spaces, and need
+
         // not line up with the underlining:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -1670,7 +2236,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("   Foo\n---\n\n  Foo\n-----\n\n  Foo\n  ===", "<h2>Foo</h2>\n<h2>Foo</h2>\n<h1>Foo</h1>", "");
         }
     }
+
         // Four spaces indent is too much:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -1699,8 +2267,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    Foo\n    ---\n\n    Foo\n---", "<pre><code>Foo\n---\n\nFoo\n</code></pre>\n<hr />", "");
         }
     }
+
         // The setext heading underline can be indented up to three spaces, and
+
         // may have trailing spaces:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -1721,7 +2292,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo\n   ----      ", "<h2>Foo</h2>", "");
         }
     }
+
         // Four spaces is too much:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -1743,7 +2316,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo\n    ---", "<p>Foo\n---</p>", "");
         }
     }
+
         // The setext heading underline cannot contain internal spaces:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -1770,7 +2345,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo\n= =\n\nFoo\n--- -", "<p>Foo\n= =</p>\n<p>Foo</p>\n<hr />", "");
         }
     }
+
         // Trailing spaces in the content line do not cause a line break:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -1791,7 +2368,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo  \n-----", "<h2>Foo</h2>", "");
         }
     }
+
         // Nor does a backslash at the end:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -1812,8 +2391,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo\\\n----", "<h2>Foo\\</h2>", "");
         }
     }
+
         // Since indicators of block structure take precedence over
+
         // indicators of inline structure, the following are setext headings:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -1842,8 +2424,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>", "<h2>`Foo</h2>\n<p>`</p>\n<h2>&lt;a title=&quot;a lot</h2>\n<p>of dashes&quot;/&gt;</p>", "");
         }
     }
+
         // The setext heading underline cannot be a [lazy continuation
+
         // line] in a list item or block quote:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -1867,6 +2452,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> Foo\n---", "<blockquote>\n<p>Foo</p>\n</blockquote>\n<hr />", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -1892,6 +2478,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> foo\nbar\n===", "<blockquote>\n<p>foo\nbar\n===</p>\n</blockquote>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -1915,9 +2502,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- Foo\n---", "<ul>\n<li>Foo</li>\n</ul>\n<hr />", "");
         }
     }
+
         // A blank line is needed between a paragraph and a following
+
         // setext heading, since otherwise the paragraph becomes part
+
         // of the heading's content:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -1940,8 +2531,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo\nBar\n---", "<h2>Foo\nBar</h2>", "");
         }
     }
+
         // But in general a blank line is not required before or after
+
         // setext headings:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -1969,7 +2563,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("---\nFoo\n---\nBar\n---\nBaz", "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>", "");
         }
     }
+
         // Setext headings cannot be empty:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -1989,9 +2585,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("====", "<p>====</p>", "");
         }
     }
+
         // Setext heading text lines must not be interpretable as block
+
         // constructs other than paragraphs.  So, the line of dashes
+
         // in these examples gets interpreted as a thematic break:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -2013,6 +2613,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("---\n---", "<hr />\n<hr />", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -2036,6 +2637,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- foo\n-----", "<ul>\n<li>foo</li>\n</ul>\n<hr />", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -2058,6 +2660,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    foo\n---", "<pre><code>foo\n</code></pre>\n<hr />", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -2081,8 +2684,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> foo\n-----", "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />", "");
         }
     }
+
         // If you want a heading with `> foo` as its literal text, you can
+
         // use backslash escapes:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -2103,28 +2709,51 @@ namespace Markdig.Tests
 			TestParser.TestSpec("\\> foo\n------", "<h2>&gt; foo</h2>", "");
         }
     }
+
         // **Compatibility note:**  Most existing Markdown implementations
+
         // do not allow the text of setext headings to span multiple lines.
+
         // But there is no consensus about how to interpret
+
         //
+
         // ``` markdown
+
         // Foo
+
         // bar
+
         // ---
+
         // baz
+
         // ```
+
         //
+
         // One can find four different interpretations:
+
         //
+
         // 1. paragraph "Foo", heading "bar", paragraph "baz"
+
         // 2. paragraph "Foo bar", thematic break, paragraph "baz"
+
         // 3. paragraph "Foo bar --- baz"
+
         // 4. heading "Foo bar", paragraph "baz"
+
         //
+
         // We find interpretation 4 most natural, and interpretation 4
+
         // increases the expressive power of CommonMark, by allowing
+
         // multiline headings.  Authors who want interpretation 1 can
+
         // put a blank line after the first paragraph:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -2150,8 +2779,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo\n\nbar\n---\nbaz", "<p>Foo</p>\n<h2>bar</h2>\n<p>baz</p>", "");
         }
     }
+
         // Authors who want interpretation 2 can put blank lines around
+
         // the thematic break,
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -2179,8 +2811,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo\nbar\n\n---\n\nbaz", "<p>Foo\nbar</p>\n<hr />\n<p>baz</p>", "");
         }
     }
+
         // or use a thematic break that cannot count as a [setext heading
+
         // underline], such as
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -2206,7 +2841,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo\nbar\n* * *\nbaz", "<p>Foo\nbar</p>\n<hr />\n<p>baz</p>", "");
         }
     }
+
         // Authors who want interpretation 3 can use backslash escapes:
+
     [TestFixture]
     public partial class TestLeafblocksSetextheadings
     {
@@ -2232,20 +2869,35 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo\nbar\n\\---\nbaz", "<p>Foo\nbar\n---\nbaz</p>", "");
         }
     }
+
         // ## Indented code blocks
+
         //
+
         // An [indented code block](@) is composed of one or more
+
         // [indented chunks] separated by blank lines.
+
         // An [indented chunk](@) is a sequence of non-blank lines,
+
         // each indented four or more spaces. The contents of the code block are
+
         // the literal contents of the lines, including trailing
+
         // [line endings], minus four spaces of indentation.
+
         // An indented code block has no [info string].
+
         //
+
         // An indented code block cannot interrupt a paragraph, so there must be
+
         // a blank line between a paragraph and a following indented code block.
+
         // (A blank line is not needed, however, between a code block and a following
+
         // paragraph.)
+
     [TestFixture]
     public partial class TestLeafblocksIndentedcodeblocks
     {
@@ -2268,9 +2920,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    a simple\n      indented code block", "<pre><code>a simple\n  indented code block\n</code></pre>", "");
         }
     }
+
         // If there is any ambiguity between an interpretation of indentation
+
         // as a code block and as indicating that material belongs to a [list
+
         // item][list items], the list item interpretation takes precedence:
+
     [TestFixture]
     public partial class TestLeafblocksIndentedcodeblocks
     {
@@ -2297,6 +2953,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("  - foo\n\n    bar", "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksIndentedcodeblocks
     {
@@ -2325,8 +2982,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("1.  foo\n\n    - bar", "<ol>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>", "");
         }
     }
+
         // The contents of a code block are literal text, and do not get parsed
+
         // as Markdown:
+
     [TestFixture]
     public partial class TestLeafblocksIndentedcodeblocks
     {
@@ -2353,7 +3013,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    <a/>\n    *hi*\n\n    - one", "<pre><code>&lt;a/&gt;\n*hi*\n\n- one\n</code></pre>", "");
         }
     }
+
         // Here we have three chunks separated by blank lines:
+
     [TestFixture]
     public partial class TestLeafblocksIndentedcodeblocks
     {
@@ -2386,8 +3048,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    chunk1\n\n    chunk2\n  \n \n \n    chunk3", "<pre><code>chunk1\n\nchunk2\n\n\n\nchunk3\n</code></pre>", "");
         }
     }
+
         // Any initial spaces beyond four will be included in the content, even
+
         // in interior blank lines:
+
     [TestFixture]
     public partial class TestLeafblocksIndentedcodeblocks
     {
@@ -2412,8 +3077,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    chunk1\n      \n      chunk2", "<pre><code>chunk1\n  \n  chunk2\n</code></pre>", "");
         }
     }
+
         // An indented code block cannot interrupt a paragraph.  (This
+
         // allows hanging indents and the like.)
+
     [TestFixture]
     public partial class TestLeafblocksIndentedcodeblocks
     {
@@ -2436,9 +3104,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo\n    bar\n", "<p>Foo\nbar</p>", "");
         }
     }
+
         // However, any non-blank line with fewer than four leading spaces ends
+
         // the code block immediately.  So a paragraph may occur immediately
+
         // after indented code:
+
     [TestFixture]
     public partial class TestLeafblocksIndentedcodeblocks
     {
@@ -2461,8 +3133,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    foo\nbar", "<pre><code>foo\n</code></pre>\n<p>bar</p>", "");
         }
     }
+
         // And indented code can occur immediately before and after other kinds of
+
         // blocks:
+
     [TestFixture]
     public partial class TestLeafblocksIndentedcodeblocks
     {
@@ -2493,7 +3168,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("# Heading\n    foo\nHeading\n------\n    foo\n----", "<h1>Heading</h1>\n<pre><code>foo\n</code></pre>\n<h2>Heading</h2>\n<pre><code>foo\n</code></pre>\n<hr />", "");
         }
     }
+
         // The first line can be indented more than four spaces:
+
     [TestFixture]
     public partial class TestLeafblocksIndentedcodeblocks
     {
@@ -2516,8 +3193,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("        foo\n    bar", "<pre><code>    foo\nbar\n</code></pre>", "");
         }
     }
+
         // Blank lines preceding or following an indented code block
+
         // are not included in it:
+
     [TestFixture]
     public partial class TestLeafblocksIndentedcodeblocks
     {
@@ -2541,7 +3221,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    \n    foo\n    \n", "<pre><code>foo\n</code></pre>", "");
         }
     }
+
         // Trailing spaces are included in the code block's content:
+
     [TestFixture]
     public partial class TestLeafblocksIndentedcodeblocks
     {
@@ -2562,51 +3244,97 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    foo  ", "<pre><code>foo  \n</code></pre>", "");
         }
     }
+
         // ## Fenced code blocks
+
         //
+
         // A [code fence](@) is a sequence
+
         // of at least three consecutive backtick characters (`` ` ``) or
+
         // tildes (`~`).  (Tildes and backticks cannot be mixed.)
+
         // A [fenced code block](@)
+
         // begins with a code fence, indented no more than three spaces.
+
         //
+
         // The line with the opening code fence may optionally contain some text
+
         // following the code fence; this is trimmed of leading and trailing
+
         // spaces and called the [info string](@).
+
         // The [info string] may not contain any backtick
+
         // characters.  (The reason for this restriction is that otherwise
+
         // some inline code would be incorrectly interpreted as the
+
         // beginning of a fenced code block.)
+
         //
+
         // The content of the code block consists of all subsequent lines, until
+
         // a closing [code fence] of the same type as the code block
+
         // began with (backticks or tildes), and with at least as many backticks
+
         // or tildes as the opening code fence.  If the leading code fence is
+
         // indented N spaces, then up to N spaces of indentation are removed from
+
         // each line of the content (if present).  (If a content line is not
+
         // indented, it is preserved unchanged.  If it is indented less than N
+
         // spaces, all of the indentation is removed.)
+
         //
+
         // The closing code fence may be indented up to three spaces, and may be
+
         // followed only by spaces, which are ignored.  If the end of the
+
         // containing block (or document) is reached and no closing code fence
+
         // has been found, the code block contains all of the lines after the
+
         // opening code fence until the end of the containing block (or
+
         // document).  (An alternative spec would require backtracking in the
+
         // event that a closing code fence is not found.  But this makes parsing
+
         // much less efficient, and there seems to be no real down side to the
+
         // behavior described here.)
+
         //
+
         // A fenced code block may interrupt a paragraph, and does not require
+
         // a blank line either before or after.
+
         //
+
         // The content of a code fence is treated as literal text, not parsed
+
         // as inlines.  The first word of the [info string] is typically used to
+
         // specify the language of the code sample, and rendered in the `class`
+
         // attribute of the `code` tag.  However, this spec does not mandate any
+
         // particular treatment of the [info string].
+
         //
+
         // Here is a simple example with backticks:
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -2631,7 +3359,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("```\n<\n >\n```", "<pre><code>&lt;\n &gt;\n</code></pre>", "");
         }
     }
+
         // With tildes:
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -2656,7 +3386,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("~~~\n<\n >\n~~~", "<pre><code>&lt;\n &gt;\n</code></pre>", "");
         }
     }
+
         // Fewer than three backticks is not enough:
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -2678,8 +3410,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("``\nfoo\n``", "<p><code>foo</code></p>", "");
         }
     }
+
         // The closing code fence must use the same character as the opening
+
         // fence:
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -2704,6 +3439,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("```\naaa\n~~~\n```", "<pre><code>aaa\n~~~\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -2728,7 +3464,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("~~~\naaa\n```\n~~~", "<pre><code>aaa\n```\n</code></pre>", "");
         }
     }
+
         // The closing code fence must be at least as long as the opening fence:
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -2753,6 +3491,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("````\naaa\n```\n``````", "<pre><code>aaa\n```\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -2777,8 +3516,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("~~~~\naaa\n~~~\n~~~~", "<pre><code>aaa\n~~~\n</code></pre>", "");
         }
     }
+
         // Unclosed code blocks are closed by the end of the document
+
         // (or the enclosing [block quote][block quotes] or [list item][list items]):
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -2798,6 +3540,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("```", "<pre><code></code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -2823,6 +3566,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("`````\n\n```\naaa", "<pre><code>\n```\naaa\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -2849,7 +3593,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> ```\n> aaa\n\nbbb", "<blockquote>\n<pre><code>aaa\n</code></pre>\n</blockquote>\n<p>bbb</p>", "");
         }
     }
+
         // A code block can have all empty lines as its content:
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -2874,7 +3620,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("```\n\n  \n```", "<pre><code>\n  \n</code></pre>", "");
         }
     }
+
         // A code block can be empty:
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -2895,9 +3643,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("```\n```", "<pre><code></code></pre>", "");
         }
     }
+
         // Fences can be indented.  If the opening fence is indented,
+
         // content lines will have equivalent opening indentation removed,
+
         // if present:
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -2922,6 +3674,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec(" ```\n aaa\naaa\n```", "<pre><code>aaa\naaa\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -2948,6 +3701,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("  ```\naaa\n  aaa\naaa\n  ```", "<pre><code>aaa\naaa\naaa\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -2974,7 +3728,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("   ```\n   aaa\n    aaa\n  aaa\n   ```", "<pre><code>aaa\n aaa\naaa\n</code></pre>", "");
         }
     }
+
         // Four spaces indentation produces an indented code block:
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -2999,8 +3755,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    ```\n    aaa\n    ```", "<pre><code>```\naaa\n```\n</code></pre>", "");
         }
     }
+
         // Closing fences may be indented by 0-3 spaces, and their indentation
+
         // need not match that of the opening fence:
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -3023,6 +3782,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("```\naaa\n  ```", "<pre><code>aaa\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -3045,7 +3805,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("   ```\naaa\n  ```", "<pre><code>aaa\n</code></pre>", "");
         }
     }
+
         // This is not a closing fence, because it is indented 4 spaces:
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -3069,7 +3831,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("```\naaa\n    ```", "<pre><code>aaa\n    ```\n</code></pre>", "");
         }
     }
+
         // Code fences (opening and closing) cannot contain internal spaces:
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -3091,6 +3855,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("``` ```\naaa", "<p><code></code>\naaa</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -3114,8 +3879,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("~~~~~~\naaa\n~~~ ~~", "<pre><code>aaa\n~~~ ~~\n</code></pre>", "");
         }
     }
+
         // Fenced code blocks can interrupt paragraphs, and can be followed
+
         // directly by paragraphs, without a blank line between:
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -3142,8 +3910,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo\n```\nbar\n```\nbaz", "<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>", "");
         }
     }
+
         // Other blocks can also occur before and after fenced code blocks
+
         // without an intervening blank line:
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -3171,10 +3942,15 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo\n---\n~~~\nbar\n~~~\n# baz", "<h2>foo</h2>\n<pre><code>bar\n</code></pre>\n<h1>baz</h1>", "");
         }
     }
+
         // An [info string] can be provided after the opening code fence.
+
         // Opening and closing spaces will be stripped, and the first word, prefixed
+
         // with `language-`, is used as the value for the `class` attribute of the
+
         // `code` element within the enclosing `pre` element.
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -3201,6 +3977,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("```ruby\ndef foo(x)\n  return 3\nend\n```", "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -3227,6 +4004,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("~~~~    ruby startline=3 $%@#$\ndef foo(x)\n  return 3\nend\n~~~~~~~", "<pre><code class=\"language-ruby\">def foo(x)\n  return 3\nend\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -3247,7 +4025,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("````;\n````", "<pre><code class=\"language-;\"></code></pre>", "");
         }
     }
+
         // [Info strings] for backtick code blocks cannot contain backticks:
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -3269,7 +4049,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("``` aa ```\nfoo", "<p><code>aa</code>\nfoo</p>", "");
         }
     }
+
         // Closing code fences cannot have [info strings]:
+
     [TestFixture]
     public partial class TestLeafblocksFencedcodeblocks
     {
@@ -3292,71 +4074,137 @@ namespace Markdig.Tests
 			TestParser.TestSpec("```\n``` aaa\n```", "<pre><code>``` aaa\n</code></pre>", "");
         }
     }
+
         // ## HTML blocks
+
         //
+
         // An [HTML block](@) is a group of lines that is treated
+
         // as raw HTML (and will not be escaped in HTML output).
+
         //
+
         // There are seven kinds of [HTML block], which can be defined
+
         // by their start and end conditions.  The block begins with a line that
+
         // meets a [start condition](@) (after up to three spaces
+
         // optional indentation).  It ends with the first subsequent line that
+
         // meets a matching [end condition](@), or the last line of
+
         // the document or other [container block]), if no line is encountered that meets the
+
         // [end condition].  If the first line meets both the [start condition]
+
         // and the [end condition], the block will contain just that line.
+
         //
+
         // 1.  **Start condition:**  line begins with the string `<script`,
+
         // `<pre`, or `<style` (case-insensitive), followed by whitespace,
+
         // the string `>`, or the end of the line.\
+
         // **End condition:**  line contains an end tag
+
         // `</script>`, `</pre>`, or `</style>` (case-insensitive; it
+
         // need not match the start tag).
+
         //
+
         // 2.  **Start condition:** line begins with the string `<!--`.\
+
         // **End condition:**  line contains the string `-->`.
+
         //
+
         // 3.  **Start condition:** line begins with the string `<?`.\
+
         // **End condition:** line contains the string `?>`.
+
         //
+
         // 4.  **Start condition:** line begins with the string `<!`
+
         // followed by an uppercase ASCII letter.\
+
         // **End condition:** line contains the character `>`.
+
         //
+
         // 5.  **Start condition:**  line begins with the string
+
         // `<![CDATA[`.\
+
         // **End condition:** line contains the string `]]>`.
+
         //
+
         // 6.  **Start condition:** line begins the string `<` or `</`
+
         // followed by one of the strings (case-insensitive) `address`,
+
         // `article`, `aside`, `base`, `basefont`, `blockquote`, `body`,
+
         // `caption`, `center`, `col`, `colgroup`, `dd`, `details`, `dialog`,
+
         // `dir`, `div`, `dl`, `dt`, `fieldset`, `figcaption`, `figure`,
+
         // `footer`, `form`, `frame`, `frameset`,
+
         // `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `head`, `header`, `hr`,
+
         // `html`, `iframe`, `legend`, `li`, `link`, `main`, `menu`, `menuitem`,
+
         // `meta`, `nav`, `noframes`, `ol`, `optgroup`, `option`, `p`, `param`,
+
         // `section`, `source`, `summary`, `table`, `tbody`, `td`,
+
         // `tfoot`, `th`, `thead`, `title`, `tr`, `track`, `ul`, followed
+
         // by [whitespace], the end of the line, the string `>`, or
+
         // the string `/>`.\
+
         // **End condition:** line is followed by a [blank line].
+
         //
+
         // 7.  **Start condition:**  line begins with a complete [open tag]
+
         // or [closing tag] (with any [tag name] other than `script`,
+
         // `style`, or `pre`) followed only by [whitespace]
+
         // or the end of the line.\
+
         // **End condition:** line is followed by a [blank line].
+
         //
+
         // HTML blocks continue until they are closed by their appropriate
+
         // [end condition], or the last line of the document or other [container block].
+
         // This means any HTML **within an HTML block** that might otherwise be recognised
+
         // as a start condition will be ignored by the parser and passed through as-is,
+
         // without changing the parser's state.
+
         //
+
         // For instance, `<pre>` within a HTML block started by `<table>` will not affect
+
         // the parser state; as the HTML block was started in by start condition 6, it
+
         // will end at any blank line. This can be surprising:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3387,17 +4235,29 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<table><tr><td>\n<pre>\n**Hello**,\n\n_world_.\n</pre>\n</td></tr></table>", "<table><tr><td>\n<pre>\n**Hello**,\n<p><em>world</em>.\n</pre></p>\n</td></tr></table>", "");
         }
     }
+
         // In this case, the HTML block is terminated by the newline — the `**hello**`
+
         // text remains verbatim — and regular parsing resumes, with a paragraph,
+
         // emphasised `world` and inline and block HTML following.
+
         //
+
         // All types of [HTML blocks] except type 7 may interrupt
+
         // a paragraph.  Blocks of type 7 may not interrupt a paragraph.
+
         // (This restriction is intended to prevent unwanted interpretation
+
         // of long tags inside a wrapped paragraph as starting HTML blocks.)
+
         //
+
         // Some simple examples follow.  Here are some basic HTML blocks
+
         // of type 6:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3432,6 +4292,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.", "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n<p>okay.</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3455,7 +4316,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec(" <div>\n  *hello*\n         <foo><a>", " <div>\n  *hello*\n         <foo><a>", "");
         }
     }
+
         // A block can also start with a closing tag:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3477,7 +4340,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("</div>\n*foo*", "</div>\n*foo*", "");
         }
     }
+
         // Here we have two HTML blocks with a Markdown paragraph between them:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3503,8 +4368,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<DIV CLASS=\"foo\">\n\n*Markdown*\n\n</DIV>", "<DIV CLASS=\"foo\">\n<p><em>Markdown</em></p>\n</DIV>", "");
         }
     }
+
         // The tag on the first line can be partial, as long
+
         // as it is split where there would be whitespace:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3528,6 +4396,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<div id=\"foo\"\n  class=\"bar\">\n</div>", "<div id=\"foo\"\n  class=\"bar\">\n</div>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3551,7 +4420,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<div id=\"foo\" class=\"bar\n  baz\">\n</div>", "<div id=\"foo\" class=\"bar\n  baz\">\n</div>", "");
         }
     }
+
         // An open tag need not be closed:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3576,8 +4447,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<div>\n*foo*\n\n*bar*", "<div>\n*foo*\n<p><em>bar</em></p>", "");
         }
     }
+
         // A partial tag need not even be completed (garbage
+
         // in, garbage out):
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3599,6 +4473,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<div id=\"foo\"\n*hi*", "<div id=\"foo\"\n*hi*", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3620,8 +4495,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<div class\nfoo", "<div class\nfoo", "");
         }
     }
+
         // The initial tag doesn't even need to be a valid
+
         // tag, as long as it starts like one:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3643,8 +4521,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<div *???-&&&-<---\n*foo*", "<div *???-&&&-<---\n*foo*", "");
         }
     }
+
         // In type 6 blocks, the initial tag need not be on a line by
+
         // itself:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3664,6 +4545,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<div><a href=\"bar\">*foo*</a></div>", "<div><a href=\"bar\">*foo*</a></div>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3687,11 +4569,17 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<table><tr><td>\nfoo\n</td></tr></table>", "<table><tr><td>\nfoo\n</td></tr></table>", "");
         }
     }
+
         // Everything until the next blank line or end of document
+
         // gets included in the HTML block.  So, in the following
+
         // example, what looks like a Markdown code block
+
         // is actually part of the HTML block, which continues until a blank
+
         // line or the end of the document is reached:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3717,9 +4605,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<div></div>\n``` c\nint x = 33;\n```", "<div></div>\n``` c\nint x = 33;\n```", "");
         }
     }
+
         // To start an [HTML block] with a tag that is *not* in the
+
         // list of block-level tags in (6), you must put the tag by
+
         // itself on the first line (and it must be complete):
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3743,7 +4635,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<a href=\"foo\">\n*bar*\n</a>", "<a href=\"foo\">\n*bar*\n</a>", "");
         }
     }
+
         // In type 7 blocks, the [tag name] can be anything:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3767,6 +4661,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<Warning>\n*bar*\n</Warning>", "<Warning>\n*bar*\n</Warning>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3790,6 +4685,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<i class=\"foo\">\n*bar*\n</i>", "<i class=\"foo\">\n*bar*\n</i>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3811,11 +4707,17 @@ namespace Markdig.Tests
 			TestParser.TestSpec("</ins>\n*bar*", "</ins>\n*bar*", "");
         }
     }
+
         // These rules are designed to allow us to work with tags that
+
         // can function as either block-level or inline-level tags.
+
         // The `<del>` tag is a nice example.  We can surround content with
+
         // `<del>` tags in three different ways.  In this case, we get a raw
+
         // HTML block, because the `<del>` tag is on a line by itself:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3839,9 +4741,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<del>\n*foo*\n</del>", "<del>\n*foo*\n</del>", "");
         }
     }
+
         // In this case, we get a raw HTML block that just includes
+
         // the `<del>` tag (because it ends with the following blank
+
         // line).  So the contents get interpreted as CommonMark:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3867,10 +4773,15 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<del>\n\n*foo*\n\n</del>", "<del>\n<p><em>foo</em></p>\n</del>", "");
         }
     }
+
         // Finally, in this case, the `<del>` tags are interpreted
+
         // as [raw HTML] *inside* the CommonMark paragraph.  (Because
+
         // the tag is not on a line by itself, we get inline HTML
+
         // rather than an [HTML block].)
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3890,14 +4801,23 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<del>*foo*</del>", "<p><del><em>foo</em></del></p>", "");
         }
     }
+
         // HTML tags designed to contain literal content
+
         // (`script`, `style`, `pre`), comments, processing instructions,
+
         // and declarations are treated somewhat differently.
+
         // Instead of ending at the first blank line, these blocks
+
         // end at the first line containing a corresponding end tag.
+
         // As a result, these blocks can contain blank lines:
+
         //
+
         // A pre tag (type 1):
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3929,7 +4849,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\nokay", "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\n<p>okay</p>", "");
         }
     }
+
         // A script tag (type 1):
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3959,7 +4881,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\nokay", "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\n<p>okay</p>", "");
         }
     }
+
         // A style tag (type 1):
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -3991,9 +4915,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\nokay", "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\n<p>okay</p>", "");
         }
     }
+
         // If there is no matching end tag, the block will end at the
+
         // end of the document (or the enclosing [block quote][block quotes]
+
         // or [list item][list items]):
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4019,6 +4947,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<style\n  type=\"text/css\">\n\nfoo", "<style\n  type=\"text/css\">\n\nfoo", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4045,6 +4974,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> <div>\n> foo\n\nbar", "<blockquote>\n<div>\nfoo\n</blockquote>\n<p>bar</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4070,7 +5000,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- <div>\n- foo", "<ul>\n<li>\n<div>\n</li>\n<li>foo</li>\n</ul>", "");
         }
     }
+
         // The end tag can occur on the same line as the start tag:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4092,6 +5024,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<style>p{color:red;}</style>\n*foo*", "<style>p{color:red;}</style>\n<p><em>foo</em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4113,8 +5046,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<!-- foo -->*bar*\n*baz*", "<!-- foo -->*bar*\n<p><em>baz</em></p>", "");
         }
     }
+
         // Note that anything on the last line after the
+
         // end tag will be included in the [HTML block]:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4138,7 +5074,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<script>\nfoo\n</script>1. *bar*", "<script>\nfoo\n</script>1. *bar*", "");
         }
     }
+
         // A comment (type 2):
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4166,7 +5104,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<!-- Foo\n\nbar\n   baz -->\nokay", "<!-- Foo\n\nbar\n   baz -->\n<p>okay</p>", "");
         }
     }
+
         // A processing instruction (type 3):
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4196,7 +5136,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<?php\n\n  echo '>';\n\n?>\nokay", "<?php\n\n  echo '>';\n\n?>\n<p>okay</p>", "");
         }
     }
+
         // A declaration (type 4):
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4216,7 +5158,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<!DOCTYPE html>", "<!DOCTYPE html>", "");
         }
     }
+
         // CDATA (type 5):
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4260,7 +5204,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\nokay", "<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\n<p>okay</p>", "");
         }
     }
+
         // The opening tag can be indented 1-3 spaces, but not 4:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4284,6 +5230,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("  <!-- foo -->\n\n    <!-- foo -->", "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4307,8 +5254,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("  <div>\n\n    <div>", "  <div>\n<pre><code>&lt;div&gt;\n</code></pre>", "");
         }
     }
+
         // An HTML block of types 1--6 can interrupt a paragraph, and need not be
+
         // preceded by a blank line.
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4334,8 +5284,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo\n<div>\nbar\n</div>", "<p>Foo</p>\n<div>\nbar\n</div>", "");
         }
     }
+
         // However, a following blank line is needed, except at the end of
+
         // a document, and except for blocks of types 1--5, above:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4361,7 +5314,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<div>\nbar\n</div>\n*foo*", "<div>\nbar\n</div>\n*foo*", "");
         }
     }
+
         // HTML blocks of type 7 cannot interrupt a paragraph:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4385,35 +5340,65 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo\n<a href=\"bar\">\nbaz", "<p>Foo\n<a href=\"bar\">\nbaz</p>", "");
         }
     }
+
         // This rule differs from John Gruber's original Markdown syntax
+
         // specification, which says:
+
         //
+
         // > The only restrictions are that block-level HTML elements —
+
         // > e.g. `<div>`, `<table>`, `<pre>`, `<p>`, etc. — must be separated from
+
         // > surrounding content by blank lines, and the start and end tags of the
+
         // > block should not be indented with tabs or spaces.
+
         //
+
         // In some ways Gruber's rule is more restrictive than the one given
+
         // here:
+
         //
+
         // - It requires that an HTML block be preceded by a blank line.
+
         // - It does not allow the start tag to be indented.
+
         // - It requires a matching end tag, which it also does not allow to
+
         // be indented.
+
         //
+
         // Most Markdown implementations (including some of Gruber's own) do not
+
         // respect all of these restrictions.
+
         //
+
         // There is one respect, however, in which Gruber's rule is more liberal
+
         // than the one given here, since it allows blank lines to occur inside
+
         // an HTML block.  There are two reasons for disallowing them here.
+
         // First, it removes the need to parse balanced tags, which is
+
         // expensive and can require backtracking from the end of the document
+
         // if no matching end tag is found. Second, it provides a very simple
+
         // and flexible way of including Markdown content inside HTML tags:
+
         // simply separate the Markdown from the HTML using blank lines:
+
         //
+
         // Compare:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4439,6 +5424,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<div>\n\n*Emphasized* text.\n\n</div>", "<div>\n<p><em>Emphasized</em> text.</p>\n</div>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4462,16 +5448,27 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<div>\n*Emphasized* text.\n</div>", "<div>\n*Emphasized* text.\n</div>", "");
         }
     }
+
         // Some Markdown implementations have adopted a convention of
+
         // interpreting content inside tags as text if the open tag has
+
         // the attribute `markdown=1`.  The rule given above seems a simpler and
+
         // more elegant way of achieving the same expressive power, which is also
+
         // much simpler to parse.
+
         //
+
         // The main potential drawback is that one can no longer paste HTML
+
         // blocks into Markdown documents with 100% reliability.  However,
+
         // *in most cases* this will work fine, because the blank lines in
+
         // HTML are usually followed by HTML block tags.  For example:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4507,9 +5504,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>", "<table>\n<tr>\n<td>\nHi\n</td>\n</tr>\n</table>", "");
         }
     }
+
         // There are problems, however, if the inner tags are indented
+
         // *and* separated by spaces, as then they will be interpreted as
+
         // an indented code block:
+
     [TestFixture]
     public partial class TestLeafblocksHTMLblocks
     {
@@ -4546,29 +5547,53 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<table>\n\n  <tr>\n\n    <td>\n      Hi\n    </td>\n\n  </tr>\n\n</table>", "<table>\n  <tr>\n<pre><code>&lt;td&gt;\n  Hi\n&lt;/td&gt;\n</code></pre>\n  </tr>\n</table>", "");
         }
     }
+
         // Fortunately, blank lines are usually not necessary and can be
+
         // deleted.  The exception is inside `<pre>` tags, but as described
+
         // above, raw HTML blocks starting with `<pre>` *can* contain blank
+
         // lines.
+
         //
+
         // ## Link reference definitions
+
         //
+
         // A [link reference definition](@)
+
         // consists of a [link label], indented up to three spaces, followed
+
         // by a colon (`:`), optional [whitespace] (including up to one
+
         // [line ending]), a [link destination],
+
         // optional [whitespace] (including up to one
+
         // [line ending]), and an optional [link
+
         // title], which if it is present must be separated
+
         // from the [link destination] by [whitespace].
+
         // No further [non-whitespace characters] may occur on the line.
+
         //
+
         // A [link reference definition]
+
         // does not correspond to a structural element of a document.  Instead, it
+
         // defines a label which can be used in [reference links]
+
         // and reference-style [images] elsewhere in the document.  [Link
+
         // reference definitions] can come either before or after the links that use
+
         // them.
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -4590,6 +5615,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]: /url \"title\"\n\n[foo]", "<p><a href=\"/url\" title=\"title\">foo</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -4613,6 +5639,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("   [foo]: \n      /url  \n           'the title'  \n\n[foo]", "<p><a href=\"/url\" title=\"the title\">foo</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -4634,6 +5661,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[Foo*bar\\]]:my_(url) 'title (with parens)'\n\n[Foo*bar\\]]", "<p><a href=\"my_(url)\" title=\"title (with parens)\">Foo*bar]</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -4657,7 +5685,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[Foo bar]:\n<my%20url>\n'title'\n\n[Foo bar]", "<p><a href=\"my%20url\" title=\"title\">Foo bar</a></p>", "");
         }
     }
+
         // The title may extend over multiple lines:
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -4687,7 +5717,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]", "<p><a href=\"/url\" title=\"\ntitle\nline1\nline2\n\">foo</a></p>", "");
         }
     }
+
         // However, it may not contain a [blank line]:
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -4713,7 +5745,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]: /url 'title\n\nwith blank line'\n\n[foo]", "<p>[foo]: /url 'title</p>\n<p>with blank line'</p>\n<p>[foo]</p>", "");
         }
     }
+
         // The title may be omitted:
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -4736,7 +5770,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]:\n/url\n\n[foo]", "<p><a href=\"/url\">foo</a></p>", "");
         }
     }
+
         // The link destination may not be omitted:
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -4759,8 +5795,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]:\n\n[foo]", "<p>[foo]:</p>\n<p>[foo]</p>", "");
         }
     }
+
         // Both title and destination can contain backslash escapes
+
         // and literal backslashes:
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -4782,7 +5821,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]: /url\\bar\\*baz \"foo\\\"bar\\baz\"\n\n[foo]", "<p><a href=\"/url%5Cbar*baz\" title=\"foo&quot;bar\\baz\">foo</a></p>", "");
         }
     }
+
         // A link can come before its corresponding definition:
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -4804,8 +5845,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]\n\n[foo]: url", "<p><a href=\"url\">foo</a></p>", "");
         }
     }
+
         // If there are several matching definitions, the first one takes
+
         // precedence:
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -4828,8 +5872,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]\n\n[foo]: first\n[foo]: second", "<p><a href=\"first\">foo</a></p>", "");
         }
     }
+
         // As noted in the section on [Links], matching of labels is
+
         // case-insensitive (see [matches]).
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -4851,6 +5898,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[FOO]: /url\n\n[Foo]", "<p><a href=\"/url\">Foo</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -4872,8 +5920,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[ΑΓΩ]: /φου\n\n[αγω]", "<p><a href=\"/%CF%86%CE%BF%CF%85\">αγω</a></p>", "");
         }
     }
+
         // Here is a link reference definition with no corresponding link.
+
         // It contributes nothing to the document.
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -4893,7 +5944,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]: /url", "", "");
         }
     }
+
         // Here is another one:
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -4916,8 +5969,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[\nfoo\n]: /url\nbar", "<p>bar</p>", "");
         }
     }
+
         // This is not a link reference definition, because there are
+
         // [non-whitespace characters] after the title:
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -4937,7 +5993,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]: /url \"title\" ok", "<p>[foo]: /url &quot;title&quot; ok</p>", "");
         }
     }
+
         // This is a link reference definition, but it has no title:
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -4958,8 +6016,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]: /url\n\"title\" ok", "<p>&quot;title&quot; ok</p>", "");
         }
     }
+
         // This is not a link reference definition, because it is indented
+
         // four spaces:
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -4983,8 +6044,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    [foo]: /url \"title\"\n\n[foo]", "<pre><code>[foo]: /url &quot;title&quot;\n</code></pre>\n<p>[foo]</p>", "");
         }
     }
+
         // This is not a link reference definition, because it occurs inside
+
         // a code block:
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -5010,7 +6074,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("```\n[foo]: /url\n```\n\n[foo]", "<pre><code>[foo]: /url\n</code></pre>\n<p>[foo]</p>", "");
         }
     }
+
         // A [link reference definition] cannot interrupt a paragraph.
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -5035,8 +6101,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo\n[bar]: /baz\n\n[bar]", "<p>Foo\n[bar]: /baz</p>\n<p>[bar]</p>", "");
         }
     }
+
         // However, it can directly follow other block elements, such as headings
+
         // and thematic breaks, and it need not be followed by a blank line.
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -5061,8 +6130,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("# [Foo]\n[foo]: /url\n> bar", "<h1><a href=\"/url\">Foo</a></h1>\n<blockquote>\n<p>bar</p>\n</blockquote>", "");
         }
     }
+
         // Several [link reference definitions]
+
         // can occur one after another, without intervening blank lines.
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -5091,10 +6163,15 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]: /foo-url \"foo\"\n[bar]: /bar-url\n  \"bar\"\n[baz]: /baz-url\n\n[foo],\n[bar],\n[baz]", "<p><a href=\"/foo-url\" title=\"foo\">foo</a>,\n<a href=\"/bar-url\" title=\"bar\">bar</a>,\n<a href=\"/baz-url\">baz</a></p>", "");
         }
     }
+
         // [Link reference definitions] can occur
+
         // inside block containers, like lists and block quotations.  They
+
         // affect the entire document, not just the container in which they
+
         // are defined:
+
     [TestFixture]
     public partial class TestLeafblocksLinkreferencedefinitions
     {
@@ -5118,16 +6195,27 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]\n\n> [foo]: /url", "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>", "");
         }
     }
+
         // ## Paragraphs
+
         //
+
         // A sequence of non-blank lines that cannot be interpreted as other
+
         // kinds of blocks forms a [paragraph](@).
+
         // The contents of the paragraph are the result of parsing the
+
         // paragraph's raw content as inlines.  The paragraph's raw content
+
         // is formed by concatenating the lines and removing initial and final
+
         // [whitespace].
+
         //
+
         // A simple example with two paragraphs:
+
     [TestFixture]
     public partial class TestLeafblocksParagraphs
     {
@@ -5150,7 +6238,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("aaa\n\nbbb", "<p>aaa</p>\n<p>bbb</p>", "");
         }
     }
+
         // Paragraphs can contain multiple lines, but no blank lines:
+
     [TestFixture]
     public partial class TestLeafblocksParagraphs
     {
@@ -5177,7 +6267,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("aaa\nbbb\n\nccc\nddd", "<p>aaa\nbbb</p>\n<p>ccc\nddd</p>", "");
         }
     }
+
         // Multiple blank lines between paragraph have no effect:
+
     [TestFixture]
     public partial class TestLeafblocksParagraphs
     {
@@ -5201,7 +6293,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("aaa\n\n\nbbb", "<p>aaa</p>\n<p>bbb</p>", "");
         }
     }
+
         // Leading spaces are skipped:
+
     [TestFixture]
     public partial class TestLeafblocksParagraphs
     {
@@ -5223,8 +6317,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("  aaa\n bbb", "<p>aaa\nbbb</p>", "");
         }
     }
+
         // Lines after the first may be indented any amount, since indented
+
         // code blocks cannot interrupt paragraphs.
+
     [TestFixture]
     public partial class TestLeafblocksParagraphs
     {
@@ -5248,8 +6345,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("aaa\n             bbb\n                                       ccc", "<p>aaa\nbbb\nccc</p>", "");
         }
     }
+
         // However, the first line may be indented at most three spaces,
+
         // or an indented code block will be triggered:
+
     [TestFixture]
     public partial class TestLeafblocksParagraphs
     {
@@ -5271,6 +6371,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("   aaa\nbbb", "<p>aaa\nbbb</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestLeafblocksParagraphs
     {
@@ -5293,9 +6394,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    aaa\nbbb", "<pre><code>aaa\n</code></pre>\n<p>bbb</p>", "");
         }
     }
+
         // Final spaces are stripped before inline parsing, so a paragraph
+
         // that ends with two or more spaces will not end with a [hard line
+
         // break]:
+
     [TestFixture]
     public partial class TestLeafblocksParagraphs
     {
@@ -5317,13 +6422,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("aaa     \nbbb     ", "<p>aaa<br />\nbbb</p>", "");
         }
     }
+
         // ## Blank lines
+
         //
+
         // [Blank lines] between block-level elements are ignored,
+
         // except for the role they play in determining whether a [list]
+
         // is [tight] or [loose].
+
         //
+
         // Blank lines at the beginning and end of the document are also ignored.
+
     [TestFixture]
     public partial class TestLeafblocksBlanklines
     {
@@ -5351,55 +6464,105 @@ namespace Markdig.Tests
 			TestParser.TestSpec("  \n\naaa\n  \n\n# aaa\n\n  ", "<p>aaa</p>\n<h1>aaa</h1>", "");
         }
     }
+
         // # Container blocks
+
         //
+
         // A [container block] is a block that has other
+
         // blocks as its contents.  There are two basic kinds of container blocks:
+
         // [block quotes] and [list items].
+
         // [Lists] are meta-containers for [list items].
+
         //
+
         // We define the syntax for container blocks recursively.  The general
+
         // form of the definition is:
+
         //
+
         // > If X is a sequence of blocks, then the result of
+
         // > transforming X in such-and-such a way is a container of type Y
+
         // > with these blocks as its content.
+
         //
+
         // So, we explain what counts as a block quote or list item by explaining
+
         // how these can be *generated* from their contents. This should suffice
+
         // to define the syntax, although it does not give a recipe for *parsing*
+
         // these constructions.  (A recipe is provided below in the section entitled
+
         // [A parsing strategy](#appendix-a-parsing-strategy).)
+
         //
+
         // ## Block quotes
+
         //
+
         // A [block quote marker](@)
+
         // consists of 0-3 spaces of initial indent, plus (a) the character `>` together
+
         // with a following space, or (b) a single character `>` not followed by a space.
+
         //
+
         // The following rules define [block quotes]:
+
         //
+
         // 1.  **Basic case.**  If a string of lines *Ls* constitute a sequence
+
         // of blocks *Bs*, then the result of prepending a [block quote
+
         // marker] to the beginning of each line in *Ls*
+
         // is a [block quote](#block-quotes) containing *Bs*.
+
         //
+
         // 2.  **Laziness.**  If a string of lines *Ls* constitute a [block
+
         // quote](#block-quotes) with contents *Bs*, then the result of deleting
+
         // the initial [block quote marker] from one or
+
         // more lines in which the next [non-whitespace character] after the [block
+
         // quote marker] is [paragraph continuation
+
         // text] is a block quote with *Bs* as its content.
+
         // [Paragraph continuation text](@) is text
+
         // that will be parsed as part of the content of a paragraph, but does
+
         // not occur at the beginning of the paragraph.
+
         //
+
         // 3.  **Consecutiveness.**  A document cannot contain two [block
+
         // quotes] in a row unless there is a [blank line] between them.
+
         //
+
         // Nothing else counts as a [block quote](#block-quotes).
+
         //
+
         // Here is a simple example:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5425,7 +6588,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> # Foo\n> bar\n> baz", "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>", "");
         }
     }
+
         // The spaces after the `>` characters can be omitted:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5451,7 +6616,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("># Foo\n>bar\n> baz", "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>", "");
         }
     }
+
         // The `>` characters can be indented 1-3 spaces:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5477,7 +6644,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("   > # Foo\n   > bar\n > baz", "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>", "");
         }
     }
+
         // Four spaces gives us a code block:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5502,8 +6671,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    > # Foo\n    > bar\n    > baz", "<pre><code>&gt; # Foo\n&gt; bar\n&gt; baz\n</code></pre>", "");
         }
     }
+
         // The Laziness clause allows us to omit the `>` before
+
         // [paragraph continuation text]:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5529,8 +6701,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> # Foo\n> bar\nbaz", "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>", "");
         }
     }
+
         // A block quote can contain some lazy and some non-lazy
+
         // continuation lines:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5556,16 +6731,27 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> bar\nbaz\n> foo", "<blockquote>\n<p>bar\nbaz\nfoo</p>\n</blockquote>", "");
         }
     }
+
         // Laziness only applies to lines that would have been continuations of
+
         // paragraphs had they been prepended with [block quote markers].
+
         // For example, the `> ` cannot be omitted in the second line of
+
         //
+
         // ``` markdown
+
         // > foo
+
         // > ---
+
         // ```
+
         //
+
         // without changing the meaning:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5589,14 +6775,23 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> foo\n---", "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />", "");
         }
     }
+
         // Similarly, if we omit the `> ` in the second line of
+
         //
+
         // ``` markdown
+
         // > - foo
+
         // > - bar
+
         // ```
+
         //
+
         // then the block quote ends after the first line:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5624,8 +6819,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> - foo\n- bar", "<blockquote>\n<ul>\n<li>foo</li>\n</ul>\n</blockquote>\n<ul>\n<li>bar</li>\n</ul>", "");
         }
     }
+
         // For the same reason, we can't omit the `> ` in front of
+
         // subsequent lines of an indented or fenced code block:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5651,6 +6849,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec(">     foo\n    bar", "<blockquote>\n<pre><code>foo\n</code></pre>\n</blockquote>\n<pre><code>bar\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5676,8 +6875,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> ```\nfoo\n```", "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>", "");
         }
     }
+
         // Note that in the following case, we have a [lazy
+
         // continuation line]:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5701,18 +6903,31 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> foo\n    - bar", "<blockquote>\n<p>foo\n- bar</p>\n</blockquote>", "");
         }
     }
+
         // To see why, note that in
+
         //
+
         // ```markdown
+
         // > foo
+
         // >     - bar
+
         // ```
+
         //
+
         // the `- bar` is indented too far to start a list, and can't
+
         // be an indented code block because indented code blocks cannot
+
         // interrupt paragraphs, so it is [paragraph continuation text].
+
         //
+
         // A block quote can be empty:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5733,6 +6948,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec(">", "<blockquote>\n</blockquote>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5755,7 +6971,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec(">\n>  \n> ", "<blockquote>\n</blockquote>", "");
         }
     }
+
         // A block quote can have initial or final blank lines:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5779,7 +6997,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec(">\n> foo\n>  ", "<blockquote>\n<p>foo</p>\n</blockquote>", "");
         }
     }
+
         // A blank line always separates block quotes:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5806,13 +7026,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> foo\n\n> bar", "<blockquote>\n<p>foo</p>\n</blockquote>\n<blockquote>\n<p>bar</p>\n</blockquote>", "");
         }
     }
+
         // (Most current Markdown implementations, including John Gruber's
+
         // original `Markdown.pl`, will parse this example as a single block quote
+
         // with two paragraphs.  But it seems better to allow the author to decide
+
         // whether two block quotes or one are wanted.)
+
         //
+
         // Consecutiveness means that if we put these block quotes together,
+
         // we get a single block quote:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5836,7 +7064,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> foo\n> bar", "<blockquote>\n<p>foo\nbar</p>\n</blockquote>", "");
         }
     }
+
         // To get a block quote with two paragraphs, use:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5861,7 +7091,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> foo\n>\n> bar", "<blockquote>\n<p>foo</p>\n<p>bar</p>\n</blockquote>", "");
         }
     }
+
         // Block quotes can interrupt paragraphs:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5885,8 +7117,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo\n> bar", "<p>foo</p>\n<blockquote>\n<p>bar</p>\n</blockquote>", "");
         }
     }
+
         // In general, blank lines are not needed before or after block
+
         // quotes:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5914,8 +7149,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> aaa\n***\n> bbb", "<blockquote>\n<p>aaa</p>\n</blockquote>\n<hr />\n<blockquote>\n<p>bbb</p>\n</blockquote>", "");
         }
     }
+
         // However, because of laziness, a blank line is needed between
+
         // a block quote and a following paragraph:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5939,6 +7177,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> bar\nbaz", "<blockquote>\n<p>bar\nbaz</p>\n</blockquote>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5963,6 +7202,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> bar\n\nbaz", "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -5987,9 +7227,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> bar\n>\nbaz", "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>", "");
         }
     }
+
         // It is a consequence of the Laziness rule that any number
+
         // of initial `>`s may be omitted on a continuation line of a
+
         // nested block quote:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -6017,6 +7261,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> > > foo\nbar", "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -6046,10 +7291,15 @@ namespace Markdig.Tests
 			TestParser.TestSpec(">>> foo\n> bar\n>>baz", "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>", "");
         }
     }
+
         // When including an indented code block in a block quote,
+
         // remember that the [block quote marker] includes
+
         // both the `>` and a following space.  So *five spaces* are needed after
+
         // the `>`:
+
     [TestFixture]
     public partial class TestContainerblocksBlockquotes
     {
@@ -6077,44 +7327,83 @@ namespace Markdig.Tests
 			TestParser.TestSpec(">     code\n\n>    not code", "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n<blockquote>\n<p>not code</p>\n</blockquote>", "");
         }
     }
+
         // ## List items
+
         //
+
         // A [list marker](@) is a
+
         // [bullet list marker] or an [ordered list marker].
+
         //
+
         // A [bullet list marker](@)
+
         // is a `-`, `+`, or `*` character.
+
         //
+
         // An [ordered list marker](@)
+
         // is a sequence of 1--9 arabic digits (`0-9`), followed by either a
+
         // `.` character or a `)` character.  (The reason for the length
+
         // limit is that with 10 digits we start seeing integer overflows
+
         // in some browsers.)
+
         //
+
         // The following rules define [list items]:
+
         //
+
         // 1.  **Basic case.**  If a sequence of lines *Ls* constitute a sequence of
+
         // blocks *Bs* starting with a [non-whitespace character] and not separated
+
         // from each other by more than one blank line, and *M* is a list
+
         // marker of width *W* followed by 1 ≤ *N* ≤ 4 spaces, then the result
+
         // of prepending *M* and the following spaces to the first line of
+
         // *Ls*, and indenting subsequent lines of *Ls* by *W + N* spaces, is a
+
         // list item with *Bs* as its contents.  The type of the list item
+
         // (bullet or ordered) is determined by the type of its list marker.
+
         // If the list item is ordered, then it is also assigned a start
+
         // number, based on the ordered list marker.
+
         //
+
         // Exceptions:
+
         //
+
         // 1. When the first list item in a [list] interrupts
+
         // a paragraph---that is, when it starts on a line that would
+
         // otherwise count as [paragraph continuation text]---then (a)
+
         // the lines *Ls* must not begin with a blank line, and (b) if
+
         // the list item is ordered, the start number must be 1.
+
         // 2. If any line is a [thematic break][thematic breaks] then
+
         // that line is not a list item.
+
         //
+
         // For example, let *Ls* be the lines
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6145,9 +7434,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.", "<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>", "");
         }
     }
+
         // And let *M* be the marker `1.`, and *N* = 2.  Then rule #1 says
+
         // that the following is an ordered list item with start number 1,
+
         // and the same contents as *Ls*:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6182,16 +7475,27 @@ namespace Markdig.Tests
 			TestParser.TestSpec("1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.", "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>", "");
         }
     }
+
         // The most important thing to notice is that the position of
+
         // the text after the list marker determines how much indentation
+
         // is needed in subsequent blocks in the list item.  If the list
+
         // marker takes up two spaces, and there are three spaces between
+
         // the list marker and the next [non-whitespace character], then blocks
+
         // must be indented five spaces in order to fall under the list
+
         // item.
+
         //
+
         // Here are some examples showing how far content must be indented to be
+
         // put under the list item:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6216,6 +7520,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- one\n\n two", "<ul>\n<li>one</li>\n</ul>\n<p>two</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6242,6 +7547,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- one\n\n  two", "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6267,6 +7573,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec(" -    one\n\n     two", "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6293,13 +7600,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec(" -    one\n\n      two", "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>", "");
         }
     }
+
         // It is tempting to think of this in terms of columns:  the continuation
+
         // blocks must be indented at least to the column of the first
+
         // [non-whitespace character] after the list marker. However, that is not quite right.
+
         // The spaces after the list marker determine how much relative indentation
+
         // is needed.  Which column this indentation reaches will depend on
+
         // how the list item is embedded in other constructions, as shown by
+
         // this example:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6330,14 +7645,23 @@ namespace Markdig.Tests
 			TestParser.TestSpec("   > > 1.  one\n>>\n>>     two", "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>", "");
         }
     }
+
         // Here `two` occurs in the same column as the list marker `1.`,
+
         // but is actually contained in the list item, because there is
+
         // sufficient indentation after the last containing blockquote marker.
+
         //
+
         // The converse is also possible.  In the following example, the word `two`
+
         // occurs far to the right of the initial text of the list item, `one`, but
+
         // it is not considered part of the list item, because it is not indented
+
         // far enough past the blockquote marker:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6366,8 +7690,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec(">>- one\n>>\n  >  > two", "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>", "");
         }
     }
+
         // Note that at least one space is needed between the list marker and
+
         // any following content, so these are not list items:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6390,8 +7717,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("-one\n\n2.two", "<p>-one</p>\n<p>2.two</p>", "");
         }
     }
+
         // A list item may contain blocks that are separated by more than
+
         // one blank line.
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6419,7 +7749,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- foo\n\n\n  bar", "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>", "");
         }
     }
+
         // A list item may contain any kind of block:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6457,8 +7789,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("1.  foo\n\n    ```\n    bar\n    ```\n\n    baz\n\n    > bam", "<ol>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n<blockquote>\n<p>bam</p>\n</blockquote>\n</li>\n</ol>", "");
         }
     }
+
         // A list item that contains an indented code block will preserve
+
         // empty lines within the code block verbatim.
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6492,7 +7827,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- Foo\n\n      bar\n\n\n      baz", "<ul>\n<li>\n<p>Foo</p>\n<pre><code>bar\n\n\nbaz\n</code></pre>\n</li>\n</ul>", "");
         }
     }
+
         // Note that ordered list start numbers must be nine digits or less:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6514,6 +7851,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("123456789. ok", "<ol start=\"123456789\">\n<li>ok</li>\n</ol>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6533,7 +7871,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("1234567890. not ok", "<p>1234567890. not ok</p>", "");
         }
     }
+
         // A start number may begin with 0s:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6555,6 +7895,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("0. ok", "<ol start=\"0\">\n<li>ok</li>\n</ol>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6576,7 +7917,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("003. ok", "<ol start=\"3\">\n<li>ok</li>\n</ol>", "");
         }
     }
+
         // A start number may not be negative:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6596,21 +7939,37 @@ namespace Markdig.Tests
 			TestParser.TestSpec("-1. not ok", "<p>-1. not ok</p>", "");
         }
     }
+
         // 2.  **Item starting with indented code.**  If a sequence of lines *Ls*
+
         // constitute a sequence of blocks *Bs* starting with an indented code
+
         // block and not separated from each other by more than one blank line,
+
         // and *M* is a list marker of width *W* followed by
+
         // one space, then the result of prepending *M* and the following
+
         // space to the first line of *Ls*, and indenting subsequent lines of
+
         // *Ls* by *W + 1* spaces, is a list item with *Bs* as its contents.
+
         // If a line is empty, then it need not be indented.  The type of the
+
         // list item (bullet or ordered) is determined by the type of its list
+
         // marker.  If the list item is ordered, then it is also assigned a
+
         // start number, based on the ordered list marker.
+
         //
+
         // An indented code block will have to be indented four spaces beyond
+
         // the edge of the region where text will be included in the list item.
+
         // In the following case that is 6 spaces:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6638,7 +7997,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- foo\n\n      bar", "<ul>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>", "");
         }
     }
+
         // And in this case it is 11 spaces:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6666,9 +8027,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("  10.  foo\n\n           bar", "<ol start=\"10\">\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ol>", "");
         }
     }
+
         // If the *first* block in the list item is an indented code block,
+
         // then by rule #2, the contents must be indented *one* space after the
+
         // list marker:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6696,6 +8061,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    indented code\n\nparagraph\n\n    more code", "<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6727,8 +8093,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("1.     indented code\n\n   paragraph\n\n       more code", "<ol>\n<li>\n<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>", "");
         }
     }
+
         // Note that an additional space indent is interpreted as space
+
         // inside the code block:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6760,13 +8129,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("1.      indented code\n\n   paragraph\n\n       more code", "<ol>\n<li>\n<pre><code> indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>", "");
         }
     }
+
         // Note that rules #1 and #2 only apply to two cases:  (a) cases
+
         // in which the lines to be included in a list item begin with a
+
         // [non-whitespace character], and (b) cases in which
+
         // they begin with an indented code
+
         // block.  In a case like the following, where the first block begins with
+
         // a three-space indent, the rules do not allow us to form a list item by
+
         // indenting the whole thing and prepending a list marker:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6789,6 +8166,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("   foo\n\nbar", "<p>foo</p>\n<p>bar</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6813,10 +8191,15 @@ namespace Markdig.Tests
 			TestParser.TestSpec("-    foo\n\n  bar", "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>", "");
         }
     }
+
         // This is not a significant restriction, because when a block begins
+
         // with 1-3 spaces indent, the indentation can always be removed without
+
         // a change in interpretation, allowing rule #1 to be applied.  So, in
+
         // the above case:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6843,19 +8226,33 @@ namespace Markdig.Tests
 			TestParser.TestSpec("-  foo\n\n   bar", "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>", "");
         }
     }
+
         // 3.  **Item starting with a blank line.**  If a sequence of lines *Ls*
+
         // starting with a single [blank line] constitute a (possibly empty)
+
         // sequence of blocks *Bs*, not separated from each other by more than
+
         // one blank line, and *M* is a list marker of width *W*,
+
         // then the result of prepending *M* to the first line of *Ls*, and
+
         // indenting subsequent lines of *Ls* by *W + 1* spaces, is a list
+
         // item with *Bs* as its contents.
+
         // If a line is empty, then it need not be indented.  The type of the
+
         // list item (bullet or ordered) is determined by the type of its list
+
         // marker.  If the list item is ordered, then it is also assigned a
+
         // start number, based on the ordered list marker.
+
         //
+
         // Here are some list items that start with a blank line but are not empty:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6892,8 +8289,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("-\n  foo\n-\n  ```\n  bar\n  ```\n-\n      baz", "<ul>\n<li>foo</li>\n<li>\n<pre><code>bar\n</code></pre>\n</li>\n<li>\n<pre><code>baz\n</code></pre>\n</li>\n</ul>", "");
         }
     }
+
         // When the list item starts with a blank line, the number of spaces
+
         // following the list marker doesn't change the required indentation:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6916,9 +8316,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("-   \n  foo", "<ul>\n<li>foo</li>\n</ul>", "");
         }
     }
+
         // A list item can begin with at most one blank line.
+
         // In the following example, `foo` is not part of the list
+
         // item:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6943,7 +8347,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("-\n\n  foo", "<ul>\n<li></li>\n</ul>\n<p>foo</p>", "");
         }
     }
+
         // Here is an empty bullet list item:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6969,7 +8375,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- foo\n-\n- bar", "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>", "");
         }
     }
+
         // It does not matter whether there are spaces following the [list marker]:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -6995,7 +8403,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- foo\n-   \n- bar", "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>", "");
         }
     }
+
         // Here is an empty ordered list item:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -7021,7 +8431,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("1. foo\n2.\n3. bar", "<ol>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ol>", "");
         }
     }
+
         // A list may start or end with an empty list item:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -7043,7 +8455,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*", "<ul>\n<li></li>\n</ul>", "");
         }
     }
+
         // However, an empty list item cannot interrupt a paragraph:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -7070,13 +8484,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo\n*\n\nfoo\n1.", "<p>foo\n*</p>\n<p>foo\n1.</p>", "");
         }
     }
+
         // 4.  **Indentation.**  If a sequence of lines *Ls* constitutes a list item
+
         // according to rule #1, #2, or #3, then the result of indenting each line
+
         // of *Ls* by 1-3 spaces (the same for each line) also constitutes a
+
         // list item with the same contents and attributes.  If a line is
+
         // empty, then it need not be indented.
+
         //
+
         // Indented one space:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -7111,7 +8533,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec(" 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.", "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>", "");
         }
     }
+
         // Indented two spaces:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -7146,7 +8570,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.", "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>", "");
         }
     }
+
         // Indented three spaces:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -7181,7 +8607,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.", "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>", "");
         }
     }
+
         // Four spaces indent gives a code block:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -7212,16 +8640,27 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.", "<pre><code>1.  A paragraph\n    with two lines.\n\n        indented code\n\n    &gt; A block quote.\n</code></pre>", "");
         }
     }
+
         // 5.  **Laziness.**  If a string of lines *Ls* constitute a [list
+
         // item](#list-items) with contents *Bs*, then the result of deleting
+
         // some or all of the indentation from one or more lines in which the
+
         // next [non-whitespace character] after the indentation is
+
         // [paragraph continuation text] is a
+
         // list item with the same contents and attributes.  The unindented
+
         // lines are called
+
         // [lazy continuation line](@)s.
+
         //
+
         // Here is an example with [lazy continuation lines]:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -7256,7 +8695,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.", "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>", "");
         }
     }
+
         // Indentation can be partially deleted:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -7280,7 +8721,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("  1.  A paragraph\n    with two lines.", "<ol>\n<li>A paragraph\nwith two lines.</li>\n</ol>", "");
         }
     }
+
         // These examples show how laziness can work in nested structures:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -7310,6 +8753,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> 1. > Blockquote\ncontinued here.", "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -7339,14 +8783,23 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> 1. > Blockquote\n> continued here.", "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>", "");
         }
     }
+
         // 6.  **That's all.** Nothing that is not counted as a list item by rules
+
         // #1--5 counts as a [list item](#list-items).
+
         //
+
         // The rules for sublists follow from the general rules above.  A sublist
+
         // must be indented the same number of spaces a paragraph would need to be
+
         // in order to be included in the list item.
+
         //
+
         // So, in this case we need two spaces indent:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -7383,7 +8836,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- foo\n  - bar\n    - baz\n      - boo", "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz\n<ul>\n<li>boo</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>", "");
         }
     }
+
         // One is not enough:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -7411,7 +8866,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- foo\n - bar\n  - baz\n   - boo", "<ul>\n<li>foo</li>\n<li>bar</li>\n<li>baz</li>\n<li>boo</li>\n</ul>", "");
         }
     }
+
         // Here we need four, because the list marker is wider:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -7438,7 +8895,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("10) foo\n    - bar", "<ol start=\"10\">\n<li>foo\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>", "");
         }
     }
+
         // Three is not enough:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -7464,7 +8923,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("10) foo\n   - bar", "<ol start=\"10\">\n<li>foo</li>\n</ol>\n<ul>\n<li>bar</li>\n</ul>", "");
         }
     }
+
         // A list may be the first block in a list item:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -7490,6 +8951,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- - foo", "<ul>\n<li>\n<ul>\n<li>foo</li>\n</ul>\n</li>\n</ul>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -7519,7 +8981,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("1. - 2. foo", "<ol>\n<li>\n<ul>\n<li>\n<ol start=\"2\">\n<li>foo</li>\n</ol>\n</li>\n</ul>\n</li>\n</ol>", "");
         }
     }
+
         // A list item can contain a heading:
+
     [TestFixture]
     public partial class TestContainerblocksListitems
     {
@@ -7549,224 +9013,443 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- # Foo\n- Bar\n  ---\n  baz", "<ul>\n<li>\n<h1>Foo</h1>\n</li>\n<li>\n<h2>Bar</h2>\nbaz</li>\n</ul>", "");
         }
     }
+
         // ### Motivation
+
         //
+
         // John Gruber's Markdown spec says the following about list items:
+
         //
+
         // 1. "List markers typically start at the left margin, but may be indented
+
         // by up to three spaces. List markers must be followed by one or more
+
         // spaces or a tab."
+
         //
+
         // 2. "To make lists look nice, you can wrap items with hanging indents....
+
         // But if you don't want to, you don't have to."
+
         //
+
         // 3. "List items may consist of multiple paragraphs. Each subsequent
+
         // paragraph in a list item must be indented by either 4 spaces or one
+
         // tab."
+
         //
+
         // 4. "It looks nice if you indent every line of the subsequent paragraphs,
+
         // but here again, Markdown will allow you to be lazy."
+
         //
+
         // 5. "To put a blockquote within a list item, the blockquote's `>`
+
         // delimiters need to be indented."
+
         //
+
         // 6. "To put a code block within a list item, the code block needs to be
+
         // indented twice — 8 spaces or two tabs."
+
         //
+
         // These rules specify that a paragraph under a list item must be indented
+
         // four spaces (presumably, from the left margin, rather than the start of
+
         // the list marker, but this is not said), and that code under a list item
+
         // must be indented eight spaces instead of the usual four.  They also say
+
         // that a block quote must be indented, but not by how much; however, the
+
         // example given has four spaces indentation.  Although nothing is said
+
         // about other kinds of block-level content, it is certainly reasonable to
+
         // infer that *all* block elements under a list item, including other
+
         // lists, must be indented four spaces.  This principle has been called the
+
         // *four-space rule*.
+
         //
+
         // The four-space rule is clear and principled, and if the reference
+
         // implementation `Markdown.pl` had followed it, it probably would have
+
         // become the standard.  However, `Markdown.pl` allowed paragraphs and
+
         // sublists to start with only two spaces indentation, at least on the
+
         // outer level.  Worse, its behavior was inconsistent: a sublist of an
+
         // outer-level list needed two spaces indentation, but a sublist of this
+
         // sublist needed three spaces.  It is not surprising, then, that different
+
         // implementations of Markdown have developed very different rules for
+
         // determining what comes under a list item.  (Pandoc and python-Markdown,
+
         // for example, stuck with Gruber's syntax description and the four-space
+
         // rule, while discount, redcarpet, marked, PHP Markdown, and others
+
         // followed `Markdown.pl`'s behavior more closely.)
+
         //
+
         // Unfortunately, given the divergences between implementations, there
+
         // is no way to give a spec for list items that will be guaranteed not
+
         // to break any existing documents.  However, the spec given here should
+
         // correctly handle lists formatted with either the four-space rule or
+
         // the more forgiving `Markdown.pl` behavior, provided they are laid out
+
         // in a way that is natural for a human to read.
+
         //
+
         // The strategy here is to let the width and indentation of the list marker
+
         // determine the indentation necessary for blocks to fall under the list
+
         // item, rather than having a fixed and arbitrary number.  The writer can
+
         // think of the body of the list item as a unit which gets indented to the
+
         // right enough to fit the list marker (and any indentation on the list
+
         // marker).  (The laziness rule, #5, then allows continuation lines to be
+
         // unindented if needed.)
+
         //
+
         // This rule is superior, we claim, to any rule requiring a fixed level of
+
         // indentation from the margin.  The four-space rule is clear but
+
         // unnatural. It is quite unintuitive that
+
         //
+
         // ``` markdown
+
         // - foo
+
         //
+
         // bar
+
         //
+
         // - baz
+
         // ```
+
         //
+
         // should be parsed as two lists with an intervening paragraph,
+
         //
+
         // ``` html
+
         // <ul>
+
         // <li>foo</li>
+
         // </ul>
+
         // <p>bar</p>
+
         // <ul>
+
         // <li>baz</li>
+
         // </ul>
+
         // ```
+
         //
+
         // as the four-space rule demands, rather than a single list,
+
         //
+
         // ``` html
+
         // <ul>
+
         // <li>
+
         // <p>foo</p>
+
         // <p>bar</p>
+
         // <ul>
+
         // <li>baz</li>
+
         // </ul>
+
         // </li>
+
         // </ul>
+
         // ```
+
         //
+
         // The choice of four spaces is arbitrary.  It can be learned, but it is
+
         // not likely to be guessed, and it trips up beginners regularly.
+
         //
+
         // Would it help to adopt a two-space rule?  The problem is that such
+
         // a rule, together with the rule allowing 1--3 spaces indentation of the
+
         // initial list marker, allows text that is indented *less than* the
+
         // original list marker to be included in the list item. For example,
+
         // `Markdown.pl` parses
+
         //
+
         // ``` markdown
+
         // - one
+
         //
+
         // two
+
         // ```
+
         //
+
         // as a single list item, with `two` a continuation paragraph:
+
         //
+
         // ``` html
+
         // <ul>
+
         // <li>
+
         // <p>one</p>
+
         // <p>two</p>
+
         // </li>
+
         // </ul>
+
         // ```
+
         //
+
         // and similarly
+
         //
+
         // ``` markdown
+
         // >   - one
+
         // >
+
         // >  two
+
         // ```
+
         //
+
         // as
+
         //
+
         // ``` html
+
         // <blockquote>
+
         // <ul>
+
         // <li>
+
         // <p>one</p>
+
         // <p>two</p>
+
         // </li>
+
         // </ul>
+
         // </blockquote>
+
         // ```
+
         //
+
         // This is extremely unintuitive.
+
         //
+
         // Rather than requiring a fixed indent from the margin, we could require
+
         // a fixed indent (say, two spaces, or even one space) from the list marker (which
+
         // may itself be indented).  This proposal would remove the last anomaly
+
         // discussed.  Unlike the spec presented above, it would count the following
+
         // as a list item with a subparagraph, even though the paragraph `bar`
+
         // is not indented as far as the first paragraph `foo`:
+
         //
+
         // ``` markdown
+
         // 10. foo
+
         //
+
         // bar
+
         // ```
+
         //
+
         // Arguably this text does read like a list item with `bar` as a subparagraph,
+
         // which may count in favor of the proposal.  However, on this proposal indented
+
         // code would have to be indented six spaces after the list marker.  And this
+
         // would break a lot of existing Markdown, which has the pattern:
+
         //
+
         // ``` markdown
+
         // 1.  foo
+
         //
+
         // indented code
+
         // ```
+
         //
+
         // where the code is indented eight spaces.  The spec above, by contrast, will
+
         // parse this text as expected, since the code block's indentation is measured
+
         // from the beginning of `foo`.
+
         //
+
         // The one case that needs special treatment is a list item that *starts*
+
         // with indented code.  How much indentation is required in that case, since
+
         // we don't have a "first paragraph" to measure from?  Rule #2 simply stipulates
+
         // that in such cases, we require one space indentation from the list marker
+
         // (and then the normal four spaces for the indented code).  This will match the
+
         // four-space rule in cases where the list marker plus its initial indentation
+
         // takes four spaces (a common case), but diverge in other cases.
+
         //
+
         // ## Lists
+
         //
+
         // A [list](@) is a sequence of one or more
+
         // list items [of the same type].  The list items
+
         // may be separated by any number of blank lines.
+
         //
+
         // Two list items are [of the same type](@)
+
         // if they begin with a [list marker] of the same type.
+
         // Two list markers are of the
+
         // same type if (a) they are bullet list markers using the same character
+
         // (`-`, `+`, or `*`) or (b) they are ordered list numbers with the same
+
         // delimiter (either `.` or `)`).
+
         //
+
         // A list is an [ordered list](@)
+
         // if its constituent list items begin with
+
         // [ordered list markers], and a
+
         // [bullet list](@) if its constituent list
+
         // items begin with [bullet list markers].
+
         //
+
         // The [start number](@)
+
         // of an [ordered list] is determined by the list number of
+
         // its initial list item.  The numbers of subsequent list items are
+
         // disregarded.
+
         //
+
         // A list is [loose](@) if any of its constituent
+
         // list items are separated by blank lines, or if any of its constituent
+
         // list items directly contain two block-level elements with a blank line
+
         // between them.  Otherwise a list is [tight](@).
+
         // (The difference in HTML output is that paragraphs in a loose list are
+
         // wrapped in `<p>` tags, while paragraphs in a tight list are not.)
+
         //
+
         // Changing the bullet or ordered list delimiter starts a new list:
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -7794,6 +9477,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- foo\n- bar\n+ baz", "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -7821,9 +9505,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("1. foo\n2. bar\n3) baz", "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>\n<ol start=\"3\">\n<li>baz</li>\n</ol>", "");
         }
     }
+
         // In CommonMark, a list can interrupt a paragraph. That is,
+
         // no blank line is needed to separate a paragraph from a following
+
         // list:
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -7849,70 +9537,135 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo\n- bar\n- baz", "<p>Foo</p>\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>", "");
         }
     }
+
         // `Markdown.pl` does not allow this, through fear of triggering a list
+
         // via a numeral in a hard-wrapped line:
+
         //
+
         // ``` markdown
+
         // The number of windows in my house is
+
         // 14.  The number of doors is 6.
+
         // ```
+
         //
+
         // Oddly, though, `Markdown.pl` *does* allow a blockquote to
+
         // interrupt a paragraph, even though the same considerations might
+
         // apply.
+
         //
+
         // In CommonMark, we do allow lists to interrupt paragraphs, for
+
         // two reasons.  First, it is natural and not uncommon for people
+
         // to start lists without blank lines:
+
         //
+
         // ``` markdown
+
         // I need to buy
+
         // - new shoes
+
         // - a coat
+
         // - a plane ticket
+
         // ```
+
         //
+
         // Second, we are attracted to a
+
         //
+
         // > [principle of uniformity](@):
+
         // > if a chunk of text has a certain
+
         // > meaning, it will continue to have the same meaning when put into a
+
         // > container block (such as a list item or blockquote).
+
         //
+
         // (Indeed, the spec for [list items] and [block quotes] presupposes
+
         // this principle.) This principle implies that if
+
         //
+
         // ``` markdown
+
         // * I need to buy
+
         // - new shoes
+
         // - a coat
+
         // - a plane ticket
+
         // ```
+
         //
+
         // is a list item containing a paragraph followed by a nested sublist,
+
         // as all Markdown implementations agree it is (though the paragraph
+
         // may be rendered without `<p>` tags, since the list is "tight"),
+
         // then
+
         //
+
         // ``` markdown
+
         // I need to buy
+
         // - new shoes
+
         // - a coat
+
         // - a plane ticket
+
         // ```
+
         //
+
         // by itself should be a paragraph followed by a nested sublist.
+
         //
+
         // Since it is well established Markdown practice to allow lists to
+
         // interrupt paragraphs inside list items, the [principle of
+
         // uniformity] requires us to allow this outside list items as
+
         // well.  ([reStructuredText](http://docutils.sourceforge.net/rst.html)
+
         // takes a different approach, requiring blank lines before lists
+
         // even inside other list items.)
+
         //
+
         // In order to solve of unwanted lists in paragraphs with
+
         // hard-wrapped numerals, we allow only lists starting with `1` to
+
         // interrupt paragraphs.  Thus,
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -7934,7 +9687,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("The number of windows in my house is\n14.  The number of doors is 6.", "<p>The number of windows in my house is\n14.  The number of doors is 6.</p>", "");
         }
     }
+
         // We may still get an unintended result in cases like
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -7958,9 +9713,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("The number of windows in my house is\n1.  The number of doors is 6.", "<p>The number of windows in my house is</p>\n<ol>\n<li>The number of doors is 6.</li>\n</ol>", "");
         }
     }
+
         // but this rule should prevent most spurious list captures.
+
         //
+
         // There can be any number of blank lines between items:
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -7995,6 +9754,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- foo\n\n- bar\n\n\n- baz", "<ul>\n<li>\n<p>foo</p>\n</li>\n<li>\n<p>bar</p>\n</li>\n<li>\n<p>baz</p>\n</li>\n</ul>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -8032,10 +9792,15 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- foo\n  - bar\n    - baz\n\n\n      bim", "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>\n<p>baz</p>\n<p>bim</p>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>", "");
         }
     }
+
         // To separate consecutive lists of the same type, or to separate a
+
         // list from an indented code block that would otherwise be parsed
+
         // as a subparagraph of the final list item, you can insert a blank HTML
+
         // comment:
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -8069,6 +9834,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- foo\n- bar\n\n<!-- -->\n\n- baz\n- bim", "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<!-- -->\n<ul>\n<li>baz</li>\n<li>bim</li>\n</ul>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -8107,10 +9873,15 @@ namespace Markdig.Tests
 			TestParser.TestSpec("-   foo\n\n    notcode\n\n-   foo\n\n<!-- -->\n\n    code", "<ul>\n<li>\n<p>foo</p>\n<p>notcode</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<!-- -->\n<pre><code>code\n</code></pre>", "");
         }
     }
+
         // List items need not be indented to the same level.  The following
+
         // list items will be treated as items at the same list level,
+
         // since none is indented enough to belong to the previous list
+
         // item:
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -8148,6 +9919,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- a\n - b\n  - c\n   - d\n    - e\n   - f\n  - g\n - h\n- i", "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n<li>h</li>\n<li>i</li>\n</ul>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -8181,8 +9953,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("1. a\n\n  2. b\n\n    3. c", "<ol>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ol>", "");
         }
     }
+
         // This is a loose list, because there is a blank line between
+
         // two of the list items:
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -8215,7 +9990,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- a\n- b\n\n- c", "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ul>", "");
         }
     }
+
         // So is this, with a empty second item:
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -8246,9 +10023,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("* a\n*\n\n* c", "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>", "");
         }
     }
+
         // These are loose lists, even though there is no space between the items,
+
         // because one of the items directly contains two block-level elements
+
         // with a blank line between them:
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -8283,6 +10064,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- a\n- b\n\n  c\n- d", "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -8316,7 +10098,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- a\n- b\n\n  [ref]: /url\n- d", "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>", "");
         }
     }
+
         // This is a tight list, because the blank lines are in a code block:
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -8351,9 +10135,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- a\n- ```\n  b\n\n\n  ```\n- c", "<ul>\n<li>a</li>\n<li>\n<pre><code>b\n\n\n</code></pre>\n</li>\n<li>c</li>\n</ul>", "");
         }
     }
+
         // This is a tight list, because the blank line is between two
+
         // paragraphs of a sublist.  So the sublist is loose while
+
         // the outer list is tight:
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -8387,8 +10175,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- a\n  - b\n\n    c\n- d", "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>", "");
         }
     }
+
         // This is a tight list, because the blank line is inside the
+
         // block quote:
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -8418,8 +10209,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("* a\n  > b\n  >\n* c", "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>", "");
         }
     }
+
         // This list is tight, because the consecutive block elements
+
         // are not separated by blank lines:
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -8453,7 +10247,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- a\n  > b\n  ```\n  c\n  ```\n- d", "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>", "");
         }
     }
+
         // A single-paragraph list is tight:
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -8475,6 +10271,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- a", "<ul>\n<li>a</li>\n</ul>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -8501,8 +10298,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- a\n  - b", "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>", "");
         }
     }
+
         // This list is loose, because of the blank line between the
+
         // two block elements in the list item:
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -8532,7 +10332,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("1. ```\n   foo\n   ```\n\n   bar", "<ol>\n<li>\n<pre><code>foo\n</code></pre>\n<p>bar</p>\n</li>\n</ol>", "");
         }
     }
+
         // Here the outer list is loose, the inner list tight:
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -8563,6 +10365,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("* foo\n  * bar\n\n  baz", "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>", "");
         }
     }
+
     [TestFixture]
     public partial class TestContainerblocksLists
     {
@@ -8603,11 +10406,17 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- a\n  - b\n  - c\n\n- d\n  - e\n  - f", "<ul>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n<li>c</li>\n</ul>\n</li>\n<li>\n<p>d</p>\n<ul>\n<li>e</li>\n<li>f</li>\n</ul>\n</li>\n</ul>", "");
         }
     }
+
         // # Inlines
+
         //
+
         // Inlines are parsed sequentially from the beginning of the character
+
         // stream to the end (left to right, in left-to-right languages).
+
         // Thus, for example, in
+
     [TestFixture]
     public partial class TestInlines
     {
@@ -8627,12 +10436,19 @@ namespace Markdig.Tests
 			TestParser.TestSpec("`hi`lo`", "<p><code>hi</code>lo`</p>", "");
         }
     }
+
         // `hi` is parsed as code, leaving the backtick at the end as a literal
+
         // backtick.
+
         //
+
         // ## Backslash escapes
+
         //
+
         // Any ASCII punctuation character may be backslash-escaped:
+
     [TestFixture]
     public partial class TestInlinesBackslashescapes
     {
@@ -8652,8 +10468,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~", "<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>", "");
         }
     }
+
         // Backslashes before other characters are treated as literal
+
         // backslashes:
+
     [TestFixture]
     public partial class TestInlinesBackslashescapes
     {
@@ -8673,8 +10492,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("\\\t\\A\\a\\ \\3\\φ\\«", "<p>\\\t\\A\\a\\ \\3\\φ\\«</p>", "");
         }
     }
+
         // Escaped characters are treated as regular characters and do
+
         // not have their usual Markdown meanings:
+
     [TestFixture]
     public partial class TestInlinesBackslashescapes
     {
@@ -8708,7 +10530,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a heading\n\\[foo]: /url \"not a reference\"", "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a heading\n[foo]: /url &quot;not a reference&quot;</p>", "");
         }
     }
+
         // If a backslash is itself escaped, the following character is not:
+
     [TestFixture]
     public partial class TestInlinesBackslashescapes
     {
@@ -8728,7 +10552,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("\\\\*emphasis*", "<p>\\<em>emphasis</em></p>", "");
         }
     }
+
         // A backslash at the end of the line is a [hard line break]:
+
     [TestFixture]
     public partial class TestInlinesBackslashescapes
     {
@@ -8750,8 +10576,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo\\\nbar", "<p>foo<br />\nbar</p>", "");
         }
     }
+
         // Backslash escapes do not work in code blocks, code spans, autolinks, or
+
         // raw HTML:
+
     [TestFixture]
     public partial class TestInlinesBackslashescapes
     {
@@ -8771,6 +10600,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("`` \\[\\` ``", "<p><code>\\[\\`</code></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesBackslashescapes
     {
@@ -8791,6 +10621,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    \\[\\]", "<pre><code>\\[\\]\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesBackslashescapes
     {
@@ -8813,6 +10644,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("~~~\n\\[\\]\n~~~", "<pre><code>\\[\\]\n</code></pre>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesBackslashescapes
     {
@@ -8832,6 +10664,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<http://example.com?find=\\*>", "<p><a href=\"http://example.com?find=%5C*\">http://example.com?find=\\*</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesBackslashescapes
     {
@@ -8851,8 +10684,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<a href=\"/bar\\/)\">", "<a href=\"/bar\\/)\">", "");
         }
     }
+
         // But they work in all other contexts, including URLs and link titles,
+
         // link references, and [info strings] in [fenced code blocks]:
+
     [TestFixture]
     public partial class TestInlinesBackslashescapes
     {
@@ -8872,6 +10708,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo](/bar\\* \"ti\\*tle\")", "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesBackslashescapes
     {
@@ -8893,6 +10730,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"", "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesBackslashescapes
     {
@@ -8915,21 +10753,37 @@ namespace Markdig.Tests
 			TestParser.TestSpec("``` foo\\+bar\nfoo\n```", "<pre><code class=\"language-foo+bar\">foo\n</code></pre>", "");
         }
     }
+
         // ## Entity and numeric character references
+
         //
+
         // All valid HTML entity references and numeric character
+
         // references, except those occuring in code blocks and code spans,
+
         // are recognized as such and treated as equivalent to the
+
         // corresponding Unicode characters.  Conforming CommonMark parsers
+
         // need not store information about whether a particular character
+
         // was represented in the source using a Unicode character or
+
         // an entity reference.
+
         //
+
         // [Entity references](@) consist of `&` + any of the valid
+
         // HTML5 entity names + `;`. The
+
         // document <https://html.spec.whatwg.org/multipage/entities.json>
+
         // is used as an authoritative source for the valid entity
+
         // references and their corresponding code points.
+
     [TestFixture]
     public partial class TestInlinesEntityandnumericcharacterreferences
     {
@@ -8953,13 +10807,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("&nbsp; &amp; &copy; &AElig; &Dcaron;\n&frac34; &HilbertSpace; &DifferentialD;\n&ClockwiseContourIntegral; &ngE;", "<p>  &amp; © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸</p>", "");
         }
     }
+
         // [Decimal numeric character
+
         // references](@)
+
         // consist of `&#` + a string of 1--8 arabic digits + `;`. A
+
         // numeric character reference is parsed as the corresponding
+
         // Unicode character. Invalid Unicode code points will be replaced by
+
         // the REPLACEMENT CHARACTER (`U+FFFD`).  For security reasons,
+
         // the code point `U+0000` will also be replaced by `U+FFFD`.
+
     [TestFixture]
     public partial class TestInlinesEntityandnumericcharacterreferences
     {
@@ -8979,11 +10841,17 @@ namespace Markdig.Tests
 			TestParser.TestSpec("&#35; &#1234; &#992; &#98765432; &#0;", "<p># Ӓ Ϡ � �</p>", "");
         }
     }
+
         // [Hexadecimal numeric character
+
         // references](@) consist of `&#` +
+
         // either `X` or `x` + a string of 1-8 hexadecimal digits + `;`.
+
         // They too are parsed as the corresponding Unicode character (this
+
         // time specified with a hexadecimal numeral instead of decimal).
+
     [TestFixture]
     public partial class TestInlinesEntityandnumericcharacterreferences
     {
@@ -9003,7 +10871,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("&#X22; &#XD06; &#xcab;", "<p>&quot; ആ ಫ</p>", "");
         }
     }
+
         // Here are some nonentities:
+
     [TestFixture]
     public partial class TestInlinesEntityandnumericcharacterreferences
     {
@@ -9025,9 +10895,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("&nbsp &x; &#; &#x;\n&ThisIsNotDefined; &hi?;", "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x;\n&amp;ThisIsNotDefined; &amp;hi?;</p>", "");
         }
     }
+
         // Although HTML5 does accept some entity references
+
         // without a trailing semicolon (such as `&copy`), these are not
+
         // recognized here, because it makes the grammar too ambiguous:
+
     [TestFixture]
     public partial class TestInlinesEntityandnumericcharacterreferences
     {
@@ -9047,8 +10921,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("&copy", "<p>&amp;copy</p>", "");
         }
     }
+
         // Strings that are not on the list of HTML5 named entities are not
+
         // recognized as entity references either:
+
     [TestFixture]
     public partial class TestInlinesEntityandnumericcharacterreferences
     {
@@ -9068,9 +10945,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("&MadeUpEntity;", "<p>&amp;MadeUpEntity;</p>", "");
         }
     }
+
         // Entity and numeric character references are recognized in any
+
         // context besides code spans or code blocks, including
+
         // URLs, [link titles], and [fenced code block][] [info strings]:
+
     [TestFixture]
     public partial class TestInlinesEntityandnumericcharacterreferences
     {
@@ -9090,6 +10971,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<a href=\"&ouml;&ouml;.html\">", "<a href=\"&ouml;&ouml;.html\">", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEntityandnumericcharacterreferences
     {
@@ -9109,6 +10991,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")", "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEntityandnumericcharacterreferences
     {
@@ -9130,6 +11013,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"", "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEntityandnumericcharacterreferences
     {
@@ -9152,8 +11036,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("``` f&ouml;&ouml;\nfoo\n```", "<pre><code class=\"language-föö\">foo\n</code></pre>", "");
         }
     }
+
         // Entity and numeric character references are treated as literal
+
         // text in code spans and code blocks:
+
     [TestFixture]
     public partial class TestInlinesEntityandnumericcharacterreferences
     {
@@ -9173,6 +11060,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("`f&ouml;&ouml;`", "<p><code>f&amp;ouml;&amp;ouml;</code></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEntityandnumericcharacterreferences
     {
@@ -9193,19 +11081,33 @@ namespace Markdig.Tests
 			TestParser.TestSpec("    f&ouml;f&ouml;", "<pre><code>f&amp;ouml;f&amp;ouml;\n</code></pre>", "");
         }
     }
+
         // ## Code spans
+
         //
+
         // A [backtick string](@)
+
         // is a string of one or more backtick characters (`` ` ``) that is neither
+
         // preceded nor followed by a backtick.
+
         //
+
         // A [code span](@) begins with a backtick string and ends with
+
         // a backtick string of equal length.  The contents of the code span are
+
         // the characters between the two backtick strings, with leading and
+
         // trailing spaces and [line endings] removed, and
+
         // [whitespace] collapsed to single spaces.
+
         //
+
         // This is a simple code span:
+
     [TestFixture]
     public partial class TestInlinesCodespans
     {
@@ -9225,8 +11127,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("`foo`", "<p><code>foo</code></p>", "");
         }
     }
+
         // Here two backticks are used, because the code contains a backtick.
+
         // This example also illustrates stripping of leading and trailing spaces:
+
     [TestFixture]
     public partial class TestInlinesCodespans
     {
@@ -9246,8 +11151,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("`` foo ` bar  ``", "<p><code>foo ` bar</code></p>", "");
         }
     }
+
         // This example shows the motivation for stripping leading and trailing
+
         // spaces:
+
     [TestFixture]
     public partial class TestInlinesCodespans
     {
@@ -9267,7 +11175,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("` `` `", "<p><code>``</code></p>", "");
         }
     }
+
         // [Line endings] are treated like spaces:
+
     [TestFixture]
     public partial class TestInlinesCodespans
     {
@@ -9289,8 +11199,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("``\nfoo\n``", "<p><code>foo</code></p>", "");
         }
     }
+
         // Interior spaces and [line endings] are collapsed into
+
         // single spaces, just as they would be by a browser:
+
     [TestFixture]
     public partial class TestInlinesCodespans
     {
@@ -9311,8 +11224,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("`foo   bar\n  baz`", "<p><code>foo bar baz</code></p>", "");
         }
     }
+
         // Not all [Unicode whitespace] (for instance, non-breaking space) is
+
         // collapsed, however:
+
     [TestFixture]
     public partial class TestInlinesCodespans
     {
@@ -9332,18 +11248,31 @@ namespace Markdig.Tests
 			TestParser.TestSpec("`a  b`", "<p><code>a  b</code></p>", "");
         }
     }
+
         // Q: Why not just leave the spaces, since browsers will collapse them
+
         // anyway?  A:  Because we might be targeting a non-HTML format, and we
+
         // shouldn't rely on HTML-specific rendering assumptions.
+
         //
+
         // (Existing implementations differ in their treatment of internal
+
         // spaces and [line endings].  Some, including `Markdown.pl` and
+
         // `showdown`, convert an internal [line ending] into a
+
         // `<br />` tag.  But this makes things difficult for those who like to
+
         // hard-wrap their paragraphs, since a line break in the midst of a code
+
         // span will cause an unintended line break in the output.  Others just
+
         // leave internal spaces as they are, which is fine if only HTML is being
+
         // targeted.)
+
     [TestFixture]
     public partial class TestInlinesCodespans
     {
@@ -9363,8 +11292,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("`foo `` bar`", "<p><code>foo `` bar</code></p>", "");
         }
     }
+
         // Note that backslash escapes do not work in code spans. All backslashes
+
         // are treated literally:
+
     [TestFixture]
     public partial class TestInlinesCodespans
     {
@@ -9384,14 +11316,23 @@ namespace Markdig.Tests
 			TestParser.TestSpec("`foo\\`bar`", "<p><code>foo\\</code>bar`</p>", "");
         }
     }
+
         // Backslash escapes are never needed, because one can always choose a
+
         // string of *n* backtick characters as delimiters, where the code does
+
         // not contain any strings of exactly *n* backtick characters.
+
         //
+
         // Code span backticks have higher precedence than any other inline
+
         // constructs except HTML tags and autolinks.  Thus, for example, this is
+
         // not parsed as emphasized text, since the second `*` is part of a code
+
         // span:
+
     [TestFixture]
     public partial class TestInlinesCodespans
     {
@@ -9411,7 +11352,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo`*`", "<p>*foo<code>*</code></p>", "");
         }
     }
+
         // And this is not parsed as a link:
+
     [TestFixture]
     public partial class TestInlinesCodespans
     {
@@ -9431,8 +11374,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[not a `link](/foo`)", "<p>[not a <code>link](/foo</code>)</p>", "");
         }
     }
+
         // Code spans, HTML tags, and autolinks have the same precedence.
+
         // Thus, this is code:
+
     [TestFixture]
     public partial class TestInlinesCodespans
     {
@@ -9452,7 +11398,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("`<a href=\"`\">`", "<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>", "");
         }
     }
+
         // But this is an HTML tag:
+
     [TestFixture]
     public partial class TestInlinesCodespans
     {
@@ -9472,7 +11420,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<a href=\"`\">`", "<p><a href=\"`\">`</p>", "");
         }
     }
+
         // And this is code:
+
     [TestFixture]
     public partial class TestInlinesCodespans
     {
@@ -9492,7 +11442,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("`<http://foo.bar.`baz>`", "<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>", "");
         }
     }
+
         // But this is an autolink:
+
     [TestFixture]
     public partial class TestInlinesCodespans
     {
@@ -9512,8 +11464,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<http://foo.bar.`baz>`", "<p><a href=\"http://foo.bar.%60baz\">http://foo.bar.`baz</a>`</p>", "");
         }
     }
+
         // When a backtick string is not closed by a matching backtick string,
+
         // we just have literal backticks:
+
     [TestFixture]
     public partial class TestInlinesCodespans
     {
@@ -9533,6 +11488,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("```foo``", "<p>```foo``</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesCodespans
     {
@@ -9552,8 +11508,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("`foo", "<p>`foo</p>", "");
         }
     }
+
         // The following case also illustrates the need for opening and
+
         // closing backtick strings to be equal in length:
+
     [TestFixture]
     public partial class TestInlinesCodespans
     {
@@ -9573,211 +11532,417 @@ namespace Markdig.Tests
 			TestParser.TestSpec("`foo``bar``", "<p>`foo<code>bar</code></p>", "");
         }
     }
+
         // ## Emphasis and strong emphasis
+
         //
+
         // John Gruber's original [Markdown syntax
+
         // description](http://daringfireball.net/projects/markdown/syntax#em) says:
+
         //
+
         // > Markdown treats asterisks (`*`) and underscores (`_`) as indicators of
+
         // > emphasis. Text wrapped with one `*` or `_` will be wrapped with an HTML
+
         // > `<em>` tag; double `*`'s or `_`'s will be wrapped with an HTML `<strong>`
+
         // > tag.
+
         //
+
         // This is enough for most users, but these rules leave much undecided,
+
         // especially when it comes to nested emphasis.  The original
+
         // `Markdown.pl` test suite makes it clear that triple `***` and
+
         // `___` delimiters can be used for strong emphasis, and most
+
         // implementations have also allowed the following patterns:
+
         //
+
         // ``` markdown
+
         // ***strong emph***
+
         // ***strong** in emph*
+
         // ***emph* in strong**
+
         // **in strong *emph***
+
         // *in emph **strong***
+
         // ```
+
         //
+
         // The following patterns are less widely supported, but the intent
+
         // is clear and they are useful (especially in contexts like bibliography
+
         // entries):
+
         //
+
         // ``` markdown
+
         // *emph *with emph* in it*
+
         // **strong **with strong** in it**
+
         // ```
+
         //
+
         // Many implementations have also restricted intraword emphasis to
+
         // the `*` forms, to avoid unwanted emphasis in words containing
+
         // internal underscores.  (It is best practice to put these in code
+
         // spans, but users often do not.)
+
         //
+
         // ``` markdown
+
         // internal emphasis: foo*bar*baz
+
         // no emphasis: foo_bar_baz
+
         // ```
+
         //
+
         // The rules given below capture all of these patterns, while allowing
+
         // for efficient parsing strategies that do not backtrack.
+
         //
+
         // First, some definitions.  A [delimiter run](@) is either
+
         // a sequence of one or more `*` characters that is not preceded or
+
         // followed by a non-backslash-escaped `*` character, or a sequence
+
         // of one or more `_` characters that is not preceded or followed by
+
         // a non-backslash-escaped `_` character.
+
         //
+
         // A [left-flanking delimiter run](@) is
+
         // a [delimiter run] that is (a) not followed by [Unicode whitespace],
+
         // and (b) not followed by a [punctuation character], or
+
         // preceded by [Unicode whitespace] or a [punctuation character].
+
         // For purposes of this definition, the beginning and the end of
+
         // the line count as Unicode whitespace.
+
         //
+
         // A [right-flanking delimiter run](@) is
+
         // a [delimiter run] that is (a) not preceded by [Unicode whitespace],
+
         // and (b) not preceded by a [punctuation character], or
+
         // followed by [Unicode whitespace] or a [punctuation character].
+
         // For purposes of this definition, the beginning and the end of
+
         // the line count as Unicode whitespace.
+
         //
+
         // Here are some examples of delimiter runs.
+
         //
+
         // - left-flanking but not right-flanking:
+
         //
+
         // ```
+
         // ***abc
+
         // _abc
+
         // **"abc"
+
         // _"abc"
+
         // ```
+
         //
+
         // - right-flanking but not left-flanking:
+
         //
+
         // ```
+
         // abc***
+
         // abc_
+
         // "abc"**
+
         // "abc"_
+
         // ```
+
         //
+
         // - Both left and right-flanking:
+
         //
+
         // ```
+
         // abc***def
+
         // "abc"_"def"
+
         // ```
+
         //
+
         // - Neither left nor right-flanking:
+
         //
+
         // ```
+
         // abc *** def
+
         // a _ b
+
         // ```
+
         //
+
         // (The idea of distinguishing left-flanking and right-flanking
+
         // delimiter runs based on the character before and the character
+
         // after comes from Roopesh Chander's
+
         // [vfmd](http://www.vfmd.org/vfmd-spec/specification/#procedure-for-identifying-emphasis-tags).
+
         // vfmd uses the terminology "emphasis indicator string" instead of "delimiter
+
         // run," and its rules for distinguishing left- and right-flanking runs
+
         // are a bit more complex than the ones given here.)
+
         //
+
         // The following rules define emphasis and strong emphasis:
+
         //
+
         // 1.  A single `*` character [can open emphasis](@)
+
         // iff (if and only if) it is part of a [left-flanking delimiter run].
+
         //
+
         // 2.  A single `_` character [can open emphasis] iff
+
         // it is part of a [left-flanking delimiter run]
+
         // and either (a) not part of a [right-flanking delimiter run]
+
         // or (b) part of a [right-flanking delimiter run]
+
         // preceded by punctuation.
+
         //
+
         // 3.  A single `*` character [can close emphasis](@)
+
         // iff it is part of a [right-flanking delimiter run].
+
         //
+
         // 4.  A single `_` character [can close emphasis] iff
+
         // it is part of a [right-flanking delimiter run]
+
         // and either (a) not part of a [left-flanking delimiter run]
+
         // or (b) part of a [left-flanking delimiter run]
+
         // followed by punctuation.
+
         //
+
         // 5.  A double `**` [can open strong emphasis](@)
+
         // iff it is part of a [left-flanking delimiter run].
+
         //
+
         // 6.  A double `__` [can open strong emphasis] iff
+
         // it is part of a [left-flanking delimiter run]
+
         // and either (a) not part of a [right-flanking delimiter run]
+
         // or (b) part of a [right-flanking delimiter run]
+
         // preceded by punctuation.
+
         //
+
         // 7.  A double `**` [can close strong emphasis](@)
+
         // iff it is part of a [right-flanking delimiter run].
+
         //
+
         // 8.  A double `__` [can close strong emphasis] iff
+
         // it is part of a [right-flanking delimiter run]
+
         // and either (a) not part of a [left-flanking delimiter run]
+
         // or (b) part of a [left-flanking delimiter run]
+
         // followed by punctuation.
+
         //
+
         // 9.  Emphasis begins with a delimiter that [can open emphasis] and ends
+
         // with a delimiter that [can close emphasis], and that uses the same
+
         // character (`_` or `*`) as the opening delimiter.  The
+
         // opening and closing delimiters must belong to separate
+
         // [delimiter runs].  If one of the delimiters can both
+
         // open and close emphasis, then the sum of the lengths of the
+
         // delimiter runs containing the opening and closing delimiters
+
         // must not be a multiple of 3.
+
         //
+
         // 10. Strong emphasis begins with a delimiter that
+
         // [can open strong emphasis] and ends with a delimiter that
+
         // [can close strong emphasis], and that uses the same character
+
         // (`_` or `*`) as the opening delimiter.  The
+
         // opening and closing delimiters must belong to separate
+
         // [delimiter runs].  If one of the delimiters can both open
+
         // and close strong emphasis, then the sum of the lengths of
+
         // the delimiter runs containing the opening and closing
+
         // delimiters must not be a multiple of 3.
+
         //
+
         // 11. A literal `*` character cannot occur at the beginning or end of
+
         // `*`-delimited emphasis or `**`-delimited strong emphasis, unless it
+
         // is backslash-escaped.
+
         //
+
         // 12. A literal `_` character cannot occur at the beginning or end of
+
         // `_`-delimited emphasis or `__`-delimited strong emphasis, unless it
+
         // is backslash-escaped.
+
         //
+
         // Where rules 1--12 above are compatible with multiple parsings,
+
         // the following principles resolve ambiguity:
+
         //
+
         // 13. The number of nestings should be minimized. Thus, for example,
+
         // an interpretation `<strong>...</strong>` is always preferred to
+
         // `<em><em>...</em></em>`.
+
         //
+
         // 14. An interpretation `<em><strong>...</strong></em>` is always
+
         // preferred to `<strong><em>...</em></strong>`.
+
         //
+
         // 15. When two potential emphasis or strong emphasis spans overlap,
+
         // so that the second begins before the first ends and ends after
+
         // the first ends, the first takes precedence. Thus, for example,
+
         // `*foo _bar* baz_` is parsed as `<em>foo _bar</em> baz_` rather
+
         // than `*foo <em>bar* baz</em>`.
+
         //
+
         // 16. When there are two potential emphasis or strong emphasis spans
+
         // with the same closing delimiter, the shorter one (the one that
+
         // opens later) takes precedence. Thus, for example,
+
         // `**foo **bar baz**` is parsed as `**foo <strong>bar baz</strong>`
+
         // rather than `<strong>foo **bar baz</strong>`.
+
         //
+
         // 17. Inline code spans, links, images, and HTML tags group more tightly
+
         // than emphasis.  So, when there is a choice between an interpretation
+
         // that contains one of these elements and one that does not, the
+
         // former always wins.  Thus, for example, `*[foo*](bar)` is
+
         // parsed as `*<a href="bar">foo*</a>` rather than as
+
         // `<em>[foo</em>](bar)`.
+
         //
+
         // These rules can be illustrated through a series of examples.
+
         //
+
         // Rule 1:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -9797,8 +11962,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo bar*", "<p><em>foo bar</em></p>", "");
         }
     }
+
         // This is not emphasis, because the opening `*` is followed by
+
         // whitespace, and hence not part of a [left-flanking delimiter run]:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -9818,9 +11986,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a * foo bar*", "<p>a * foo bar*</p>", "");
         }
     }
+
         // This is not emphasis, because the opening `*` is preceded
+
         // by an alphanumeric and followed by punctuation, and hence
+
         // not part of a [left-flanking delimiter run]:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -9840,7 +12012,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a*\"foo\"*", "<p>a*&quot;foo&quot;*</p>", "");
         }
     }
+
         // Unicode nonbreaking spaces count as whitespace, too:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -9860,7 +12034,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("* a *", "<p>* a *</p>", "");
         }
     }
+
         // Intraword emphasis with `*` is permitted:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -9880,6 +12056,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo*bar*", "<p>foo<em>bar</em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -9899,7 +12076,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("5*6*78", "<p>5<em>6</em>78</p>", "");
         }
     }
+
         // Rule 2:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -9919,8 +12098,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_foo bar_", "<p><em>foo bar</em></p>", "");
         }
     }
+
         // This is not emphasis, because the opening `_` is followed by
+
         // whitespace:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -9940,8 +12122,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_ foo bar_", "<p>_ foo bar_</p>", "");
         }
     }
+
         // This is not emphasis, because the opening `_` is preceded
+
         // by an alphanumeric and followed by punctuation:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -9961,7 +12146,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a_\"foo\"_", "<p>a_&quot;foo&quot;_</p>", "");
         }
     }
+
         // Emphasis with `_` is not allowed inside words:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -9981,6 +12168,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo_bar_", "<p>foo_bar_</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10000,6 +12188,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("5_6_78", "<p>5_6_78</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10019,8 +12208,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("пристаням_стремятся_", "<p>пристаням_стремятся_</p>", "");
         }
     }
+
         // Here `_` does not generate emphasis, because the first delimiter run
+
         // is right-flanking and the second left-flanking:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10040,9 +12232,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("aa_\"bb\"_cc", "<p>aa_&quot;bb&quot;_cc</p>", "");
         }
     }
+
         // This is emphasis, even though the opening delimiter is
+
         // both left- and right-flanking, because it is preceded by
+
         // punctuation:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10062,10 +12258,15 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo-_(bar)_", "<p>foo-<em>(bar)</em></p>", "");
         }
     }
+
         // Rule 3:
+
         //
+
         // This is not emphasis, because the closing delimiter does
+
         // not match the opening delimiter:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10085,8 +12286,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_foo*", "<p>_foo*</p>", "");
         }
     }
+
         // This is not emphasis, because the closing `*` is preceded by
+
         // whitespace:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10106,7 +12310,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo bar *", "<p>*foo bar *</p>", "");
         }
     }
+
         // A newline also counts as whitespace:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10128,9 +12334,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo bar\n*", "<p>*foo bar\n*</p>", "");
         }
     }
+
         // This is not emphasis, because the second `*` is
+
         // preceded by punctuation and followed by an alphanumeric
+
         // (hence it is not part of a [right-flanking delimiter run]:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10150,8 +12360,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*(*foo)", "<p>*(*foo)</p>", "");
         }
     }
+
         // The point of this restriction is more easily appreciated
+
         // with this example:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10171,7 +12384,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*(*foo*)*", "<p><em>(<em>foo</em>)</em></p>", "");
         }
     }
+
         // Intraword emphasis with `*` is allowed:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10191,10 +12406,15 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo*bar", "<p><em>foo</em>bar</p>", "");
         }
     }
+
         // Rule 4:
+
         //
+
         // This is not emphasis, because the closing `_` is preceded by
+
         // whitespace:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10214,8 +12434,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_foo bar _", "<p>_foo bar _</p>", "");
         }
     }
+
         // This is not emphasis, because the second `_` is
+
         // preceded by punctuation and followed by an alphanumeric:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10235,7 +12458,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_(_foo)", "<p>_(_foo)</p>", "");
         }
     }
+
         // This is emphasis within emphasis:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10255,7 +12480,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_(_foo_)_", "<p><em>(<em>foo</em>)</em></p>", "");
         }
     }
+
         // Intraword emphasis is disallowed for `_`:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10275,6 +12502,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_foo_bar", "<p>_foo_bar</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10294,6 +12522,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_пристаням_стремятся", "<p>_пристаням_стремятся</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10313,9 +12542,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_foo_bar_baz_", "<p><em>foo_bar_baz</em></p>", "");
         }
     }
+
         // This is emphasis, even though the closing delimiter is
+
         // both left- and right-flanking, because it is followed by
+
         // punctuation:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10335,7 +12568,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_(bar)_.", "<p><em>(bar)</em>.</p>", "");
         }
     }
+
         // Rule 5:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10355,8 +12590,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**foo bar**", "<p><strong>foo bar</strong></p>", "");
         }
     }
+
         // This is not strong emphasis, because the opening delimiter is
+
         // followed by whitespace:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10376,9 +12614,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("** foo bar**", "<p>** foo bar**</p>", "");
         }
     }
+
         // This is not strong emphasis, because the opening `**` is preceded
+
         // by an alphanumeric and followed by punctuation, and hence
+
         // not part of a [left-flanking delimiter run]:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10398,7 +12640,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a**\"foo\"**", "<p>a**&quot;foo&quot;**</p>", "");
         }
     }
+
         // Intraword strong emphasis with `**` is permitted:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10418,7 +12662,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo**bar**", "<p>foo<strong>bar</strong></p>", "");
         }
     }
+
         // Rule 6:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10438,8 +12684,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__foo bar__", "<p><strong>foo bar</strong></p>", "");
         }
     }
+
         // This is not strong emphasis, because the opening delimiter is
+
         // followed by whitespace:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10459,7 +12708,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__ foo bar__", "<p>__ foo bar__</p>", "");
         }
     }
+
         // A newline counts as whitespace:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10481,8 +12732,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__\nfoo bar__", "<p>__\nfoo bar__</p>", "");
         }
     }
+
         // This is not strong emphasis, because the opening `__` is preceded
+
         // by an alphanumeric and followed by punctuation:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10502,7 +12756,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a__\"foo\"__", "<p>a__&quot;foo&quot;__</p>", "");
         }
     }
+
         // Intraword strong emphasis is forbidden with `__`:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10522,6 +12778,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo__bar__", "<p>foo__bar__</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10541,6 +12798,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("5__6__78", "<p>5__6__78</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10560,6 +12818,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("пристаням__стремятся__", "<p>пристаням__стремятся__</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10579,9 +12838,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__foo, __bar__, baz__", "<p><strong>foo, <strong>bar</strong>, baz</strong></p>", "");
         }
     }
+
         // This is strong emphasis, even though the opening delimiter is
+
         // both left- and right-flanking, because it is preceded by
+
         // punctuation:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10601,10 +12864,15 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo-__(bar)__", "<p>foo-<strong>(bar)</strong></p>", "");
         }
     }
+
         // Rule 7:
+
         //
+
         // This is not strong emphasis, because the closing delimiter is preceded
+
         // by whitespace:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10624,11 +12892,17 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**foo bar **", "<p>**foo bar **</p>", "");
         }
     }
+
         // (Nor can it be interpreted as an emphasized `*foo bar *`, because of
+
         // Rule 11.)
+
         //
+
         // This is not strong emphasis, because the second `**` is
+
         // preceded by punctuation and followed by an alphanumeric:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10648,8 +12922,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**(**foo)", "<p>**(**foo)</p>", "");
         }
     }
+
         // The point of this restriction is more easily appreciated
+
         // with these examples:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10669,6 +12946,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*(**foo**)*", "<p><em>(<strong>foo</strong>)</em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10690,6 +12968,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**", "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10709,7 +12988,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**foo \"*bar*\" foo**", "<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>", "");
         }
     }
+
         // Intraword emphasis:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10729,10 +13010,15 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**foo**bar", "<p><strong>foo</strong>bar</p>", "");
         }
     }
+
         // Rule 8:
+
         //
+
         // This is not strong emphasis, because the closing delimiter is
+
         // preceded by whitespace:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10752,8 +13038,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__foo bar __", "<p>__foo bar __</p>", "");
         }
     }
+
         // This is not strong emphasis, because the second `__` is
+
         // preceded by punctuation and followed by an alphanumeric:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10773,8 +13062,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__(__foo)", "<p>__(__foo)</p>", "");
         }
     }
+
         // The point of this restriction is more easily appreciated
+
         // with this example:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10794,7 +13086,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_(__foo__)_", "<p><em>(<strong>foo</strong>)</em></p>", "");
         }
     }
+
         // Intraword strong emphasis is forbidden with `__`:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10814,6 +13108,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__foo__bar", "<p>__foo__bar</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10833,6 +13128,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__пристаням__стремятся", "<p>__пристаням__стремятся</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10852,9 +13148,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__foo__bar__baz__", "<p><strong>foo__bar__baz</strong></p>", "");
         }
     }
+
         // This is strong emphasis, even though the closing delimiter is
+
         // both left- and right-flanking, because it is followed by
+
         // punctuation:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10874,10 +13174,15 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__(bar)__.", "<p><strong>(bar)</strong>.</p>", "");
         }
     }
+
         // Rule 9:
+
         //
+
         // Any nonempty sequence of inline elements can be the contents of an
+
         // emphasized span.
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10897,6 +13202,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo [bar](/url)*", "<p><em>foo <a href=\"/url\">bar</a></em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10918,8 +13224,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo\nbar*", "<p><em>foo\nbar</em></p>", "");
         }
     }
+
         // In particular, emphasis and strong emphasis can be nested
+
         // inside emphasis:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10939,6 +13248,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_foo __bar__ baz_", "<p><em>foo <strong>bar</strong> baz</em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10958,6 +13268,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_foo _bar_ baz_", "<p><em>foo <em>bar</em> baz</em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10977,6 +13288,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__foo_ bar_", "<p><em><em>foo</em> bar</em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -10996,6 +13308,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo *bar**", "<p><em>foo <em>bar</em></em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11015,6 +13328,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo **bar** baz*", "<p><em>foo <strong>bar</strong> baz</em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11034,22 +13348,39 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo**bar**baz*", "<p><em>foo<strong>bar</strong>baz</em></p>", "");
         }
     }
+
         // Note that in the preceding case, the interpretation
+
         //
+
         // ``` markdown
+
         // <p><em>foo</em><em>bar<em></em>baz</em></p>
+
         // ```
+
         //
+
         // is precluded by the condition that a delimiter that
+
         // can both open and close (like the `*` after `foo`)
+
         // cannot form emphasis if the sum of the lengths of
+
         // the delimiter runs containing the opening and
+
         // closing delimiters is a multiple of 3.
+
         //
+
         // The same condition ensures that the following
+
         // cases are all strong emphasis nested inside
+
         // emphasis, even when the interior spaces are
+
         // omitted:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11069,6 +13400,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("***foo** bar*", "<p><em><strong>foo</strong> bar</em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11088,6 +13420,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo **bar***", "<p><em>foo <strong>bar</strong></em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11107,7 +13440,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo**bar***", "<p><em>foo<strong>bar</strong></em></p>", "");
         }
     }
+
         // Indefinite levels of nesting are possible:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11127,6 +13462,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo **bar *baz* bim** bop*", "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11146,7 +13482,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo [*bar*](/url)*", "<p><em>foo <a href=\"/url\"><em>bar</em></a></em></p>", "");
         }
     }
+
         // There can be no empty emphasis or strong emphasis:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11166,6 +13504,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("** is not an empty emphasis", "<p>** is not an empty emphasis</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11185,10 +13524,15 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**** is not an empty strong emphasis", "<p>**** is not an empty strong emphasis</p>", "");
         }
     }
+
         // Rule 10:
+
         //
+
         // Any nonempty sequence of inline elements can be the contents of an
+
         // strongly emphasized span.
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11208,6 +13552,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**foo [bar](/url)**", "<p><strong>foo <a href=\"/url\">bar</a></strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11229,8 +13574,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**foo\nbar**", "<p><strong>foo\nbar</strong></p>", "");
         }
     }
+
         // In particular, emphasis and strong emphasis can be nested
+
         // inside strong emphasis:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11250,6 +13598,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__foo _bar_ baz__", "<p><strong>foo <em>bar</em> baz</strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11269,6 +13618,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__foo __bar__ baz__", "<p><strong>foo <strong>bar</strong> baz</strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11288,6 +13638,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("____foo__ bar__", "<p><strong><strong>foo</strong> bar</strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11307,6 +13658,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**foo **bar****", "<p><strong>foo <strong>bar</strong></strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11326,6 +13678,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**foo *bar* baz**", "<p><strong>foo <em>bar</em> baz</strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11345,6 +13698,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**foo*bar*baz**", "<p><strong>foo<em>bar</em>baz</strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11364,6 +13718,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("***foo* bar**", "<p><strong><em>foo</em> bar</strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11383,7 +13738,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**foo *bar***", "<p><strong>foo <em>bar</em></strong></p>", "");
         }
     }
+
         // Indefinite levels of nesting are possible:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11405,6 +13762,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**foo *bar **baz**\nbim* bop**", "<p><strong>foo <em>bar <strong>baz</strong>\nbim</em> bop</strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11424,7 +13782,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**foo [*bar*](/url)**", "<p><strong>foo <a href=\"/url\"><em>bar</em></a></strong></p>", "");
         }
     }
+
         // There can be no empty emphasis or strong emphasis:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11444,6 +13804,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__ is not an empty emphasis", "<p>__ is not an empty emphasis</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11463,7 +13824,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("____ is not an empty strong emphasis", "<p>____ is not an empty strong emphasis</p>", "");
         }
     }
+
         // Rule 11:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11483,6 +13846,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo ***", "<p>foo ***</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11502,6 +13866,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo *\\**", "<p>foo <em>*</em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11521,6 +13886,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo *_*", "<p>foo <em>_</em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11540,6 +13906,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo *****", "<p>foo *****</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11559,6 +13926,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo **\\***", "<p>foo <strong>*</strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11578,9 +13946,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo **_**", "<p>foo <strong>_</strong></p>", "");
         }
     }
+
         // Note that when delimiters do not match evenly, Rule 11 determines
+
         // that the excess literal `*` characters will appear outside of the
+
         // emphasis, rather than inside it:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11600,6 +13972,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**foo*", "<p>*<em>foo</em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11619,6 +13992,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo**", "<p><em>foo</em>*</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11638,6 +14012,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("***foo**", "<p>*<strong>foo</strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11657,6 +14032,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("****foo*", "<p>***<em>foo</em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11676,6 +14052,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**foo***", "<p><strong>foo</strong>*</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11695,7 +14072,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo****", "<p><em>foo</em>***</p>", "");
         }
     }
+
         // Rule 12:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11715,6 +14094,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo ___", "<p>foo ___</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11734,6 +14114,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo _\\__", "<p>foo <em>_</em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11753,6 +14134,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo _*_", "<p>foo <em>*</em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11772,6 +14154,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo _____", "<p>foo _____</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11791,6 +14174,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo __\\___", "<p>foo <strong>_</strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11810,6 +14194,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo __*__", "<p>foo <strong>*</strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11829,9 +14214,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__foo_", "<p>_<em>foo</em></p>", "");
         }
     }
+
         // Note that when delimiters do not match evenly, Rule 12 determines
+
         // that the excess literal `_` characters will appear outside of the
+
         // emphasis, rather than inside it:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11851,6 +14240,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_foo__", "<p><em>foo</em>_</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11870,6 +14260,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("___foo__", "<p>_<strong>foo</strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11889,6 +14280,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("____foo_", "<p>___<em>foo</em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11908,6 +14300,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__foo___", "<p><strong>foo</strong>_</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11927,8 +14320,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_foo____", "<p><em>foo</em>___</p>", "");
         }
     }
+
         // Rule 13 implies that if you want emphasis nested directly inside
+
         // emphasis, you must use different delimiters:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11948,6 +14344,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**foo**", "<p><strong>foo</strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11967,6 +14364,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*_foo_*", "<p><em><em>foo</em></em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -11986,6 +14384,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__foo__", "<p><strong>foo</strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12005,8 +14404,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_*foo*_", "<p><em><em>foo</em></em></p>", "");
         }
     }
+
         // However, strong emphasis within strong emphasis is possible without
+
         // switching delimiters:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12026,6 +14428,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("****foo****", "<p><strong><strong>foo</strong></strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12045,8 +14448,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("____foo____", "<p><strong><strong>foo</strong></strong></p>", "");
         }
     }
+
         // Rule 13 can be applied to arbitrarily long sequences of
+
         // delimiters:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12066,7 +14472,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("******foo******", "<p><strong><strong><strong>foo</strong></strong></strong></p>", "");
         }
     }
+
         // Rule 14:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12086,6 +14494,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("***foo***", "<p><em><strong>foo</strong></em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12105,7 +14514,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_____foo_____", "<p><em><strong><strong>foo</strong></strong></em></p>", "");
         }
     }
+
         // Rule 15:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12125,6 +14536,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo _bar* baz_", "<p><em>foo _bar</em> baz_</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12144,7 +14556,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo __bar *baz bim__ bam*", "<p><em>foo <strong>bar *baz bim</strong> bam</em></p>", "");
         }
     }
+
         // Rule 16:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12164,6 +14578,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**foo **bar baz**", "<p>**foo <strong>bar baz</strong></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12183,7 +14598,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo *bar baz*", "<p>*foo <em>bar baz</em></p>", "");
         }
     }
+
         // Rule 17:
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12203,6 +14620,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*[bar*](/url)", "<p>*<a href=\"/url\">bar*</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12222,6 +14640,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_foo [bar_](/url)", "<p>_foo <a href=\"/url\">bar_</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12241,6 +14660,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*<img src=\"foo\" title=\"*\"/>", "<p>*<img src=\"foo\" title=\"*\"/></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12260,6 +14680,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**<a href=\"**\">", "<p>**<a href=\"**\"></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12279,6 +14700,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__<a href=\"__\">", "<p>__<a href=\"__\"></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12298,6 +14720,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*a `*`*", "<p><em>a <code>*</code></em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12317,6 +14740,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("_a `_`_", "<p><em>a <code>_</code></em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12336,6 +14760,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("**a<http://foo.bar/?q=**>", "<p>**a<a href=\"http://foo.bar/?q=**\">http://foo.bar/?q=**</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesEmphasisandstrongemphasis
     {
@@ -12355,78 +14780,151 @@ namespace Markdig.Tests
 			TestParser.TestSpec("__a<http://foo.bar/?q=__>", "<p>__a<a href=\"http://foo.bar/?q=__\">http://foo.bar/?q=__</a></p>", "");
         }
     }
+
         // ## Links
+
         //
+
         // A link contains [link text] (the visible text), a [link destination]
+
         // (the URI that is the link destination), and optionally a [link title].
+
         // There are two basic kinds of links in Markdown.  In [inline links] the
+
         // destination and title are given immediately after the link text.  In
+
         // [reference links] the destination and title are defined elsewhere in
+
         // the document.
+
         //
+
         // A [link text](@) consists of a sequence of zero or more
+
         // inline elements enclosed by square brackets (`[` and `]`).  The
+
         // following rules apply:
+
         //
+
         // - Links may not contain other links, at any level of nesting. If
+
         // multiple otherwise valid link definitions appear nested inside each
+
         // other, the inner-most definition is used.
+
         //
+
         // - Brackets are allowed in the [link text] only if (a) they
+
         // are backslash-escaped or (b) they appear as a matched pair of brackets,
+
         // with an open bracket `[`, a sequence of zero or more inlines, and
+
         // a close bracket `]`.
+
         //
+
         // - Backtick [code spans], [autolinks], and raw [HTML tags] bind more tightly
+
         // than the brackets in link text.  Thus, for example,
+
         // `` [foo`]` `` could not be a link text, since the second `]`
+
         // is part of a code span.
+
         //
+
         // - The brackets in link text bind more tightly than markers for
+
         // [emphasis and strong emphasis]. Thus, for example, `*[foo*](url)` is a link.
+
         //
+
         // A [link destination](@) consists of either
+
         //
+
         // - a sequence of zero or more characters between an opening `<` and a
+
         // closing `>` that contains no spaces, line breaks, or unescaped
+
         // `<` or `>` characters, or
+
         //
+
         // - a nonempty sequence of characters that does not include
+
         // ASCII space or control characters, and includes parentheses
+
         // only if (a) they are backslash-escaped or (b) they are part of
+
         // a balanced pair of unescaped parentheses.  (Implementations
+
         // may impose limits on parentheses nesting to avoid performance
+
         // issues, but at least three levels of nesting should be supported.)
+
         //
+
         // A [link title](@)  consists of either
+
         //
+
         // - a sequence of zero or more characters between straight double-quote
+
         // characters (`"`), including a `"` character only if it is
+
         // backslash-escaped, or
+
         //
+
         // - a sequence of zero or more characters between straight single-quote
+
         // characters (`'`), including a `'` character only if it is
+
         // backslash-escaped, or
+
         //
+
         // - a sequence of zero or more characters between matching parentheses
+
         // (`(...)`), including a `)` character only if it is backslash-escaped.
+
         //
+
         // Although [link titles] may span multiple lines, they may not contain
+
         // a [blank line].
+
         //
+
         // An [inline link](@) consists of a [link text] followed immediately
+
         // by a left parenthesis `(`, optional [whitespace], an optional
+
         // [link destination], an optional [link title] separated from the link
+
         // destination by [whitespace], optional [whitespace], and a right
+
         // parenthesis `)`. The link's text consists of the inlines contained
+
         // in the [link text] (excluding the enclosing square brackets).
+
         // The link's URI consists of the link destination, excluding enclosing
+
         // `<...>` if present, with backslash-escapes in effect as described
+
         // above.  The link's title consists of the link title, excluding its
+
         // enclosing delimiters, with backslash-escapes in effect as described
+
         // above.
+
         //
+
         // Here is a simple inline link:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12446,7 +14944,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](/uri \"title\")", "<p><a href=\"/uri\" title=\"title\">link</a></p>", "");
         }
     }
+
         // The title may be omitted:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12466,7 +14966,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](/uri)", "<p><a href=\"/uri\">link</a></p>", "");
         }
     }
+
         // Both the title and the destination may be omitted:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12486,6 +14988,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link]()", "<p><a href=\"\">link</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12505,8 +15008,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](<>)", "<p><a href=\"\">link</a></p>", "");
         }
     }
+
         // The destination cannot contain spaces or line breaks,
+
         // even if enclosed in pointy brackets:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12526,6 +15032,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](/my uri)", "<p>[link](/my uri)</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12545,6 +15052,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](</my uri>)", "<p>[link](&lt;/my uri&gt;)</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12566,6 +15074,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](foo\nbar)", "<p>[link](foo\nbar)</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12587,7 +15096,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](<foo\nbar>)", "<p>[link](<foo\nbar>)</p>", "");
         }
     }
+
         // Parentheses inside the link destination may be escaped:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12607,8 +15118,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](\\(foo\\))", "<p><a href=\"(foo)\">link</a></p>", "");
         }
     }
+
         // Any number of parentheses are allowed without escaping, as long as they are
+
         // balanced:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12628,8 +15142,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](foo(and(bar)))", "<p><a href=\"foo(and(bar))\">link</a></p>", "");
         }
     }
+
         // However, if you have unbalanced parentheses, you need to escape or use the
+
         // `<...>` form:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12649,6 +15166,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](foo\\(and\\(bar\\))", "<p><a href=\"foo(and(bar)\">link</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12668,8 +15186,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](<foo(and(bar)>)", "<p><a href=\"foo(and(bar)\">link</a></p>", "");
         }
     }
+
         // Parentheses and other symbols can also be escaped, as usual
+
         // in Markdown:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12689,7 +15210,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](foo\\)\\:)", "<p><a href=\"foo):\">link</a></p>", "");
         }
     }
+
         // A link can contain fragment identifiers and queries:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12715,8 +15238,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](#fragment)\n\n[link](http://example.com#fragment)\n\n[link](http://example.com?foo=3#frag)", "<p><a href=\"#fragment\">link</a></p>\n<p><a href=\"http://example.com#fragment\">link</a></p>\n<p><a href=\"http://example.com?foo=3#frag\">link</a></p>", "");
         }
     }
+
         // Note that a backslash before a non-escapable character is
+
         // just a backslash:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12736,14 +15262,23 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](foo\\bar)", "<p><a href=\"foo%5Cbar\">link</a></p>", "");
         }
     }
+
         // URL-escaping should be left alone inside the destination, as all
+
         // URL-escaped characters are also valid URL characters. Entity and
+
         // numerical character references in the destination will be parsed
+
         // into the corresponding Unicode code points, as usual.  These may
+
         // be optionally URL-escaped when written as HTML, but this spec
+
         // does not enforce any particular policy for rendering URLs in
+
         // HTML or other formats.  Renderers may make different decisions
+
         // about how to escape or normalize URLs in the output.
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12763,9 +15298,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](foo%20b&auml;)", "<p><a href=\"foo%20b%C3%A4\">link</a></p>", "");
         }
     }
+
         // Note that, because titles can often be parsed as destinations,
+
         // if you try to omit the destination and keep the title, you'll
+
         // get unexpected results:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12785,7 +15324,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](\"title\")", "<p><a href=\"%22title%22\">link</a></p>", "");
         }
     }
+
         // Titles may be in single quotes, double quotes, or parentheses:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12809,8 +15350,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))", "<p><a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a></p>", "");
         }
     }
+
         // Backslash escapes and entity and numeric character references
+
         // may be used in titles:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12830,8 +15374,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](/url \"title \\\"&quot;\")", "<p><a href=\"/url\" title=\"title &quot;&quot;\">link</a></p>", "");
         }
     }
+
         // Titles must be separated from the link using a [whitespace].
+
         // Other [Unicode whitespace] like non-breaking space doesn't work.
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12851,7 +15398,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](/url \"title\")", "<p><a href=\"/url%C2%A0%22title%22\">link</a></p>", "");
         }
     }
+
         // Nested balanced quotes are not allowed without escaping:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12871,7 +15420,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](/url \"title \"and\" title\")", "<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>", "");
         }
     }
+
         // But it is easy to work around this by using a different quote type:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12891,22 +15442,39 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](/url 'title \"and\" title')", "<p><a href=\"/url\" title=\"title &quot;and&quot; title\">link</a></p>", "");
         }
     }
+
         // (Note:  `Markdown.pl` did allow double quotes inside a double-quoted
+
         // title, and its test suite included a test demonstrating this.
+
         // But it is hard to see a good rationale for the extra complexity this
+
         // brings, since there are already many ways---backslash escaping,
+
         // entity and numeric character references, or using a different
+
         // quote type for the enclosing title---to write titles containing
+
         // double quotes.  `Markdown.pl`'s handling of titles has a number
+
         // of other strange features.  For example, it allows single-quoted
+
         // titles in inline links, but not reference links.  And, in
+
         // reference links but not inline links, it allows a title to begin
+
         // with `"` and end with `)`.  `Markdown.pl` 1.0.1 even allows
+
         // titles with no closing quotation mark, though 1.0.2b8 does not.
+
         // It seems preferable to adopt a simple, rational rule that works
+
         // the same way in inline links and link reference definitions.)
+
         //
+
         // [Whitespace] is allowed around the destination and title:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12927,8 +15495,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link](   /uri\n  \"title\"  )", "<p><a href=\"/uri\" title=\"title\">link</a></p>", "");
         }
     }
+
         // But it is not allowed between the link text and the
+
         // following parenthesis:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12948,8 +15519,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link] (/uri)", "<p>[link] (/uri)</p>", "");
         }
     }
+
         // The link text may contain balanced brackets, but not unbalanced ones,
+
         // unless they are escaped:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12969,6 +15543,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link [foo [bar]]](/uri)", "<p><a href=\"/uri\">link [foo [bar]]</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -12988,6 +15563,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link] bar](/uri)", "<p>[link] bar](/uri)</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13007,6 +15583,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link [bar](/uri)", "<p>[link <a href=\"/uri\">bar</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13026,7 +15603,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link \\[bar](/uri)", "<p><a href=\"/uri\">link [bar</a></p>", "");
         }
     }
+
         // The link text may contain inline content:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13046,6 +15625,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link *foo **bar** `#`*](/uri)", "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13065,7 +15645,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[![moon](moon.jpg)](/uri)", "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>", "");
         }
     }
+
         // However, links may not contain other links, at any level of nesting.
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13085,6 +15667,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo [bar](/uri)](/uri)", "<p>[foo <a href=\"/uri\">bar</a>](/uri)</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13104,6 +15687,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo *[bar [baz](/uri)](/uri)*](/uri)", "<p>[foo <em>[bar <a href=\"/uri\">baz</a>](/uri)</em>](/uri)</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13123,8 +15707,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![[[foo](uri1)](uri2)](uri3)", "<p><img src=\"uri3\" alt=\"[foo](uri2)\" /></p>", "");
         }
     }
+
         // These cases illustrate the precedence of link text grouping over
+
         // emphasis grouping:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13144,6 +15731,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*[foo*](/uri)", "<p>*<a href=\"/uri\">foo*</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13163,8 +15751,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo *bar](baz*)", "<p><a href=\"baz*\">foo *bar</a></p>", "");
         }
     }
+
         // Note that brackets that *aren't* part of links do not take
+
         // precedence:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13184,8 +15775,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo [bar* baz]", "<p><em>foo [bar</em> baz]</p>", "");
         }
     }
+
         // These cases illustrate the precedence of HTML tags, code spans,
+
         // and autolinks over link grouping:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13205,6 +15799,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo <bar attr=\"](baz)\">", "<p>[foo <bar attr=\"](baz)\"></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13224,6 +15819,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo`](/uri)`", "<p>[foo<code>](/uri)</code></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13243,36 +15839,67 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo<http://example.com/?search=](uri)>", "<p>[foo<a href=\"http://example.com/?search=%5D(uri)\">http://example.com/?search=](uri)</a></p>", "");
         }
     }
+
         // There are three kinds of [reference link](@)s:
+
         // [full](#full-reference-link), [collapsed](#collapsed-reference-link),
+
         // and [shortcut](#shortcut-reference-link).
+
         //
+
         // A [full reference link](@)
+
         // consists of a [link text] immediately followed by a [link label]
+
         // that [matches] a [link reference definition] elsewhere in the document.
+
         //
+
         // A [link label](@)  begins with a left bracket (`[`) and ends
+
         // with the first right bracket (`]`) that is not backslash-escaped.
+
         // Between these brackets there must be at least one [non-whitespace character].
+
         // Unescaped square bracket characters are not allowed inside the
+
         // opening and closing square brackets of [link labels].  A link
+
         // label can have at most 999 characters inside the square
+
         // brackets.
+
         //
+
         // One label [matches](@)
+
         // another just in case their normalized forms are equal.  To normalize a
+
         // label, strip off the opening and closing brackets,
+
         // perform the *Unicode case fold*, strip leading and trailing
+
         // [whitespace] and collapse consecutive internal
+
         // [whitespace] to a single space.  If there are multiple
+
         // matching reference link definitions, the one that comes first in the
+
         // document is used.  (It is desirable in such cases to emit a warning.)
+
         //
+
         // The contents of the first link label are parsed as inlines, which are
+
         // used as the link's text.  The link's URI and title are provided by the
+
         // matching [link reference definition].
+
         //
+
         // Here is a simple example:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13294,11 +15921,17 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo][bar]\n\n[bar]: /url \"title\"", "<p><a href=\"/url\" title=\"title\">foo</a></p>", "");
         }
     }
+
         // The rules for the [link text] are the same as with
+
         // [inline links].  Thus:
+
         //
+
         // The link text may contain balanced brackets, but not unbalanced ones,
+
         // unless they are escaped:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13320,6 +15953,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link [foo [bar]]][ref]\n\n[ref]: /uri", "<p><a href=\"/uri\">link [foo [bar]]</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13341,7 +15975,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link \\[bar][ref]\n\n[ref]: /uri", "<p><a href=\"/uri\">link [bar</a></p>", "");
         }
     }
+
         // The link text may contain inline content:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13363,6 +15999,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[link *foo **bar** `#`*][ref]\n\n[ref]: /uri", "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13384,7 +16021,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[![moon](moon.jpg)][ref]\n\n[ref]: /uri", "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>", "");
         }
     }
+
         // However, links may not contain other links, at any level of nesting.
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13406,6 +16045,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo [bar](/uri)][ref]\n\n[ref]: /uri", "<p>[foo <a href=\"/uri\">bar</a>]<a href=\"/uri\">ref</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13427,11 +16067,17 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri", "<p>[foo <em>bar <a href=\"/uri\">baz</a></em>]<a href=\"/uri\">ref</a></p>", "");
         }
     }
+
         // (In the examples above, we have two [shortcut reference links]
+
         // instead of one [full reference link].)
+
         //
+
         // The following cases illustrate the precedence of link text grouping over
+
         // emphasis grouping:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13453,6 +16099,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*[foo*][ref]\n\n[ref]: /uri", "<p>*<a href=\"/uri\">foo*</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13474,8 +16121,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo *bar][ref]\n\n[ref]: /uri", "<p><a href=\"/uri\">foo *bar</a></p>", "");
         }
     }
+
         // These cases illustrate the precedence of HTML tags, code spans,
+
         // and autolinks over link grouping:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13497,6 +16147,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo <bar attr=\"][ref]\">\n\n[ref]: /uri", "<p>[foo <bar attr=\"][ref]\"></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13518,6 +16169,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo`][ref]`\n\n[ref]: /uri", "<p>[foo<code>][ref]</code></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13539,7 +16191,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo<http://example.com/?search=][ref]>\n\n[ref]: /uri", "<p>[foo<a href=\"http://example.com/?search=%5D%5Bref%5D\">http://example.com/?search=][ref]</a></p>", "");
         }
     }
+
         // Matching is case-insensitive:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13561,7 +16215,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo][BaR]\n\n[bar]: /url \"title\"", "<p><a href=\"/url\" title=\"title\">foo</a></p>", "");
         }
     }
+
         // Unicode case fold is used:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13583,8 +16239,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url", "<p><a href=\"/url\">Толпой</a> is a Russian word.</p>", "");
         }
     }
+
         // Consecutive internal [whitespace] is treated as one space for
+
         // purposes of determining matching:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13607,8 +16266,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[Foo\n  bar]: /url\n\n[Baz][Foo bar]", "<p><a href=\"/url\">Baz</a></p>", "");
         }
     }
+
         // No [whitespace] is allowed between the [link text] and the
+
         // [link label]:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13630,6 +16292,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo] [bar]\n\n[bar]: /url \"title\"", "<p>[foo] <a href=\"/url\" title=\"title\">bar</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13653,35 +16316,65 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]\n[bar]\n\n[bar]: /url \"title\"", "<p>[foo]\n<a href=\"/url\" title=\"title\">bar</a></p>", "");
         }
     }
+
         // This is a departure from John Gruber's original Markdown syntax
+
         // description, which explicitly allows whitespace between the link
+
         // text and the link label.  It brings reference links in line with
+
         // [inline links], which (according to both original Markdown and
+
         // this spec) cannot have whitespace after the link text.  More
+
         // importantly, it prevents inadvertent capture of consecutive
+
         // [shortcut reference links]. If whitespace is allowed between the
+
         // link text and the link label, then in the following we will have
+
         // a single reference link, not two shortcut reference links, as
+
         // intended:
+
         //
+
         // ``` markdown
+
         // [foo]
+
         // [bar]
+
         //
+
         // [foo]: /url1
+
         // [bar]: /url2
+
         // ```
+
         //
+
         // (Note that [shortcut reference links] were introduced by Gruber
+
         // himself in a beta version of `Markdown.pl`, but never included
+
         // in the official syntax description.  Without shortcut reference
+
         // links, it is harmless to allow space between the link text and
+
         // link label; but once shortcut references are introduced, it is
+
         // too dangerous to allow this, as it frequently leads to
+
         // unintended results.)
+
         //
+
         // When there are multiple matching [link reference definitions],
+
         // the first is used:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13705,9 +16398,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]", "<p><a href=\"/url1\">bar</a></p>", "");
         }
     }
+
         // Note that matching is performed on normalized strings, not parsed
+
         // inline content.  So the following does not match, even though the
+
         // labels define equivalent inline content:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13729,8 +16426,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[bar][foo\\!]\n\n[foo!]: /url", "<p>[bar][foo!]</p>", "");
         }
     }
+
         // [Link labels] cannot contain brackets, unless they are
+
         // backslash-escaped:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13753,6 +16453,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo][ref[]\n\n[ref[]: /uri", "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13775,6 +16476,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo][ref[bar]]\n\n[ref[bar]]: /uri", "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13797,6 +16499,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[[[foo]]]\n\n[[[foo]]]: /url", "<p>[[[foo]]]</p>\n<p>[[[foo]]]: /url</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13818,7 +16521,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo][ref\\[]\n\n[ref\\[]: /uri", "<p><a href=\"/uri\">foo</a></p>", "");
         }
     }
+
         // Note that in this example `]` is not backslash-escaped:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13840,7 +16545,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[bar\\\\]: /uri\n\n[bar\\\\]", "<p><a href=\"/uri\">bar\\</a></p>", "");
         }
     }
+
         // A [link label] must contain at least one [non-whitespace character]:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13863,6 +16570,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[]\n\n[]: /uri", "<p>[]</p>\n<p>[]: /uri</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13889,14 +16597,23 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[\n ]\n\n[\n ]: /uri", "<p>[\n]</p>\n<p>[\n]: /uri</p>", "");
         }
     }
+
         // A [collapsed reference link](@)
+
         // consists of a [link label] that [matches] a
+
         // [link reference definition] elsewhere in the
+
         // document, followed by the string `[]`.
+
         // The contents of the first link label are parsed as inlines,
+
         // which are used as the link's text.  The link's URI and title are
+
         // provided by the matching reference link definition.  Thus,
+
         // `[foo][]` is equivalent to `[foo][foo]`.
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13918,6 +16635,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo][]\n\n[foo]: /url \"title\"", "<p><a href=\"/url\" title=\"title\">foo</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13939,7 +16657,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[*foo* bar][]\n\n[*foo* bar]: /url \"title\"", "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>", "");
         }
     }
+
         // The link labels are case-insensitive:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13961,8 +16681,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[Foo][]\n\n[foo]: /url \"title\"", "<p><a href=\"/url\" title=\"title\">Foo</a></p>", "");
         }
     }
+
         // As with full reference links, [whitespace] is not
+
         // allowed between the two sets of brackets:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -13986,14 +16709,23 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo] \n[]\n\n[foo]: /url \"title\"", "<p><a href=\"/url\" title=\"title\">foo</a>\n[]</p>", "");
         }
     }
+
         // A [shortcut reference link](@)
+
         // consists of a [link label] that [matches] a
+
         // [link reference definition] elsewhere in the
+
         // document and is not followed by `[]` or a link label.
+
         // The contents of the first link label are parsed as inlines,
+
         // which are used as the link's text.  The link's URI and title
+
         // are provided by the matching link reference definition.
+
         // Thus, `[foo]` is equivalent to `[foo][]`.
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -14015,6 +16747,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]\n\n[foo]: /url \"title\"", "<p><a href=\"/url\" title=\"title\">foo</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -14036,6 +16769,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[*foo* bar]\n\n[*foo* bar]: /url \"title\"", "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -14057,6 +16791,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"", "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -14078,7 +16813,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[[bar [foo]\n\n[foo]: /url", "<p>[[bar <a href=\"/url\">foo</a></p>", "");
         }
     }
+
         // The link labels are case-insensitive:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -14100,7 +16837,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[Foo]\n\n[foo]: /url \"title\"", "<p><a href=\"/url\" title=\"title\">Foo</a></p>", "");
         }
     }
+
         // A space after the link text should be preserved:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -14122,8 +16861,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo] bar\n\n[foo]: /url", "<p><a href=\"/url\">foo</a> bar</p>", "");
         }
     }
+
         // If you just want bracketed text, you can backslash-escape the
+
         // opening bracket to avoid links:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -14145,8 +16887,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("\\[foo]\n\n[foo]: /url \"title\"", "<p>[foo]</p>", "");
         }
     }
+
         // Note that this is a link, because a link label ends with the first
+
         // following closing bracket:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -14168,8 +16913,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo*]: /url\n\n*[foo*]", "<p>*<a href=\"/url\">foo*</a></p>", "");
         }
     }
+
         // Full and compact references take precedence over shortcut
+
         // references:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -14192,6 +16940,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo][bar]\n\n[foo]: /url1\n[bar]: /url2", "<p><a href=\"/url2\">foo</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -14213,7 +16962,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo][]\n\n[foo]: /url1", "<p><a href=\"/url1\">foo</a></p>", "");
         }
     }
+
         // Inline links also take precedence:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -14235,6 +16986,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo]()\n\n[foo]: /url1", "<p><a href=\"\">foo</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -14256,8 +17008,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo](not a link)\n\n[foo]: /url1", "<p><a href=\"/url1\">foo</a>(not a link)</p>", "");
         }
     }
+
         // In the following case `[bar][baz]` is parsed as a reference,
+
         // `[foo]` as normal text:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -14279,8 +17034,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo][bar][baz]\n\n[baz]: /url", "<p>[foo]<a href=\"/url\">bar</a></p>", "");
         }
     }
+
         // Here, though, `[foo][bar]` is parsed as a reference, since
+
         // `[bar]` is defined:
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -14303,8 +17061,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2", "<p><a href=\"/url2\">foo</a><a href=\"/url1\">baz</a></p>", "");
         }
     }
+
         // Here `[foo]` is not parsed as a shortcut reference, because it
+
         // is followed by a link label (even though `[bar]` is not defined):
+
     [TestFixture]
     public partial class TestInlinesLinks
     {
@@ -14327,17 +17088,29 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2", "<p>[foo]<a href=\"/url1\">bar</a></p>", "");
         }
     }
+
         // ## Images
+
         //
+
         // Syntax for images is like the syntax for links, with one
+
         // difference. Instead of [link text], we have an
+
         // [image description](@).  The rules for this are the
+
         // same as for [link text], except that (a) an
+
         // image description starts with `![` rather than `[`, and
+
         // (b) an image description may contain links.
+
         // An image description has inline elements
+
         // as its contents.  When an image is rendered to HTML,
+
         // this is standardly used as the image's `alt` attribute.
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14357,6 +17130,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![foo](/url \"title\")", "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14378,6 +17152,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"", "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14397,6 +17172,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![foo ![bar](/url)](/url2)", "<p><img src=\"/url2\" alt=\"foo bar\" /></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14416,12 +17192,19 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![foo [bar](/url)](/url2)", "<p><img src=\"/url2\" alt=\"foo bar\" /></p>", "");
         }
     }
+
         // Though this spec is concerned with parsing, not rendering, it is
+
         // recommended that in rendering to HTML, only the plain string content
+
         // of the [image description] be used.  Note that in
+
         // the above example, the alt attribute's value is `foo bar`, not `foo
+
         // [bar](/url)` or `foo <a href="/url">bar</a>`.  Only the plain string
+
         // content is rendered, without formatting.
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14443,6 +17226,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"", "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14464,6 +17248,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"", "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14483,6 +17268,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![foo](train.jpg)", "<p><img src=\"train.jpg\" alt=\"foo\" /></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14502,6 +17288,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("My ![foo bar](/path/to/train.jpg  \"title\"   )", "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14521,6 +17308,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![foo](<url>)", "<p><img src=\"url\" alt=\"foo\" /></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14540,7 +17328,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![](/url)", "<p><img src=\"/url\" alt=\"\" /></p>", "");
         }
     }
+
         // Reference-style:
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14562,6 +17352,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![foo][bar]\n\n[bar]: /url", "<p><img src=\"/url\" alt=\"foo\" /></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14583,7 +17374,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![foo][bar]\n\n[BAR]: /url", "<p><img src=\"/url\" alt=\"foo\" /></p>", "");
         }
     }
+
         // Collapsed:
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14605,6 +17398,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![foo][]\n\n[foo]: /url \"title\"", "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14626,7 +17420,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![*foo* bar][]\n\n[*foo* bar]: /url \"title\"", "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>", "");
         }
     }
+
         // The labels are case-insensitive:
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14648,8 +17444,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![Foo][]\n\n[foo]: /url \"title\"", "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>", "");
         }
     }
+
         // As with reference links, [whitespace] is not allowed
+
         // between the two sets of brackets:
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14673,7 +17472,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![foo] \n[]\n\n[foo]: /url \"title\"", "<p><img src=\"/url\" alt=\"foo\" title=\"title\" />\n[]</p>", "");
         }
     }
+
         // Shortcut:
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14695,6 +17496,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![foo]\n\n[foo]: /url \"title\"", "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14716,7 +17518,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![*foo* bar]\n\n[*foo* bar]: /url \"title\"", "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>", "");
         }
     }
+
         // Note that link labels cannot contain unescaped brackets:
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14739,7 +17543,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![[foo]]\n\n[[foo]]: /url \"title\"", "<p>![[foo]]</p>\n<p>[[foo]]: /url &quot;title&quot;</p>", "");
         }
     }
+
         // The link labels are case-insensitive:
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14761,8 +17567,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![Foo]\n\n[foo]: /url \"title\"", "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>", "");
         }
     }
+
         // If you just want a literal `!` followed by bracketed text, you can
+
         // backslash-escape the opening `[`:
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14784,8 +17593,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("!\\[foo]\n\n[foo]: /url \"title\"", "<p>![foo]</p>", "");
         }
     }
+
         // If you want a link after a literal `!`, backslash-escape the
+
         // `!`:
+
     [TestFixture]
     public partial class TestInlinesImages
     {
@@ -14807,29 +17619,53 @@ namespace Markdig.Tests
 			TestParser.TestSpec("\\![foo]\n\n[foo]: /url \"title\"", "<p>!<a href=\"/url\" title=\"title\">foo</a></p>", "");
         }
     }
+
         // ## Autolinks
+
         //
+
         // [Autolink](@)s are absolute URIs and email addresses inside
+
         // `<` and `>`. They are parsed as links, with the URL or email address
+
         // as the link label.
+
         //
+
         // A [URI autolink](@) consists of `<`, followed by an
+
         // [absolute URI] not containing `<`, followed by `>`.  It is parsed as
+
         // a link to the URI, with the URI as the link's label.
+
         //
+
         // An [absolute URI](@),
+
         // for these purposes, consists of a [scheme] followed by a colon (`:`)
+
         // followed by zero or more characters other than ASCII
+
         // [whitespace] and control characters, `<`, and `>`.  If
+
         // the URI includes these characters, they must be percent-encoded
+
         // (e.g. `%20` for a space).
+
         //
+
         // For purposes of this spec, a [scheme](@) is any sequence
+
         // of 2--32 characters beginning with an ASCII letter and followed
+
         // by any combination of ASCII letters, digits, or the symbols plus
+
         // ("+"), period ("."), or hyphen ("-").
+
         //
+
         // Here are some valid autolinks:
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -14849,6 +17685,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<http://foo.bar.baz>", "<p><a href=\"http://foo.bar.baz\">http://foo.bar.baz</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -14868,6 +17705,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<http://foo.bar.baz/test?q=hello&id=22&boolean>", "<p><a href=\"http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean\">http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -14887,7 +17725,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<irc://foo.bar:2233/baz>", "<p><a href=\"irc://foo.bar:2233/baz\">irc://foo.bar:2233/baz</a></p>", "");
         }
     }
+
         // Uppercase is also fine:
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -14907,10 +17747,15 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<MAILTO:FOO@BAR.BAZ>", "<p><a href=\"MAILTO:FOO@BAR.BAZ\">MAILTO:FOO@BAR.BAZ</a></p>", "");
         }
     }
+
         // Note that many strings that count as [absolute URIs] for
+
         // purposes of this spec are not valid URIs, because their
+
         // schemes are not registered or because of other problems
+
         // with their syntax:
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -14930,6 +17775,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<a+b+c:d>", "<p><a href=\"a+b+c:d\">a+b+c:d</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -14949,6 +17795,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<made-up-scheme://foo,bar>", "<p><a href=\"made-up-scheme://foo,bar\">made-up-scheme://foo,bar</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -14968,6 +17815,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<http://../>", "<p><a href=\"http://../\">http://../</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -14987,7 +17835,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<localhost:5001/foo>", "<p><a href=\"localhost:5001/foo\">localhost:5001/foo</a></p>", "");
         }
     }
+
         // Spaces are not allowed in autolinks:
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -15007,7 +17857,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<http://foo.bar/baz bim>", "<p>&lt;http://foo.bar/baz bim&gt;</p>", "");
         }
     }
+
         // Backslash-escapes do not work inside autolinks:
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -15027,20 +17879,35 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<http://example.com/\\[\\>", "<p><a href=\"http://example.com/%5C%5B%5C\">http://example.com/\\[\\</a></p>", "");
         }
     }
+
         // An [email autolink](@)
+
         // consists of `<`, followed by an [email address],
+
         // followed by `>`.  The link's label is the email address,
+
         // and the URL is `mailto:` followed by the email address.
+
         //
+
         // An [email address](@),
+
         // for these purposes, is anything that matches
+
         // the [non-normative regex from the HTML5
+
         // spec](https://html.spec.whatwg.org/multipage/forms.html#e-mail-state-(type=email)):
+
         //
+
         // /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?
+
         // (?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
+
         //
+
         // Examples of email autolinks:
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -15060,6 +17927,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<foo@bar.example.com>", "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -15079,7 +17947,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<foo+special@Bar.baz-bar0.com>", "<p><a href=\"mailto:foo+special@Bar.baz-bar0.com\">foo+special@Bar.baz-bar0.com</a></p>", "");
         }
     }
+
         // Backslash-escapes do not work inside email autolinks:
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -15099,7 +17969,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<foo\\+@bar.example.com>", "<p>&lt;foo+@bar.example.com&gt;</p>", "");
         }
     }
+
         // These are not autolinks:
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -15119,6 +17991,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<>", "<p>&lt;&gt;</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -15138,6 +18011,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("< http://foo.bar >", "<p>&lt; http://foo.bar &gt;</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -15157,6 +18031,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<m:abc>", "<p>&lt;m:abc&gt;</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -15176,6 +18051,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<foo.bar.baz>", "<p>&lt;foo.bar.baz&gt;</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -15195,6 +18071,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("http://example.com", "<p>http://example.com</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesAutolinks
     {
@@ -15214,80 +18091,155 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo@bar.example.com", "<p>foo@bar.example.com</p>", "");
         }
     }
+
         // ## Raw HTML
+
         //
+
         // Text between `<` and `>` that looks like an HTML tag is parsed as a
+
         // raw HTML tag and will be rendered in HTML without escaping.
+
         // Tag and attribute names are not limited to current HTML tags,
+
         // so custom tags (and even, say, DocBook tags) may be used.
+
         //
+
         // Here is the grammar for tags:
+
         //
+
         // A [tag name](@) consists of an ASCII letter
+
         // followed by zero or more ASCII letters, digits, or
+
         // hyphens (`-`).
+
         //
+
         // An [attribute](@) consists of [whitespace],
+
         // an [attribute name], and an optional
+
         // [attribute value specification].
+
         //
+
         // An [attribute name](@)
+
         // consists of an ASCII letter, `_`, or `:`, followed by zero or more ASCII
+
         // letters, digits, `_`, `.`, `:`, or `-`.  (Note:  This is the XML
+
         // specification restricted to ASCII.  HTML5 is laxer.)
+
         //
+
         // An [attribute value specification](@)
+
         // consists of optional [whitespace],
+
         // a `=` character, optional [whitespace], and an [attribute
+
         // value].
+
         //
+
         // An [attribute value](@)
+
         // consists of an [unquoted attribute value],
+
         // a [single-quoted attribute value], or a [double-quoted attribute value].
+
         //
+
         // An [unquoted attribute value](@)
+
         // is a nonempty string of characters not
+
         // including spaces, `"`, `'`, `=`, `<`, `>`, or `` ` ``.
+
         //
+
         // A [single-quoted attribute value](@)
+
         // consists of `'`, zero or more
+
         // characters not including `'`, and a final `'`.
+
         //
+
         // A [double-quoted attribute value](@)
+
         // consists of `"`, zero or more
+
         // characters not including `"`, and a final `"`.
+
         //
+
         // An [open tag](@) consists of a `<` character, a [tag name],
+
         // zero or more [attributes], optional [whitespace], an optional `/`
+
         // character, and a `>` character.
+
         //
+
         // A [closing tag](@) consists of the string `</`, a
+
         // [tag name], optional [whitespace], and the character `>`.
+
         //
+
         // An [HTML comment](@) consists of `<!--` + *text* + `-->`,
+
         // where *text* does not start with `>` or `->`, does not end with `-`,
+
         // and does not contain `--`.  (See the
+
         // [HTML5 spec](http://www.w3.org/TR/html5/syntax.html#comments).)
+
         //
+
         // A [processing instruction](@)
+
         // consists of the string `<?`, a string
+
         // of characters not including the string `?>`, and the string
+
         // `?>`.
+
         //
+
         // A [declaration](@) consists of the
+
         // string `<!`, a name consisting of one or more uppercase ASCII letters,
+
         // [whitespace], a string of characters not including the
+
         // character `>`, and the character `>`.
+
         //
+
         // A [CDATA section](@) consists of
+
         // the string `<![CDATA[`, a string of characters not including the string
+
         // `]]>`, and the string `]]>`.
+
         //
+
         // An [HTML tag](@) consists of an [open tag], a [closing tag],
+
         // an [HTML comment], a [processing instruction], a [declaration],
+
         // or a [CDATA section].
+
         //
+
         // Here are some simple open tags:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15307,7 +18259,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<a><bab><c2c>", "<p><a><bab><c2c></p>", "");
         }
     }
+
         // Empty elements:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15327,7 +18281,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<a/><b2/>", "<p><a/><b2/></p>", "");
         }
     }
+
         // [Whitespace] is allowed:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15349,7 +18305,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<a  /><b2\ndata=\"foo\" >", "<p><a  /><b2\ndata=\"foo\" ></p>", "");
         }
     }
+
         // With attributes:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15371,7 +18329,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />", "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>", "");
         }
     }
+
         // Custom tag names can be used:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15391,7 +18351,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo <responsive-image src=\"foo.jpg\" />", "<p>Foo <responsive-image src=\"foo.jpg\" /></p>", "");
         }
     }
+
         // Illegal tag names, not parsed as HTML:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15411,7 +18373,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<33> <__>", "<p>&lt;33&gt; &lt;__&gt;</p>", "");
         }
     }
+
         // Illegal attribute names:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15431,7 +18395,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<a h*#ref=\"hi\">", "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>", "");
         }
     }
+
         // Illegal attribute values:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15451,7 +18417,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<a href=\"hi'> <a href=hi'>", "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>", "");
         }
     }
+
         // Illegal [whitespace]:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15473,7 +18441,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("< a><\nfoo><bar/ >", "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;</p>", "");
         }
     }
+
         // Missing [whitespace]:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15493,7 +18463,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<a href='bar'title=title>", "<p>&lt;a href='bar'title=title&gt;</p>", "");
         }
     }
+
         // Closing tags:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15513,7 +18485,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("</a></foo >", "<p></a></foo ></p>", "");
         }
     }
+
         // Illegal attributes in closing tag:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15533,7 +18507,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("</a href=\"foo\">", "<p>&lt;/a href=&quot;foo&quot;&gt;</p>", "");
         }
     }
+
         // Comments:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15555,6 +18531,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo <!-- this is a\ncomment - with hyphen -->", "<p>foo <!-- this is a\ncomment - with hyphen --></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15574,7 +18551,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo <!-- not a comment -- two hyphens -->", "<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>", "");
         }
     }
+
         // Not comments:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15597,7 +18576,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo <!--> foo -->\n\nfoo <!-- foo--->", "<p>foo &lt;!--&gt; foo --&gt;</p>\n<p>foo &lt;!-- foo---&gt;</p>", "");
         }
     }
+
         // Processing instructions:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15617,7 +18598,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo <?php echo $a; ?>", "<p>foo <?php echo $a; ?></p>", "");
         }
     }
+
         // Declarations:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15637,7 +18620,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo <!ELEMENT br EMPTY>", "<p>foo <!ELEMENT br EMPTY></p>", "");
         }
     }
+
         // CDATA sections:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15657,8 +18642,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo <![CDATA[>&<]]>", "<p>foo <![CDATA[>&<]]></p>", "");
         }
     }
+
         // Entity and numeric character references are preserved in HTML
+
         // attributes:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15678,7 +18666,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo <a href=\"&ouml;\">", "<p>foo <a href=\"&ouml;\"></p>", "");
         }
     }
+
         // Backslash escapes do not work in HTML attributes:
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15698,6 +18688,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo <a href=\"\\*\">", "<p>foo <a href=\"\\*\"></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesRawHTML
     {
@@ -15717,12 +18708,19 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<a href=\"\\\"\">", "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>", "");
         }
     }
+
         // ## Hard line breaks
+
         //
+
         // A line break (not in a code span or HTML tag) that is preceded
+
         // by two or more spaces and does not occur at the end of a block
+
         // is parsed as a [hard line break](@) (rendered
+
         // in HTML as a `<br />` tag):
+
     [TestFixture]
     public partial class TestInlinesHardlinebreaks
     {
@@ -15744,8 +18742,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo  \nbaz", "<p>foo<br />\nbaz</p>", "");
         }
     }
+
         // For a more visible alternative, a backslash before the
+
         // [line ending] may be used instead of two spaces:
+
     [TestFixture]
     public partial class TestInlinesHardlinebreaks
     {
@@ -15767,7 +18768,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo\\\nbaz", "<p>foo<br />\nbaz</p>", "");
         }
     }
+
         // More than two spaces can be used:
+
     [TestFixture]
     public partial class TestInlinesHardlinebreaks
     {
@@ -15789,7 +18792,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo       \nbaz", "<p>foo<br />\nbaz</p>", "");
         }
     }
+
         // Leading spaces at the beginning of the next line are ignored:
+
     [TestFixture]
     public partial class TestInlinesHardlinebreaks
     {
@@ -15811,6 +18816,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo  \n     bar", "<p>foo<br />\nbar</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesHardlinebreaks
     {
@@ -15832,8 +18838,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo\\\n     bar", "<p>foo<br />\nbar</p>", "");
         }
     }
+
         // Line breaks can occur inside emphasis, links, and other constructs
+
         // that allow inline content:
+
     [TestFixture]
     public partial class TestInlinesHardlinebreaks
     {
@@ -15855,6 +18864,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo  \nbar*", "<p><em>foo<br />\nbar</em></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesHardlinebreaks
     {
@@ -15876,7 +18886,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*foo\\\nbar*", "<p><em>foo<br />\nbar</em></p>", "");
         }
     }
+
         // Line breaks do not occur inside code spans
+
     [TestFixture]
     public partial class TestInlinesHardlinebreaks
     {
@@ -15897,6 +18909,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("`code  \nspan`", "<p><code>code span</code></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesHardlinebreaks
     {
@@ -15917,7 +18930,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("`code\\\nspan`", "<p><code>code\\ span</code></p>", "");
         }
     }
+
         // or HTML tags:
+
     [TestFixture]
     public partial class TestInlinesHardlinebreaks
     {
@@ -15939,6 +18954,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<a href=\"foo  \nbar\">", "<p><a href=\"foo  \nbar\"></p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesHardlinebreaks
     {
@@ -15960,9 +18976,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<a href=\"foo\\\nbar\">", "<p><a href=\"foo\\\nbar\"></p>", "");
         }
     }
+
         // Hard line breaks are for separating inline content within a block.
+
         // Neither syntax for hard line breaks works at the end of a paragraph or
+
         // other block element:
+
     [TestFixture]
     public partial class TestInlinesHardlinebreaks
     {
@@ -15982,6 +19002,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo\\", "<p>foo\\</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesHardlinebreaks
     {
@@ -16001,6 +19022,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo  ", "<p>foo</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesHardlinebreaks
     {
@@ -16020,6 +19042,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("### foo\\", "<h3>foo\\</h3>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesHardlinebreaks
     {
@@ -16039,13 +19062,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("### foo  ", "<h3>foo</h3>", "");
         }
     }
+
         // ## Soft line breaks
+
         //
+
         // A regular line break (not in a code span or HTML tag) that is not
+
         // preceded by two or more spaces or a backslash is parsed as a
+
         // [softbreak](@).  (A softbreak may be rendered in HTML either as a
+
         // [line ending] or as a space. The result will be the same in
+
         // browsers. In the examples here, a [line ending] will be used.)
+
     [TestFixture]
     public partial class TestInlinesSoftlinebreaks
     {
@@ -16067,8 +19098,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo\nbaz", "<p>foo\nbaz</p>", "");
         }
     }
+
         // Spaces at the end of the line and beginning of the next line are
+
         // removed:
+
     [TestFixture]
     public partial class TestInlinesSoftlinebreaks
     {
@@ -16090,16 +19124,27 @@ namespace Markdig.Tests
 			TestParser.TestSpec("foo \n baz", "<p>foo\nbaz</p>", "");
         }
     }
+
         // A conforming parser may render a soft line break in HTML either as a
+
         // line break or as a space.
+
         //
+
         // A renderer may also provide an option to render soft line breaks
+
         // as hard line breaks.
+
         //
+
         // ## Textual content
+
         //
+
         // Any characters not given an interpretation by the above rules will
+
         // be parsed as plain textual content.
+
     [TestFixture]
     public partial class TestInlinesTextualcontent
     {
@@ -16119,6 +19164,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("hello $.;'there", "<p>hello $.;'there</p>", "");
         }
     }
+
     [TestFixture]
     public partial class TestInlinesTextualcontent
     {
@@ -16138,7 +19184,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Foo χρῆν", "<p>Foo χρῆν</p>", "");
         }
     }
+
         // Internal spaces are preserved verbatim:
+
     [TestFixture]
     public partial class TestInlinesTextualcontent
     {
@@ -16158,360 +19206,715 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Multiple     spaces", "<p>Multiple     spaces</p>", "");
         }
     }
+
         // # Appendix: A parsing strategy
+
         //
+
         // In this appendix we describe some features of the parsing strategy
+
         // used in the CommonMark reference implementations.
+
         //
+
         // ## Overview
+
         //
+
         // Parsing has two phases:
+
         //
+
         // 1. In the first phase, lines of input are consumed and the block
+
         // structure of the document---its division into paragraphs, block quotes,
+
         // list items, and so on---is constructed.  Text is assigned to these
+
         // blocks but not parsed. Link reference definitions are parsed and a
+
         // map of links is constructed.
+
         //
+
         // 2. In the second phase, the raw text contents of paragraphs and headings
+
         // are parsed into sequences of Markdown inline elements (strings,
+
         // code spans, links, emphasis, and so on), using the map of link
+
         // references constructed in phase 1.
+
         //
+
         // At each point in processing, the document is represented as a tree of
+
         // **blocks**.  The root of the tree is a `document` block.  The `document`
+
         // may have any number of other blocks as **children**.  These children
+
         // may, in turn, have other blocks as children.  The last child of a block
+
         // is normally considered **open**, meaning that subsequent lines of input
+
         // can alter its contents.  (Blocks that are not open are **closed**.)
+
         // Here, for example, is a possible document tree, with the open blocks
+
         // marked by arrows:
+
         //
+
         // ``` tree
+
         // -> document
+
         // -> block_quote
+
         // paragraph
+
         // "Lorem ipsum dolor\nsit amet."
+
         // -> list (type=bullet tight=true bullet_char=-)
+
         // list_item
+
         // paragraph
+
         // "Qui *quodsi iracundia*"
+
         // -> list_item
+
         // -> paragraph
+
         // "aliquando id"
+
         // ```
+
         //
+
         // ## Phase 1: block structure
+
         //
+
         // Each line that is processed has an effect on this tree.  The line is
+
         // analyzed and, depending on its contents, the document may be altered
+
         // in one or more of the following ways:
+
         //
+
         // 1. One or more open blocks may be closed.
+
         // 2. One or more new blocks may be created as children of the
+
         // last open block.
+
         // 3. Text may be added to the last (deepest) open block remaining
+
         // on the tree.
+
         //
+
         // Once a line has been incorporated into the tree in this way,
+
         // it can be discarded, so input can be read in a stream.
+
         //
+
         // For each line, we follow this procedure:
+
         //
+
         // 1. First we iterate through the open blocks, starting with the
+
         // root document, and descending through last children down to the last
+
         // open block.  Each block imposes a condition that the line must satisfy
+
         // if the block is to remain open.  For example, a block quote requires a
+
         // `>` character.  A paragraph requires a non-blank line.
+
         // In this phase we may match all or just some of the open
+
         // blocks.  But we cannot close unmatched blocks yet, because we may have a
+
         // [lazy continuation line].
+
         //
+
         // 2.  Next, after consuming the continuation markers for existing
+
         // blocks, we look for new block starts (e.g. `>` for a block quote).
+
         // If we encounter a new block start, we close any blocks unmatched
+
         // in step 1 before creating the new block as a child of the last
+
         // matched block.
+
         //
+
         // 3.  Finally, we look at the remainder of the line (after block
+
         // markers like `>`, list markers, and indentation have been consumed).
+
         // This is text that can be incorporated into the last open
+
         // block (a paragraph, code block, heading, or raw HTML).
+
         //
+
         // Setext headings are formed when we see a line of a paragraph
+
         // that is a [setext heading underline].
+
         //
+
         // Reference link definitions are detected when a paragraph is closed;
+
         // the accumulated text lines are parsed to see if they begin with
+
         // one or more reference link definitions.  Any remainder becomes a
+
         // normal paragraph.
+
         //
+
         // We can see how this works by considering how the tree above is
+
         // generated by four lines of Markdown:
+
         //
+
         // ``` markdown
+
         // > Lorem ipsum dolor
+
         // sit amet.
+
         // > - Qui *quodsi iracundia*
+
         // > - aliquando id
+
         // ```
+
         //
+
         // At the outset, our document model is just
+
         //
+
         // ``` tree
+
         // -> document
+
         // ```
+
         //
+
         // The first line of our text,
+
         //
+
         // ``` markdown
+
         // > Lorem ipsum dolor
+
         // ```
+
         //
+
         // causes a `block_quote` block to be created as a child of our
+
         // open `document` block, and a `paragraph` block as a child of
+
         // the `block_quote`.  Then the text is added to the last open
+
         // block, the `paragraph`:
+
         //
+
         // ``` tree
+
         // -> document
+
         // -> block_quote
+
         // -> paragraph
+
         // "Lorem ipsum dolor"
+
         // ```
+
         //
+
         // The next line,
+
         //
+
         // ``` markdown
+
         // sit amet.
+
         // ```
+
         //
+
         // is a "lazy continuation" of the open `paragraph`, so it gets added
+
         // to the paragraph's text:
+
         //
+
         // ``` tree
+
         // -> document
+
         // -> block_quote
+
         // -> paragraph
+
         // "Lorem ipsum dolor\nsit amet."
+
         // ```
+
         //
+
         // The third line,
+
         //
+
         // ``` markdown
+
         // > - Qui *quodsi iracundia*
+
         // ```
+
         //
+
         // causes the `paragraph` block to be closed, and a new `list` block
+
         // opened as a child of the `block_quote`.  A `list_item` is also
+
         // added as a child of the `list`, and a `paragraph` as a child of
+
         // the `list_item`.  The text is then added to the new `paragraph`:
+
         //
+
         // ``` tree
+
         // -> document
+
         // -> block_quote
+
         // paragraph
+
         // "Lorem ipsum dolor\nsit amet."
+
         // -> list (type=bullet tight=true bullet_char=-)
+
         // -> list_item
+
         // -> paragraph
+
         // "Qui *quodsi iracundia*"
+
         // ```
+
         //
+
         // The fourth line,
+
         //
+
         // ``` markdown
+
         // > - aliquando id
+
         // ```
+
         //
+
         // causes the `list_item` (and its child the `paragraph`) to be closed,
+
         // and a new `list_item` opened up as child of the `list`.  A `paragraph`
+
         // is added as a child of the new `list_item`, to contain the text.
+
         // We thus obtain the final tree:
+
         //
+
         // ``` tree
+
         // -> document
+
         // -> block_quote
+
         // paragraph
+
         // "Lorem ipsum dolor\nsit amet."
+
         // -> list (type=bullet tight=true bullet_char=-)
+
         // list_item
+
         // paragraph
+
         // "Qui *quodsi iracundia*"
+
         // -> list_item
+
         // -> paragraph
+
         // "aliquando id"
+
         // ```
+
         //
+
         // ## Phase 2: inline structure
+
         //
+
         // Once all of the input has been parsed, all open blocks are closed.
+
         //
+
         // We then "walk the tree," visiting every node, and parse raw
+
         // string contents of paragraphs and headings as inlines.  At this
+
         // point we have seen all the link reference definitions, so we can
+
         // resolve reference links as we go.
+
         //
+
         // ``` tree
+
         // document
+
         // block_quote
+
         // paragraph
+
         // str "Lorem ipsum dolor"
+
         // softbreak
+
         // str "sit amet."
+
         // list (type=bullet tight=true bullet_char=-)
+
         // list_item
+
         // paragraph
+
         // str "Qui "
+
         // emph
+
         // str "quodsi iracundia"
+
         // list_item
+
         // paragraph
+
         // str "aliquando id"
+
         // ```
+
         //
+
         // Notice how the [line ending] in the first paragraph has
+
         // been parsed as a `softbreak`, and the asterisks in the first list item
+
         // have become an `emph`.
+
         //
+
         // ### An algorithm for parsing nested emphasis and links
+
         //
+
         // By far the trickiest part of inline parsing is handling emphasis,
+
         // strong emphasis, links, and images.  This is done using the following
+
         // algorithm.
+
         //
+
         // When we're parsing inlines and we hit either
+
         //
+
         // - a run of `*` or `_` characters, or
+
         // - a `[` or `![`
+
         //
+
         // we insert a text node with these symbols as its literal content, and we
+
         // add a pointer to this text node to the [delimiter stack](@).
+
         //
+
         // The [delimiter stack] is a doubly linked list.  Each
+
         // element contains a pointer to a text node, plus information about
+
         //
+
         // - the type of delimiter (`[`, `![`, `*`, `_`)
+
         // - the number of delimiters,
+
         // - whether the delimiter is "active" (all are active to start), and
+
         // - whether the delimiter is a potential opener, a potential closer,
+
         // or both (which depends on what sort of characters precede
+
         // and follow the delimiters).
+
         //
+
         // When we hit a `]` character, we call the *look for link or image*
+
         // procedure (see below).
+
         //
+
         // When we hit the end of the input, we call the *process emphasis*
+
         // procedure (see below), with `stack_bottom` = NULL.
+
         //
+
         // #### *look for link or image*
+
         //
+
         // Starting at the top of the delimiter stack, we look backwards
+
         // through the stack for an opening `[` or `![` delimiter.
+
         //
+
         // - If we don't find one, we return a literal text node `]`.
+
         //
+
         // - If we do find one, but it's not *active*, we remove the inactive
+
         // delimiter from the stack, and return a literal text node `]`.
+
         //
+
         // - If we find one and it's active, then we parse ahead to see if
+
         // we have an inline link/image, reference link/image, compact reference
+
         // link/image, or shortcut reference link/image.
+
         //
+
         // + If we don't, then we remove the opening delimiter from the
+
         // delimiter stack and return a literal text node `]`.
+
         //
+
         // + If we do, then
+
         //
+
         // * We return a link or image node whose children are the inlines
+
         // after the text node pointed to by the opening delimiter.
+
         //
+
         // * We run *process emphasis* on these inlines, with the `[` opener
+
         // as `stack_bottom`.
+
         //
+
         // * We remove the opening delimiter.
+
         //
+
         // * If we have a link (and not an image), we also set all
+
         // `[` delimiters before the opening delimiter to *inactive*.  (This
+
         // will prevent us from getting links within links.)
+
         //
+
         // #### *process emphasis*
+
         //
+
         // Parameter `stack_bottom` sets a lower bound to how far we
+
         // descend in the [delimiter stack].  If it is NULL, we can
+
         // go all the way to the bottom.  Otherwise, we stop before
+
         // visiting `stack_bottom`.
+
         //
+
         // Let `current_position` point to the element on the [delimiter stack]
+
         // just above `stack_bottom` (or the first element if `stack_bottom`
+
         // is NULL).
+
         //
+
         // We keep track of the `openers_bottom` for each delimiter
+
         // type (`*`, `_`).  Initialize this to `stack_bottom`.
+
         //
+
         // Then we repeat the following until we run out of potential
+
         // closers:
+
         //
+
         // - Move `current_position` forward in the delimiter stack (if needed)
+
         // until we find the first potential closer with delimiter `*` or `_`.
+
         // (This will be the potential closer closest
+
         // to the beginning of the input -- the first one in parse order.)
+
         //
+
         // - Now, look back in the stack (staying above `stack_bottom` and
+
         // the `openers_bottom` for this delimiter type) for the
+
         // first matching potential opener ("matching" means same delimiter).
+
         //
+
         // - If one is found:
+
         //
+
         // + Figure out whether we have emphasis or strong emphasis:
+
         // if both closer and opener spans have length >= 2, we have
+
         // strong, otherwise regular.
+
         //
+
         // + Insert an emph or strong emph node accordingly, after
+
         // the text node corresponding to the opener.
+
         //
+
         // + Remove any delimiters between the opener and closer from
+
         // the delimiter stack.
+
         //
+
         // + Remove 1 (for regular emph) or 2 (for strong emph) delimiters
+
         // from the opening and closing text nodes.  If they become empty
+
         // as a result, remove them and remove the corresponding element
+
         // of the delimiter stack.  If the closing node is removed, reset
+
         // `current_position` to the next element in the stack.
+
         //
+
         // - If none in found:
+
         //
+
         // + Set `openers_bottom` to the element before `current_position`.
+
         // (We know that there are no openers for this kind of closer up to and
+
         // including this point, so this puts a lower bound on future searches.)
+
         //
+
         // + If the closer at `current_position` is not a potential opener,
+
         // remove it from the delimiter stack (since we know it can't
+
         // be a closer either).
+
         //
+
         // + Advance `current_position` to the next element in the stack.
+
         //
+
         // After we're done, we remove all delimiters above `stack_bottom` from the
+
         // delimiter stack.
+
         //
+
         // # Extensions
+
         //
+
         // This section describes the different extensions supported:
+
         //
+
         // ## Pipe Table
+
         //
+
         // A pipe table is detected when:
+
         //
+
         // **Rule #1**
+
         // - Each line of a paragraph block have to contain at least a **column delimiter** `|` that is not embedded by either a code inline (backstick \`) or a HTML inline.
+
         // - The second row must separate the first header row from sub-sequent rows by containing a **header column separator** for each column separated by a column delimiter. A header column separator is:
+
         // - starting by optional spaces
+
         // - followed by an optional `:` to specify left align
+
         // - followed by a sequence of at least one `-` character
+
         // - followed by an optional `:` to specify right align (or center align if left align is also defined)
+
         // - ending by optional spaces
+
         //
+
         // Because a list has a higher precedence than a pipe table, a table header row separator requires at least 2 dashes `--` to start a header row:
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -16546,7 +19949,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a | b\n-- | -\n0 | 1", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
+
         // The following is also considered as a table, even if the second line starts like a list:
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -16581,7 +19986,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a | b\n- | -\n0 | 1", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
+
         // A pipe table with only one header row is allowed:
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -16609,7 +20016,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a | b\n-- | --", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n</table>", "pipetables|advanced");
         }
     }
+
         // After a row separator header, they will be interpreted as plain column:
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -16644,7 +20053,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a | b\n-- | --\n-- | --", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>--</td>\n<td>--</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
+
         // But if a table doesn't start with a column delimiter, it is not interpreted as a table, even if following lines have a column delimiter
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -16668,7 +20079,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a b\nc | d\ne | f", "<p>a b\nc | d\ne | f</p>", "pipetables|advanced");
         }
     }
+
         // If a line doesn't have a column delimiter `|` the table is not detected
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -16690,7 +20103,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a | b\nc no d", "<p>a | b\nc no d</p>", "pipetables|advanced");
         }
     }
+
         // If a row contains more column than the header row, it will still be added as a column:
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -16739,11 +20154,17 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a  | b \n-- | --\n0  | 1 | 2\n3  | 4\n5  |", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n<th></th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n<td>2</td>\n</tr>\n<tr>\n<td>3</td>\n<td>4</td>\n<td></td>\n</tr>\n<tr>\n<td>5</td>\n<td></td>\n<td></td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
+
         // **Rule #2**
+
         // A pipe table ends after a blank line or the end of the file.
+
         //
+
         // **Rule #3**
+
         // A cell content is trimmed (start and end) from white-spaces.
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -16778,8 +20199,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a          | b              |\n-- | --\n0      | 1       |", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
+
         // **Rule #4**
+
         // Column delimiters `|` at the very beginning of a line or just before a line ending with only spaces and/or terminated by a newline can be omitted
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -16824,7 +20248,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("  a     | b     |\n--      | --\n| 0     | 1\n| 2     | 3     |\n  4     | 5 ", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n<tr>\n<td>2</td>\n<td>3</td>\n</tr>\n<tr>\n<td>4</td>\n<td>5</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
+
         // A pipe may be present at both the beginning/ending of each line:
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -16859,7 +20285,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("|a|b|\n|-|-|\n|0|1|", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
+
         // Or may be ommitted on one side:
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -16894,6 +20322,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a|b|\n-|-|\n0|1|", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -16928,7 +20357,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("|a|b\n|-|-\n|0|1", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
+
         // Single column table can be declared with lines starting only by a column delimiter:
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -16965,15 +20396,25 @@ namespace Markdig.Tests
 			TestParser.TestSpec("| a\n| --\n| b\n| c ", "<table>\n<thead>\n<tr>\n<th>a</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>b</td>\n</tr>\n<tr>\n<td>c</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
+
         // **Rule #5**
+
         //
+
         // The first row is considered as a **header row** if it is separated from the regular rows by a row containing a **header column separator** for each column. A header column separator is:
+
         //
+
         // - starting by optional spaces
+
         // - followed by an optional `:` to specify left align
+
         // - followed by a sequence of at least one `-` character
+
         // - followed by an optional `:` to specify right align (or center align if left align is also defined)
+
         // - ending by optional spaces
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -17013,9 +20454,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec(" a     | b \n-------|-------\n 0     | 1 \n 2     | 3 ", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n<tr>\n<td>2</td>\n<td>3</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
+
         // The text alignment is defined by default to be center for header and left for cells. If the left alignment is applied, it will force the column heading to be left aligned.
+
         // There is no way to define a different alignment for heading and cells (apart from the default).
+
         // The text alignment can be changed by using the character `:` with the header column separator:
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -17058,7 +20503,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec(" a     | b       | c \n:------|:-------:| ----:\n 0     | 1       | 2 \n 3     | 4       | 5 ", "<table>\n<thead>\n<tr>\n<th style=\"text-align: left;\">a</th>\n<th style=\"text-align: center;\">b</th>\n<th style=\"text-align: right;\">c</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: left;\">0</td>\n<td style=\"text-align: center;\">1</td>\n<td style=\"text-align: right;\">2</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\">3</td>\n<td style=\"text-align: center;\">4</td>\n<td style=\"text-align: right;\">5</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
+
         // Test alignment with starting and ending pipes:
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -17095,7 +20542,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("| abc | def | ghi |\n|:---:|-----|----:|\n|  1  | 2   | 3   |", "<table>\n<thead>\n<tr>\n<th style=\"text-align: center;\">abc</th>\n<th>def</th>\n<th style=\"text-align: right;\">ghi</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: center;\">1</td>\n<td>2</td>\n<td style=\"text-align: right;\">3</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
+
         // The following example shows a non matching header column separator:
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -17121,9 +20570,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec(" a     | b\n-------|---x---\n 0     | 1\n 2     | 3 ", "<p>a     | b\n-------|---x---\n0     | 1\n2     | 3</p> ", "pipetables|advanced");
         }
     }
+
         // **Rule #6**
+
         //
+
         // A column delimiter has a higher priority than emphasis delimiter
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -17163,9 +20616,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec(" *a*   | b\n-----  |-----\n 0     | _1_\n _2    | 3* ", "<table>\n<thead>\n<tr>\n<th><em>a</em></th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td><em>1</em></td>\n</tr>\n<tr>\n<td>_2</td>\n<td>3*</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
+
         // **Rule #7**
+
         //
+
         // A backstick/code delimiter has a higher precedence than a column delimiter `|`:
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -17186,9 +20643,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a | b `\n0 | ` ", "<p>a | b <code>0 |</code></p> ", "pipetables|advanced");
         }
     }
+
         // **Rule #7**
+
         //
+
         // A HTML inline has a higher precedence than a column delimiter `|`:
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -17223,9 +20684,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a <a href=\"\" title=\"|\"></a> | b\n-- | --\n0  | 1", "<table>\n<thead>\n<tr>\n<th>a <a href=\"\" title=\"|\"></a></th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
+
         // **Rule #8**
+
         //
+
         // Links have a higher precedence than the column delimiter character `|`:
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -17260,9 +20725,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a  | b\n-- | --\n[This is a link with a | inside the label](http://google.com) | 1", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td><a href=\"http://google.com\">This is a link with a | inside the label</a></td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
+
         // ** Rule #9**
+
         //
+
         // It is possible to have a single row header only:
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -17290,6 +20759,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a  | b\n-- | --", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n</table>", "pipetables|advanced");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -17318,9 +20788,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("|a|b|c\n|---|---|---|", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n<th>c</th>\n</tr>\n</thead>\n</table>", "pipetables|advanced");
         }
     }
+
         // ** Tests **
+
         //
+
         // Tests trailing spaces after pipes
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -17370,9 +20844,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("| abc | def | \n|---|---|\n| cde| ddd| \n| eee| fff|\n| fff | fffff   | \n|gggg  | ffff | ", "<table>\n<thead>\n<tr>\n<th>abc</th>\n<th>def</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>cde</td>\n<td>ddd</td>\n</tr>\n<tr>\n<td>eee</td>\n<td>fff</td>\n</tr>\n<tr>\n<td>fff</td>\n<td>fffff</td>\n</tr>\n<tr>\n<td>gggg</td>\n<td>ffff</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
+
         // ** Normalized columns count **
+
         //
+
         // The tables are normalized to the maximum number of columns found in a table
+
     [TestFixture]
     public partial class TestExtensionsPipeTable
     {
@@ -17409,13 +20887,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a | b\n-- | - \n0 | 1 | 2", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n<th></th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n<td>2</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
+
         // # Extensions
+
         //
+
         // This section describes the different extensions supported:
+
         //
+
         // ## Footontes
+
         //
+
         // Allows footnotes using the following syntax (taken from pandoc example):
+
     [TestFixture]
     public partial class TestExtensionsFootontes
     {
@@ -17484,7 +20970,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Here is a footnote reference,[^1] and another.[^longnote]\n\nThis is another reference to [^1]\n\n[^1]: Here is the footnote.\n\nAnd another reference to [^longnote]\n\n[^longnote]: Here's one with multiple blocks.\n\n    Subsequent paragraphs are indented to show that they\nbelong to the previous footnote.\n\n    > This is a block quote\n    > Inside a footnote\n\n        { some.code }\n\n    The whole paragraph can be indented, or just the first\n    line.  In this way, multi-paragraph footnotes work like\n    multi-paragraph list items.\n\nThis paragraph won't be part of the note, because it\nisn't indented.", "<p>Here is a footnote reference,<a id=\"fnref:1\" href=\"#fn:1\" class=\"footnote-ref\"><sup>1</sup></a> and another.<a id=\"fnref:3\" href=\"#fn:2\" class=\"footnote-ref\"><sup>2</sup></a></p>\n<p>This is another reference to <a id=\"fnref:2\" href=\"#fn:1\" class=\"footnote-ref\"><sup>1</sup></a></p>\n<p>And another reference to <a id=\"fnref:4\" href=\"#fn:2\" class=\"footnote-ref\"><sup>2</sup></a></p>\n<p>This paragraph won't be part of the note, because it\nisn't indented.</p>\n<div class=\"footnotes\">\n<hr />\n<ol>\n<li id=\"fn:1\">\n<p>Here is the footnote.<a href=\"#fnref:1\" class=\"footnote-back-ref\">&#8617;</a><a href=\"#fnref:2\" class=\"footnote-back-ref\">&#8617;</a></p>\n</li>\n<li id=\"fn:2\">\n<p>Here's one with multiple blocks.</p>\n<p>Subsequent paragraphs are indented to show that they\nbelong to the previous footnote.</p>\n<blockquote>\n<p>This is a block quote\nInside a footnote</p>\n</blockquote>\n<pre><code>{ some.code }\n</code></pre>\n<p>The whole paragraph can be indented, or just the first\nline.  In this way, multi-paragraph footnotes work like\nmulti-paragraph list items.<a href=\"#fnref:3\" class=\"footnote-back-ref\">&#8617;</a><a href=\"#fnref:4\" class=\"footnote-back-ref\">&#8617;</a></p>\n</li>\n</ol>\n</div>", "footnotes|advanced");
         }
     }
+
         // Check with mulitple consecutive footnotes:
+
     [TestFixture]
     public partial class TestExtensionsFootontes
     {
@@ -17528,7 +21016,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Here is a footnote[^1]. And another one[^2]. And a third one[^3]. And a fourth[^4].\n\n[^1]: Footnote 1 text\n\n[^2]: Footnote 2 text\n\na\n\n[^3]: Footnote 3 text\n\n[^4]: Footnote 4 text", "<p>Here is a footnote<a id=\"fnref:1\" href=\"#fn:1\" class=\"footnote-ref\"><sup>1</sup></a>. And another one<a id=\"fnref:2\" href=\"#fn:2\" class=\"footnote-ref\"><sup>2</sup></a>. And a third one<a id=\"fnref:3\" href=\"#fn:3\" class=\"footnote-ref\"><sup>3</sup></a>. And a fourth<a id=\"fnref:4\" href=\"#fn:4\" class=\"footnote-ref\"><sup>4</sup></a>.</p>\n<p>a</p>\n<div class=\"footnotes\">\n<hr />\n<ol>\n<li id=\"fn:1\">\n<p>Footnote 1 text<a href=\"#fnref:1\" class=\"footnote-back-ref\">&#8617;</a></p></li>\n<li id=\"fn:2\">\n<p>Footnote 2 text<a href=\"#fnref:2\" class=\"footnote-back-ref\">&#8617;</a></p></li>\n<li id=\"fn:3\">\n<p>Footnote 3 text<a href=\"#fnref:3\" class=\"footnote-back-ref\">&#8617;</a></p></li>\n<li id=\"fn:4\">\n<p>Footnote 4 text<a href=\"#fnref:4\" class=\"footnote-back-ref\">&#8617;</a></p></li>\n</ol>\n</div>", "footnotes|advanced");
         }
     }
+
         // Another test with consecutive footnotes without a blank line separator:
+
     [TestFixture]
     public partial class TestExtensionsFootontes
     {
@@ -17566,7 +21056,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Here is a footnote[^1]. And another one[^2]. And a third one[^3]. And a fourth[^4].\n\n[^1]: Footnote 1 text\n[^2]: Footnote 2 text\n[^3]: Footnote 3 text\n[^4]: Footnote 4 text", "<p>Here is a footnote<a id=\"fnref:1\" href=\"#fn:1\" class=\"footnote-ref\"><sup>1</sup></a>. And another one<a id=\"fnref:2\" href=\"#fn:2\" class=\"footnote-ref\"><sup>2</sup></a>. And a third one<a id=\"fnref:3\" href=\"#fn:3\" class=\"footnote-ref\"><sup>3</sup></a>. And a fourth<a id=\"fnref:4\" href=\"#fn:4\" class=\"footnote-ref\"><sup>4</sup></a>.</p>\n<div class=\"footnotes\">\n<hr />\n<ol>\n<li id=\"fn:1\">\n<p>Footnote 1 text<a href=\"#fnref:1\" class=\"footnote-back-ref\">&#8617;</a></p></li>\n<li id=\"fn:2\">\n<p>Footnote 2 text<a href=\"#fnref:2\" class=\"footnote-back-ref\">&#8617;</a></p></li>\n<li id=\"fn:3\">\n<p>Footnote 3 text<a href=\"#fnref:3\" class=\"footnote-back-ref\">&#8617;</a></p></li>\n<li id=\"fn:4\">\n<p>Footnote 4 text<a href=\"#fnref:4\" class=\"footnote-back-ref\">&#8617;</a></p></li>\n</ol>\n</div>", "footnotes|advanced");
         }
     }
+
         // A footnote link inside a list should work as well:
+
     [TestFixture]
     public partial class TestExtensionsFootontes
     {
@@ -17599,24 +21091,43 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- abc\n- def[^1]\n\n[^1]: Here is the footnote.", "<ul>\n<li>abc</li>\n<li>def<a id=\"fnref:1\" href=\"#fn:1\" class=\"footnote-ref\"><sup>1</sup></a></li>\n</ul>\n<div class=\"footnotes\">\n<hr />\n<ol>\n<li id=\"fn:1\">\n<p>Here is the footnote.<a href=\"#fnref:1\" class=\"footnote-back-ref\">&#8617;</a></p></li>\n</ol>\n</div>", "footnotes|advanced");
         }
     }
+
         // # Extensions
+
         //
+
         // This section describes the different extensions supported:
+
         //
+
         // ## Generic Attributes
+
         //
+
         // Attributes can be attached to:
+
         // - The previous inline element if the previous element is not a literal
+
         // - The next block if the current block is a paragraph and the attributes is the only inline present in the paragraph
+
         // - Or the current block
+
         //
+
         // Attributes can be of 3 kinds:
+
         //
+
         // - An id element, starting by `#` that will be used to set the `id` property of the HTML element
+
         // - A class element, starting by `.` that will be appended to the CSS class property of the HTML element
+
         // - a `name=value` or `name="value"` that will be appended as an attribute of the HTML element
+
         //
+
         // The following shows that attributes is attached to the current block or the previous inline:
+
     [TestFixture]
     public partial class TestExtensionsGenericAttributes
     {
@@ -17649,7 +21160,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("# This is a heading with an an attribute{#heading-link}\n\n# This is a heading # {#heading-link2}\n\n[This is a link](http://google.com){#a-link .myclass data-lang=fr data-value=\"This is a value\"}\n\nThis is a heading{#heading-link2}\n-----------------\n\nThis is a paragraph with an attached attributes {#myparagraph attached-bool-property attached-bool-property2}", "<h1 id=\"heading-link\">This is a heading with an an attribute</h1>\n<h1 id=\"heading-link2\">This is a heading</h1>\n<p><a href=\"http://google.com\" id=\"a-link\" class=\"myclass\" data-lang=\"fr\" data-value=\"This is a value\">This is a link</a></p>\n<h2 id=\"heading-link2\">This is a heading</h2>\n<p id=\"myparagraph\" attached-bool-property attached-bool-property2>This is a paragraph with an attached attributes </p>", "attributes|advanced");
         }
     }
+
         // The following shows that attributes can be attached to the next block if they are used inside a single line just preceding the block (and preceded by a blank line or beginning of a block container):
+
     [TestFixture]
     public partial class TestExtensionsGenericAttributes
     {
@@ -17673,13 +21186,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("{#fenced-id .fenced-class}\n~~~\nThis is a fenced with attached attributes\n~~~ ", "<pre><code id=\"fenced-id\" class=\"fenced-class\">This is a fenced with attached attributes\n</code></pre>", "attributes|advanced");
         }
     }
+
         // # Extensions
+
         //
+
         // The following additional emphasis are supported:
+
         //
+
         // ## Strikethrough
+
         //
+
         // Allows to strikethrough a span of text by surrounding it by `~~`. The semantic used for the generated HTML is the tag `<del>`.
+
     [TestFixture]
     public partial class TestExtensionsStrikethrough
     {
@@ -17699,9 +21220,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("The following text ~~is deleted~~", "<p>The following text <del>is deleted</del></p>", "emphasisextras|advanced");
         }
     }
+
         // ## Superscript and Subscript
+
         //
+
         // Superscripts can be written by surrounding a text by ^ characters; subscripts can be written by surrounding the subscripted text by ~ characters
+
     [TestFixture]
     public partial class TestExtensionsSuperscriptandSubscript
     {
@@ -17721,7 +21246,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("H~2~O is a liquid. 2^10^ is 1024", "<p>H<sub>2</sub>O is a liquid. 2<sup>10</sup> is 1024</p>", "emphasisextras|advanced");
         }
     }
+
         // Certain punctuation characters are exempted from the rule forbidding them within inline delimiters
+
     [TestFixture]
     public partial class TestExtensionsSuperscriptandSubscript
     {
@@ -17744,9 +21271,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("One quintillionth can be expressed as 10^-18^\n\nDaggers^†^ and double-daggers^‡^ can be used to denote notes.", "<p>One quintillionth can be expressed as 10<sup>-18</sup></p>\n<p>Daggers<sup>†</sup> and double-daggers<sup>‡</sup> can be used to denote notes.</p>", "emphasisextras|advanced");
         }
     }
+
         // ## Inserted
+
         //
+
         // Inserted text can be used to specify that a text has been added to a document.  The semantic used for the generated HTML is the tag `<ins>`.
+
     [TestFixture]
     public partial class TestExtensionsInserted
     {
@@ -17766,9 +21297,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("++Inserted text++", "<p><ins>Inserted text</ins></p>", "emphasisextras|advanced");
         }
     }
+
         // ## Marked
+
         //
+
         // Marked text can be used to specify that a text has been marked in a document.  The semantic used for the generated HTML is the tag `<mark>`.
+
     [TestFixture]
     public partial class TestExtensionsMarked
     {
@@ -17788,7 +21323,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("==Marked text==", "<p><mark>Marked text</mark></p>", "emphasisextras|advanced");
         }
     }
+
         // ## Emphasis on Html Entities
+
     [TestFixture]
     public partial class TestExtensionsEmphasisonHtmlEntities
     {
@@ -17812,13 +21349,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is text MyBrand ^&reg;^ and MyTrademark ^&trade;^\nThis is text MyBrand^&reg;^ and MyTrademark^&trade;^\nThis is text MyBrand~&reg;~ and MyCopyright^&copy;^", "<p>This is text MyBrand <sup>®</sup> and MyTrademark <sup>TM</sup>\nThis is text MyBrand<sup>®</sup> and MyTrademark<sup>TM</sup>\nThis is text MyBrand<sub>®</sub> and MyCopyright<sup>©</sup></p>", "emphasisextras|advanced");
         }
     }
+
         // # Extensions
+
         //
+
         // This section describes the different extensions supported:
+
         //
+
         // ## Hardline break
+
         //
+
         // When this extension is used, a new line in a paragraph block will result in a hardline break `<br>`:
+
     [TestFixture]
     public partial class TestExtensionsHardlinebreak
     {
@@ -17840,43 +21385,81 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a paragraph\nwith a break inside", "<p>This is a paragraph<br />\nwith a break inside</p>", "hardlinebreak|advanced+hardlinebreak");
         }
     }
+
         // # Extensions
+
         //
+
         // This section describes the different extensions supported:
+
         //
+
         // ## Grid Table
+
         //
+
         // A grid table allows to have multiple lines per cells and allows to span cells over multiple columns. The following shows a simple grid table
+
         //
+
         // ```
+
         // +---------+---------+
+
         // | Header  | Header  |
+
         // | Column1 | Column2 |
+
         // +=========+=========+
+
         // | 1. ab   | > This is a quote
+
         // | 2. cde  | > For the second column
+
         // | 3. f    |
+
         // +---------+---------+
+
         // | Second row spanning
+
         // | on two columns
+
         // +---------+---------+
+
         // | Back    |         |
+
         // | to      |         |
+
         // | one     |         |
+
         // | column  |         |
+
         // ```
+
         //
+
         // **Rule #1**
+
         // The first line of a grid table must a **row separator**. It must start with the column separator character `+` used to separate columns in a row separator. Each column separator is:
+
         // - starting by optional spaces
+
         // - followed by an optional `:` to specify left align, followed by optional spaces
+
         // - followed by a sequence of at least one `-` character, followed by optional spaces
+
         // - followed by an optional `:` to specify right align (or center align if left align is also defined)
+
         // - ending by optional spaces
+
         //
+
         // The first row separator must be followed by a *regular row*. A regular row must start with the character `|` that is starting at the same position than the column separator `+` of the first row separator.
+
         //
+
         // The following is a valid row separator
+
     [TestFixture]
     public partial class TestExtensionsGridTable
     {
@@ -17906,7 +21489,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("+---------+---------+\n| This is | a table |", "<table>\n<col style=\"width:50%\">\n<col style=\"width:50%\">\n<tbody>\n<tr>\n<td>This is</td>\n<td>a table</td>\n</tr>\n</tbody>\n</table>", "gridtables|advanced");
         }
     }
+
         // The following is not a valid row separator
+
     [TestFixture]
     public partial class TestExtensionsGridTable
     {
@@ -17928,8 +21513,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("|-----xxx----+---------+\n| This is    | not a table", "<p>|-----xxx----+---------+\n| This is    | not a table</p>", "gridtables|advanced");
         }
     }
+
         // **Rule #2**
+
         // A regular row can continue a previous regular row when column separator `|` are positioned at the same  position than the previous line. If they are positioned at the same location, the column may span over multiple columns:
+
     [TestFixture]
     public partial class TestExtensionsGridTable
     {
@@ -17974,7 +21562,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("+---------+---------+---------+\n| Col1    | Col2    | Col3    |\n| Col1a   | Col2a   | Col3a   |\n| Col1b             | Col3b   |\n| Col1c                       |", "<table>\n<col style=\"width:33.33%\">\n<col style=\"width:33.33%\">\n<col style=\"width:33.33%\">\n<tbody>\n<tr>\n<td>Col1\nCol1a</td>\n<td>Col2\nCol2a</td>\n<td>Col3\nCol3a</td>\n</tr>\n<tr>\n<td colspan=\"2\">Col1b</td>\n<td>Col3b</td>\n</tr>\n<tr>\n<td colspan=\"3\">Col1c</td>\n</tr>\n</tbody>\n</table>", "gridtables|advanced");
         }
     }
+
         // A row header is separated using `+========+` instead of `+---------+`:
+
     [TestFixture]
     public partial class TestExtensionsGridTable
     {
@@ -18005,7 +21595,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("+---------+---------+\n| This is | a table |\n+=========+=========+", "<table>\n<col style=\"width:50%\">\n<col style=\"width:50%\">\n<thead>\n<tr>\n<th>This is</th>\n<th>a table</th>\n</tr>\n</thead>\n</table>", "gridtables|advanced");
         }
     }
+
         // The last column separator `|` may be omitted:
+
     [TestFixture]
     public partial class TestExtensionsGridTable
     {
@@ -18035,15 +21627,25 @@ namespace Markdig.Tests
 			TestParser.TestSpec("+---------+---------+\n| This is | a table with a longer text in the second column", "<table>\n<col style=\"width:50%\">\n<col style=\"width:50%\">\n<tbody>\n<tr>\n<td>This is</td>\n<td>a table with a longer text in the second column</td>\n</tr>\n</tbody>\n</table>", "gridtables|advanced");
         }
     }
+
         // The respective width of the columns are calculated from the ratio between the total size of the first table row without counting the `+`: `+----+--------+----+` would be divided between:
+
         //
+
         // Total size is : 16
+
         //
+
         // - `----` -> 4
+
         // - `--------` -> 8
+
         // - `----` -> 4
+
         //
+
         // So the width would be 4/16 = 25%, 8/16 = 50%, 4/16 = 25%
+
     [TestFixture]
     public partial class TestExtensionsGridTable
     {
@@ -18076,7 +21678,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("+----+--------+----+\n| A  |  B C D | E  |\n+----+--------+----+", "<table>\n<col style=\"width:25%\">\n<col style=\"width:50%\">\n<col style=\"width:25%\">\n<tbody>\n<tr>\n<td>A</td>\n<td>B C D</td>\n<td>E</td>\n</tr>\n</tbody>\n</table>", "gridtables|advanced");
         }
     }
+
         // Alignment might be specified on the first row using the character `:`:
+
     [TestFixture]
     public partial class TestExtensionsGridTable
     {
@@ -18109,7 +21713,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("+-----+:---:+-----+\n|  A  |  B  |  C  |\n+-----+-----+-----+", "<table>\n<col style=\"width:33.33%\">\n<col style=\"width:33.33%\">\n<col style=\"width:33.33%\">\n<tbody>\n<tr>\n<td>A</td>\n<td style=\"text-align: center;\">B</td>\n<td>C</td>\n</tr>\n</tbody>\n</table>", "gridtables|advanced");
         }
     }
+
         // A grid table may have cells spanning both columns and rows:
+
     [TestFixture]
     public partial class TestExtensionsGridTable
     {
@@ -18156,7 +21762,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("+---+---+---+\n| AAAAA | B |\n+---+---+ B +\n| D | E | B |\n+ D +---+---+\n| D | CCCCC |\n+---+---+---+", "<table>\n<col style=\"width:33.33%\">\n<col style=\"width:33.33%\">\n<col style=\"width:33.33%\">\n<tbody>\n<tr>\n<td colspan=\"2\">AAAAA</td>\n<td rowspan=\"2\">B\nB\nB</td>\n</tr>\n<tr>\n<td rowspan=\"2\">D\nD\nD</td>\n<td>E</td>\n</tr>\n<tr>\n<td colspan=\"2\">CCCCC</td>\n</tr>\n</tbody>\n</table>", "gridtables|advanced");
         }
     }
+
         // A grid table may have cells with both colspan and rowspan:
+
     [TestFixture]
     public partial class TestExtensionsGridTable
     {
@@ -18202,7 +21810,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("+---+---+---+\n| AAAAA | B |\n+ AAAAA +---+\n| AAAAA | C |\n+---+---+---+\n| D | E | F |\n+---+---+---+", "<table>\n<col style=\"width:33.33%\">\n<col style=\"width:33.33%\">\n<col style=\"width:33.33%\">\n<tbody>\n<tr>\n<td colspan=\"2\" rowspan=\"2\">AAAAA\nAAAAA\nAAAAA</td>\n<td>B</td>\n</tr>\n<tr>\n<td>C</td>\n</tr>\n<tr>\n<td>D</td>\n<td>E</td>\n<td>F</td>\n</tr>\n</tbody>\n</table>", "gridtables|advanced");
         }
     }
+
         // A grid table may not have irregularly shaped cells:
+
     [TestFixture]
     public partial class TestExtensionsGridTable
     {
@@ -18234,7 +21844,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("+---+---+---+\n| AAAAA | B |\n+ A +---+ B +\n| A | C | B |\n+---+---+---+\n| DDDDD | E |\n+---+---+---+", "<p>+---+---+---+\n| AAAAA | B |\n+ A +---+ B +\n| A | C | B |\n+---+---+---+\n| DDDDD | E |\n+---+---+---+</p>", "gridtables|advanced");
         }
     }
+
         // An empty `+` on a line should result in a simple empty list output:
+
     [TestFixture]
     public partial class TestExtensionsGridTable
     {
@@ -18256,13 +21868,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("+", "<ul>\n<li></li>\n</ul>", "gridtables|advanced");
         }
     }
+
         // # Extensions
+
         //
+
         // This section describes the different extensions supported:
+
         //
+
         // ## Custom Container
+
         //
-        // A custom container is similar to a fenced code block, but it is using the character `:` to declare a block (with at least 3 characters), and instead of generating a `<pre><code>...</code></pre>` it will generate a `<div>...</dib>` block.
+
+        // A custom container is similar to a fenced code block, but it is using the character `:` to declare a block (with at least 3 characters), and instead of generating a `<pre><code>...</code></pre>` it will generate a `<div>...</div>` block.
+
     [TestFixture]
     public partial class TestExtensionsCustomContainer
     {
@@ -18285,7 +21905,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec(":::spoiler\nThis is a *spoiler*\n:::", "<div class=\"spoiler\"><p>This is a <em>spoiler</em></p>\n</div>", "customcontainers+attributes|advanced");
         }
     }
+
         // The text following the opened custom container is optional:
+
     [TestFixture]
     public partial class TestExtensionsCustomContainer
     {
@@ -18308,7 +21930,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec(":::\nThis is a regular div\n:::", "<div><p>This is a regular div</p>\n</div>", "customcontainers+attributes|advanced");
         }
     }
+
         // Like for fenced code block, you can use more than 3 `:` characters as long as the closing has the same number of characters:
+
     [TestFixture]
     public partial class TestExtensionsCustomContainer
     {
@@ -18331,7 +21955,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("::::::::::::spoiler\nThis is a spoiler\n::::::::::::", "<div class=\"spoiler\"><p>This is a spoiler</p>\n</div>", "customcontainers+attributes|advanced");
         }
     }
+
         // Like for fenced code block, a custom container can span over multiple empty lines in a list block:
+
     [TestFixture]
     public partial class TestExtensionsCustomContainer
     {
@@ -18367,7 +21993,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- This is a list\n  :::spoiler\n  This is a spoiler\n  - item1\n  - item2\n  :::\n- A second item in the list", "<ul>\n<li>This is a list\n<div class=\"spoiler\">This is a spoiler\n<ul>\n<li>item1</li>\n<li>item2</li>\n</ul>\n</div>\n</li>\n<li>A second item in the list</li>\n</ul>", "customcontainers+attributes|advanced");
         }
     }
+
         // Attributes extension is also supported for Custom Container, as long as the Attributes extension is activated after the CustomContainer extension (`.UseCustomContainer().UseAttributes()`)
+
     [TestFixture]
     public partial class TestExtensionsCustomContainer
     {
@@ -18390,7 +22018,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec(":::spoiler {#myspoiler myprop=yes}\nThis is a spoiler\n:::", "<div id=\"myspoiler\" class=\"spoiler\" myprop=\"yes\"><p>This is a spoiler</p>\n</div>", "customcontainers+attributes|advanced");
         }
     }
+
         // The content of a custom container can contain any blocks:
+
     [TestFixture]
     public partial class TestExtensionsCustomContainer
     {
@@ -18413,9 +22043,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec(":::mycontainer\n<p>This is a raw spoiler</p>\n:::", "<div class=\"mycontainer\"><p>This is a raw spoiler</p>\n</div>", "customcontainers+attributes|advanced");
         }
     }
+
         // ## Inline Custom Container
+
         //
+
         // A custom container can also be used within an inline container (e.g: paragraph, heading...) by enclosing a text by a new emphasis `::`
+
     [TestFixture]
     public partial class TestExtensionsInlineCustomContainer
     {
@@ -18435,7 +22069,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a text ::with special emphasis::", "<p>This is a text <span>with special emphasis</span></p>", "customcontainers+attributes|advanced");
         }
     }
+
         // Any other emphasis inline can be used within this emphasis inline container:
+
     [TestFixture]
     public partial class TestExtensionsInlineCustomContainer
     {
@@ -18455,7 +22091,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a text ::with special *emphasis*::", "<p>This is a text <span>with special <em>emphasis</em></span></p>", "customcontainers+attributes|advanced");
         }
     }
+
         // Attributes can be attached to a inline custom container:
+
     [TestFixture]
     public partial class TestExtensionsInlineCustomContainer
     {
@@ -18475,13 +22113,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a text ::with special emphasis::{#myId .myemphasis}", "<p>This is a text <span id=\"myId\" class=\"myemphasis\">with special emphasis</span></p>", "customcontainers+attributes|advanced");
         }
     }
+
         // # Extensions
+
         //
+
         // This section describes the different extensions supported:
+
         //
+
         // ## Definition lists
+
         //
+
         // A custom container is similar to a fenced code block, but it is using the character `:` to declare a block (with at least 3 characters), and instead of generating a `<pre><code>...</code></pre>` it will generate a `<div>...</dib>` block.
+
     [TestFixture]
     public partial class TestExtensionsDefinitionlists
     {
@@ -18541,7 +22187,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Term 1\n:   This is a definition item\n    With a paragraph\n    > This is a block quote\n\n    - This is a list\n    - with an item2\n\n    ```java\n    Test\n\n\n    ```\n\n    And a last line\n:   This ia another definition item\n\nTerm2\nTerm3 *with some inline*\n:   This is another definition for term2", "<dl>\n<dt>Term 1</dt>\n<dd><p>This is a definition item\nWith a paragraph</p>\n<blockquote>\n<p>This is a block quote</p>\n</blockquote>\n<ul>\n<li>This is a list</li>\n<li>with an item2</li>\n</ul>\n<pre><code class=\"language-java\">Test\n\n\n</code></pre>\n<p>And a last line</p>\n</dd>\n<dd>This ia another definition item</dd>\n<dt>Term2</dt>\n<dt>Term3 <em>with some inline</em></dt>\n<dd>This is another definition for term2</dd>\n</dl>", "definitionlists+attributes|advanced");
         }
     }
+
         // A definition term can be followed at most by one blank line. Lazy continuations are supported for definitions:
+
     [TestFixture]
     public partial class TestExtensionsDefinitionlists
     {
@@ -18572,7 +22220,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Term 1\n\n:   Definition\nwith lazy continuation.\n\n    Second paragraph of the definition.", "<dl>\n<dt>Term 1</dt>\n<dd><p>Definition\nwith lazy continuation.</p>\n<p>Second paragraph of the definition.</p>\n</dd>\n</dl>", "definitionlists+attributes|advanced");
         }
     }
+
         // The definition must be indented to 4 characters including the `:`.
+
     [TestFixture]
     public partial class TestExtensionsDefinitionlists
     {
@@ -18594,7 +22244,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Term 1\n:  Invalid with less than 3 characters", "<p>Term 1\n:  Invalid with less than 3 characters</p>", "definitionlists+attributes|advanced");
         }
     }
+
         // The `:` can be indented up to 3 spaces:
+
     [TestFixture]
     public partial class TestExtensionsDefinitionlists
     {
@@ -18618,7 +22270,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Term 1\n   : Valid even if `:` starts at most 3 spaces", "<dl>\n<dt>Term 1</dt>\n<dd>Valid even if <code>:</code> starts at most 3 spaces</dd>\n</dl>", "definitionlists+attributes|advanced");
         }
     }
+
         // But more than 3 spaces before `:` will trigger an indented code block:
+
     [TestFixture]
     public partial class TestExtensionsDefinitionlists
     {
@@ -18642,7 +22296,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Term 1\n\n    : Not valid", "<p>Term 1</p>\n<pre><code>: Not valid\n</code></pre>", "definitionlists+attributes|advanced");
         }
     }
+
         // Definition lists can be nested inside list items
+
     [TestFixture]
     public partial class TestExtensionsDefinitionlists
     {
@@ -18679,13 +22335,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("1.  First\n    \n2.  Second\n    \n    Term 1\n    :   Definition\n    \n    Term 2\n    :   Second Definition", "<ol>\n<li><p>First</p></li>\n<li><p>Second</p>\n<dl>\n<dt>Term 1</dt>\n<dd>Definition</dd>\n<dt>Term 2</dt>\n<dd>Second Definition</dd>\n</dl></li>\n</ol>", "definitionlists+attributes|advanced");
         }
     }
+
         // # Extensions
+
         //
+
         // This section describes the different extensions supported:
+
         //
+
         // ## Emoji
+
         //
+
         // Emoji and smiley can be converted to their respective unicode characters:
+
     [TestFixture]
     public partial class TestExtensionsEmoji
     {
@@ -18705,7 +22369,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a test with a :) and a :angry: smiley", "<p>This is a test with a 😃 and a 😠 smiley</p>", "emojis|advanced+emojis");
         }
     }
+
         // An emoji needs to be preceded by a space:
+
     [TestFixture]
     public partial class TestExtensionsEmoji
     {
@@ -18725,7 +22391,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("These are not:) an emoji with a:) x:angry:x", "<p>These are not:) an emoji with a:) x:angry:x</p>", "emojis|advanced+emojis");
         }
     }
+
         // Emoji can be followed by close ponctuation (or any other characters):
+
     [TestFixture]
     public partial class TestExtensionsEmoji
     {
@@ -18745,7 +22413,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("We all need :), it makes us :muscle:. (and :ok_hand:).", "<p>We all need 😃, it makes us 💪. (and 👌).</p>", "emojis|advanced+emojis");
         }
     }
+
         // Sentences can end with Emoji:
+
     [TestFixture]
     public partial class TestExtensionsEmoji
     {
@@ -18767,15 +22437,25 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a sentence :ok_hand:\nand keeps going to the next line :)", "<p>This is a sentence 👌\nand keeps going to the next line 😃</p>", "emojis|advanced+emojis");
         }
     }
+
         // # Extensions
+
         //
+
         // This section describes the different extensions supported:
+
         //
+
         // ## Abbreviation
+
         //
+
         // Abbreviation can be declared by using the `*[Abbreviation Label]: Abbreviation description`
+
         //
+
         // Abbreviation definition will be removed from the original document. Any Abbreviation label found in literals will be replaced by the abbreviation description:
+
     [TestFixture]
     public partial class TestExtensionsAbbreviation
     {
@@ -18797,7 +22477,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*[HTML]: Hypertext Markup Language\n\nLater in a text we are using HTML and it becomes an abbr tag HTML", "<p>Later in a text we are using <abbr title=\"Hypertext Markup Language\">HTML</abbr> and it becomes an abbr tag <abbr title=\"Hypertext Markup Language\">HTML</abbr></p>", "abbreviations|advanced");
         }
     }
+
         // An abbreviation definition can be indented at most 3 spaces
+
     [TestFixture]
     public partial class TestExtensionsAbbreviation
     {
@@ -18819,7 +22501,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*[HTML]: Hypertext Markup Language\n    *[This]: is not an abbreviation", "<pre><code>*[This]: is not an abbreviation\n</code></pre>", "abbreviations|advanced");
         }
     }
+
         // An abbreviation may contain spaces:
+
     [TestFixture]
     public partial class TestExtensionsAbbreviation
     {
@@ -18841,7 +22525,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*[SUPER HTML]: Super Hypertext Markup Language\n\nThis is a SUPER HTML document    ", "<p>This is a <abbr title=\"Super Hypertext Markup Language\">SUPER HTML</abbr> document</p>", "abbreviations|advanced");
         }
     }
+
         // Abbreviation may contain any unicode characters:
+
     [TestFixture]
     public partial class TestExtensionsAbbreviation
     {
@@ -18863,7 +22549,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*[😃 HTML]: Hypertext Markup Language\n\nThis is a 😃 HTML document    ", "<p>This is a <abbr title=\"Hypertext Markup Language\">😃 HTML</abbr> document</p>", "abbreviations|advanced");
         }
     }
+
         // Abbreviations may be similar:
+
     [TestFixture]
     public partial class TestExtensionsAbbreviation
     {
@@ -18887,7 +22575,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*[1A]: First\n*[1A1]: Second\n*[1A2]: Third\n\nWe can abbreviate 1A, 1A1 and 1A2!", "<p>We can abbreviate <abbr title=\"First\">1A</abbr>, <abbr title=\"Second\">1A1</abbr> and <abbr title=\"Third\">1A2</abbr>!</p>", "abbreviations|advanced");
         }
     }
+
         // Abbreviations should match whole word only:
+
     [TestFixture]
     public partial class TestExtensionsAbbreviation
     {
@@ -18909,7 +22599,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*[1A]: First\n\nWe should not abbreviate 1.1A or 11A!", "<p>We should not abbreviate 1.1A or 11A!</p>", "abbreviations|advanced");
         }
     }
+
         // Abbreviations should match whole word only, even if the word is the entire content:
+
     [TestFixture]
     public partial class TestExtensionsAbbreviation
     {
@@ -18931,7 +22623,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*[1A]: First\n\n1.1A", "<p>1.1A</p>", "abbreviations|advanced");
         }
     }
+
         // Abbreviations should match whole word only, even if there is another glossary term:
+
     [TestFixture]
     public partial class TestExtensionsAbbreviation
     {
@@ -18954,7 +22648,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*[SCO]: First\n*[SCOM]: Second\n\nSCOM", "<p><abbr title=\"Second\">SCOM</abbr></p>", "abbreviations|advanced");
         }
     }
+
         // Abbreviations should only match when surrounded by whitespace:
+
     [TestFixture]
     public partial class TestExtensionsAbbreviation
     {
@@ -18976,13 +22672,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("*[PR]: Pull Request\n\nPRAA", "<p>PRAA</p>", "abbreviations|advanced");
         }
     }
+
         // # Extensions
+
         //
+
         // The following additional list items are supported:
+
         //
+
         // ## Ordered list with alpha letter
+
         //
+
         // Allows to use a list using an alpha letter instead of a number
+
     [TestFixture]
     public partial class TestExtensionsOrderedlistwithalphaletter
     {
@@ -19008,7 +22712,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a. First item\nb. Second item\nc. Last item", "<ol type=\"a\">\n<li>First item</li>\n<li>Second item</li>\n<li>Last item</li>\n</ol>", "listextras|advanced");
         }
     }
+
         // It works also for uppercase alpha:
+
     [TestFixture]
     public partial class TestExtensionsOrderedlistwithalphaletter
     {
@@ -19034,7 +22740,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("A. First item\nB. Second item\nC. Last item", "<ol type=\"A\">\n<li>First item</li>\n<li>Second item</li>\n<li>Last item</li>\n</ol>", "listextras|advanced");
         }
     }
+
         // Like for numbered list, a list can start with a different letter
+
     [TestFixture]
     public partial class TestExtensionsOrderedlistwithalphaletter
     {
@@ -19058,7 +22766,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("b. First item\nc. Second item", "<ol type=\"a\" start=\"2\">\n<li>First item</li>\n<li>Second item</li>\n</ol>", "listextras|advanced");
         }
     }
+
         // A different type of list will break the existing list:
+
     [TestFixture]
     public partial class TestExtensionsOrderedlistwithalphaletter
     {
@@ -19086,9 +22796,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a. First item1\nb. Second item\nA. First item2", "<ol type=\"a\">\n<li>First item1</li>\n<li>Second item</li>\n</ol>\n<ol type=\"A\">\n<li>First item2</li>\n</ol>", "listextras|advanced");
         }
     }
+
         // ## Ordered list with roman letter
+
         //
+
         // Allows to use a list using a roman number instead of a number.
+
     [TestFixture]
     public partial class TestExtensionsOrderedlistwithromanletter
     {
@@ -19116,7 +22830,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("i. First item\nii. Second item\niii. Third item\niv. Last item", "<ol type=\"i\">\n<li>First item</li>\n<li>Second item</li>\n<li>Third item</li>\n<li>Last item</li>\n</ol>", "listextras|advanced");
         }
     }
+
         // It works also for uppercase alpha:
+
     [TestFixture]
     public partial class TestExtensionsOrderedlistwithromanletter
     {
@@ -19144,7 +22860,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("I. First item\nII. Second item\nIII. Third item\nIV. Last item", "<ol type=\"I\">\n<li>First item</li>\n<li>Second item</li>\n<li>Third item</li>\n<li>Last item</li>\n</ol>", "listextras|advanced");
         }
     }
+
         // Like for numbered list, a list can start with a different letter
+
     [TestFixture]
     public partial class TestExtensionsOrderedlistwithromanletter
     {
@@ -19168,7 +22886,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("ii. First item\niii. Second item", "<ol type=\"i\" start=\"2\">\n<li>First item</li>\n<li>Second item</li>\n</ol>", "listextras|advanced");
         }
     }
+
         // Lists can be restarted, specifying the start point.
+
     [TestFixture]
     public partial class TestExtensionsOrderedlistwithromanletter
     {
@@ -19198,13 +22918,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("1.   First item\n\nSome text\n\n2.   Second item", "<ol>\n<li>First item</li>\n</ol>\n<p>Some text</p>\n<ol start=\"2\">\n<li>Second item</li>\n</ol>", "listextras|advanced");
         }
     }
+
         // # Extensions
+
         //
+
         // The following the figure extension:
+
         //
+
         // ## Figures
+
         //
+
         // A figure can be defined by using a pattern equivalent to a fenced code block but with the character `^`
+
     [TestFixture]
     public partial class TestExtensionsFigures
     {
@@ -19229,9 +22957,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("^^^\nThis is a figure\n^^^ This is a *caption*", "<figure>\n<p>This is a figure</p>\n<figcaption>This is a <em>caption</em></figcaption>\n</figure>", "figures+footers+citations|advanced");
         }
     }
+
         // ## Footers
+
         //
+
         // A footer equivalent to a block quote parsing but starts with double character ^^
+
     [TestFixture]
     public partial class TestExtensionsFooters
     {
@@ -19253,9 +22985,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("^^ This is a footer\n^^ multi-line", "<footer>This is a footer\nmulti-line</footer>", "figures+footers+citations|advanced");
         }
     }
+
         // ## Cite
+
         //
+
         // A cite is working like an emphasis but using the double character ""
+
     [TestFixture]
     public partial class TestExtensionsCite
     {
@@ -19275,13 +23011,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a \"\"citation of someone\"\"", "<p>This is a <cite>citation of someone</cite></p>", "figures+footers+citations|advanced");
         }
     }
+
         // # Extensions
+
         //
+
         // Adds support for mathematics spans:
+
         //
+
         // ## Math Inline
+
         //
+
         // Allows to define a mathematic block embraced by `$...$`
+
     [TestFixture]
     public partial class TestExtensionsMathInline
     {
@@ -19301,7 +23045,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a $math block$", "<p>This is a <span class=\"math\">math block</span></p>", "mathematics|advanced");
         }
     }
+
         // Or by `$$...$$` embracing it by:
+
     [TestFixture]
     public partial class TestExtensionsMathInline
     {
@@ -19321,7 +23067,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a $$math block$$", "<p>This is a <span class=\"math\">math block</span></p>", "mathematics|advanced");
         }
     }
+
         // Newlines inside an inline math are not allowed:
+
     [TestFixture]
     public partial class TestExtensionsMathInline
     {
@@ -19343,6 +23091,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is not a $$math \nblock$$ and? this is a $$math block$$", "<p>This is not a $$math\nblock$$ and? this is a <span class=\"math\">math block</span></p>", "mathematics|advanced");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsMathInline
     {
@@ -19364,7 +23113,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is not a $math \nblock$ and? this is a $math block$", "<p>This is not a $math\nblock$ and? this is a <span class=\"math\">math block</span></p>", "mathematics|advanced");
         }
     }
+
         // An opening `$` can be followed by a space if the closing is also preceded by a space `$`:
+
     [TestFixture]
     public partial class TestExtensionsMathInline
     {
@@ -19384,6 +23135,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a $ math block $", "<p>This is a <span class=\"math\">math block</span></p>", "mathematics|advanced");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsMathInline
     {
@@ -19403,6 +23155,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a $    math block     $ after", "<p>This is a <span class=\"math\">math block</span> after</p>", "mathematics|advanced");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsMathInline
     {
@@ -19422,6 +23175,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a $$    math block     $$ after", "<p>This is a <span class=\"math\">math block</span> after</p>", "mathematics|advanced");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsMathInline
     {
@@ -19441,7 +23195,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a not $ math block$ because there is not a whitespace before the closing", "<p>This is a not $ math block$ because there is not a whitespace before the closing</p>", "mathematics|advanced");
         }
     }
+
         // For the opening `$` it requires a space or a punctuation before (but cannot be used within a word):
+
     [TestFixture]
     public partial class TestExtensionsMathInline
     {
@@ -19461,7 +23217,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is not a m$ath block$", "<p>This is not a m$ath block$</p>", "mathematics|advanced");
         }
     }
+
         // For the closing `$` it requires a space after or a punctuation (but cannot be preceded by a space and cannot be used within a word):
+
     [TestFixture]
     public partial class TestExtensionsMathInline
     {
@@ -19481,7 +23239,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is not a $math bloc$k", "<p>This is not a $math bloc$k</p>", "mathematics|advanced");
         }
     }
+
         // For the closing `$` it requires a space after or a punctuation (but cannot be preceded by a space and cannot be used within a word):
+
     [TestFixture]
     public partial class TestExtensionsMathInline
     {
@@ -19501,7 +23261,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is should not match a 16$ or a $15", "<p>This is should not match a 16$ or a $15</p>", "mathematics|advanced");
         }
     }
+
         // A `$` can be escaped between a math inline block by using the escape `\\`
+
     [TestFixture]
     public partial class TestExtensionsMathInline
     {
@@ -19521,7 +23283,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a $math \\$ block$", "<p>This is a <span class=\"math\">math \\$ block</span></p>", "mathematics|advanced");
         }
     }
+
         // At most, two `$` will be matched for the opening and closing:
+
     [TestFixture]
     public partial class TestExtensionsMathInline
     {
@@ -19541,7 +23305,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a $$$math block$$$", "<p>This is a <span class=\"math\">$math block$</span></p>", "mathematics|advanced");
         }
     }
+
         // Regular text can come both before and after the math inline
+
     [TestFixture]
     public partial class TestExtensionsMathInline
     {
@@ -19561,7 +23327,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a $math block$ with text on both sides.", "<p>This is a <span class=\"math\">math block</span> with text on both sides.</p>", "mathematics|advanced");
         }
     }
+
         // A mathematic block takes precedence over standard emphasis `*` `_`:
+
     [TestFixture]
     public partial class TestExtensionsMathInline
     {
@@ -19581,7 +23349,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is *a $math* block$", "<p>This is *a <span class=\"math\">math* block</span></p>", "mathematics|advanced");
         }
     }
+
         // An opening $$ at the beginning of a line should not be interpreted as a Math block:
+
     [TestFixture]
     public partial class TestExtensionsMathInline
     {
@@ -19601,10 +23371,15 @@ namespace Markdig.Tests
 			TestParser.TestSpec("$$ math $$ starting at a line", "<p><span class=\"math\">math</span> starting at a line</p>", "mathematics|advanced");
         }
     }
+
         // ## Math Block
+
         //
+
         // The match block can spawn on multiple lines by having a $$ starting on a line.
+
         // It is working as a fenced code block.
+
     [TestFixture]
     public partial class TestExtensionsMathBlock
     {
@@ -19633,13 +23408,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("$$\n\\begin{equation}\n  \\int_0^\\infty \\frac{x^3}{e^x-1}\\,dx = \\frac{\\pi^4}{15}\n  \\label{eq:sample}\n\\end{equation}\n$$", "<div class=\"math\">\\begin{equation}\n  \\int_0^\\infty \\frac{x^3}{e^x-1}\\,dx = \\frac{\\pi^4}{15}\n  \\label{eq:sample}\n\\end{equation}\n</div>", "mathematics|advanced");
         }
     }
+
         // # Extensions
+
         //
+
         // Adds support for outputing bootstrap ready tags:
+
         //
+
         // ## Bootstrap
+
         //
+
         // Adds bootstrap `.table` class to `<table>`:
+
     [TestFixture]
     public partial class TestExtensionsBootstrap
     {
@@ -19674,7 +23457,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Name | Value\n-----| -----\nAbc  | 16", "<table class=\"table\">\n<thead>\n<tr>\n<th>Name</th>\n<th>Value</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>Abc</td>\n<td>16</td>\n</tr>\n</tbody>\n</table>", "bootstrap+pipetables+figures+attributes");
         }
     }
+
         // Adds bootstrap `.blockquote` class to `<blockquote>`:
+
     [TestFixture]
     public partial class TestExtensionsBootstrap
     {
@@ -19696,7 +23481,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("> This is a blockquote", "<blockquote class=\"blockquote\">\n<p>This is a blockquote</p>\n</blockquote>", "bootstrap+pipetables+figures+attributes");
         }
     }
+
         // Adds bootstrap `.figure` class to `<figure>` and `.figure-caption` to `<figcaption>`
+
     [TestFixture]
     public partial class TestExtensionsBootstrap
     {
@@ -19721,7 +23508,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("^^^\nThis is a text in a caption\n^^^ This is the caption", "<figure class=\"figure\">\n<p>This is a text in a caption</p>\n<figcaption class=\"figure-caption\">This is the caption</figcaption>\n</figure>", "bootstrap+pipetables+figures+attributes");
         }
     }
+
         // Adds the `.img-fluid` class to all image links `<img>`
+
     [TestFixture]
     public partial class TestExtensionsBootstrap
     {
@@ -19741,13 +23530,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![Image Link](/url)", "<p><img src=\"/url\" class=\"img-fluid\" alt=\"Image Link\" /></p>", "bootstrap+pipetables+figures+attributes");
         }
     }
+
         // # Extensions
+
         //
+
         // Adds support for media links:
+
         //
+
         // ## Media links
+
         //
+
         // Allows to embed audio/video links to popular website:
+
     [TestFixture]
     public partial class TestExtensionsMedialinks
     {
@@ -19779,13 +23576,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![Video1](https://www.youtube.com/watch?v=mswPy5bt3TQ)\n\n![Video2](https://vimeo.com/8607834)\n\n![Video3](https://sample.com/video.mp4)\n\n![Audio4](https://music.yandex.ru/album/411845/track/4402274)\n\n![Video5](https://ok.ru/video/26870090463)", "<p><iframe src=\"https://www.youtube.com/embed/mswPy5bt3TQ\" width=\"500\" height=\"281\" frameborder=\"0\" allowfullscreen></iframe></p>\n<p><iframe src=\"https://player.vimeo.com/video/8607834\" width=\"500\" height=\"281\" frameborder=\"0\" allowfullscreen></iframe></p>\n<p><video width=\"500\" height=\"281\" controls><source type=\"video/mp4\" src=\"https://sample.com/video.mp4\"></source></video></p>\n<p><iframe src=\"https://music.yandex.ru/iframe/#track/4402274/411845/\" width=\"500\" height=\"281\" frameborder=\"0\"></iframe></p>\n<p><iframe src=\"https://ok.ru/videoembed/26870090463\" width=\"500\" height=\"281\" frameborder=\"0\" allowfullscreen></iframe></p>", "medialinks|advanced+medialinks");
         }
     }
+
         // # Extensions
+
         //
+
         // Adds support for smarty pants:
+
         //
+
         // ## SmartyPants Quotes
+
         //
+
         // Converts the following character to smarty pants:
+
     [TestFixture]
     public partial class TestExtensionsSmartyPantsQuotes
     {
@@ -19805,6 +23610,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a \"text\"", "<p>This is a &ldquo;text&rdquo;</p>", "pipetables+smartypants|advanced+smartypants");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsSmartyPantsQuotes
     {
@@ -19824,6 +23630,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a 'text'", "<p>This is a &lsquo;text&rsquo;</p>", "pipetables+smartypants|advanced+smartypants");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsSmartyPantsQuotes
     {
@@ -19843,7 +23650,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a <<text>>", "<p>This is a &laquo;text&raquo;</p>", "pipetables+smartypants|advanced+smartypants");
         }
     }
+
         // Unbalanced quotes are not changed:
+
     [TestFixture]
     public partial class TestExtensionsSmartyPantsQuotes
     {
@@ -19863,6 +23672,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a \"text", "<p>This is a &quot;text</p>", "pipetables+smartypants|advanced+smartypants");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsSmartyPantsQuotes
     {
@@ -19882,6 +23692,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a 'text", "<p>This is a 'text</p>", "pipetables+smartypants|advanced+smartypants");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsSmartyPantsQuotes
     {
@@ -19901,7 +23712,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a <<text", "<p>This is a &lt;&lt;text</p>", "pipetables+smartypants|advanced+smartypants");
         }
     }
+
         // Unbalanced quotes inside other quotes are not changed:
+
     [TestFixture]
     public partial class TestExtensionsSmartyPantsQuotes
     {
@@ -19921,6 +23734,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a \"text 'with\" a another text'", "<p>This is a &ldquo;text 'with&rdquo; a another text'</p>", "pipetables+smartypants|advanced+smartypants");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsSmartyPantsQuotes
     {
@@ -19940,6 +23754,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a 'text <<with' a another text>>", "<p>This is a &lsquo;text &lt;&lt;with&rsquo; a another text&gt;&gt;</p>", "pipetables+smartypants|advanced+smartypants");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsSmartyPantsQuotes
     {
@@ -19959,7 +23774,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a <<text 'with>> a another text'", "<p>This is a &laquo;text 'with&raquo; a another text'</p>", "pipetables+smartypants|advanced+smartypants");
         }
     }
+
         // Quotes requires to have the same rules than emphasis `_` regarding left/right frankling rules:
+
     [TestFixture]
     public partial class TestExtensionsSmartyPantsQuotes
     {
@@ -19979,6 +23796,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("It's not quotes'", "<p>It's not quotes'</p>", "pipetables+smartypants|advanced+smartypants");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsSmartyPantsQuotes
     {
@@ -19998,6 +23816,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("They are ' not matching quotes '", "<p>They are ' not matching quotes '</p>", "pipetables+smartypants|advanced+smartypants");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsSmartyPantsQuotes
     {
@@ -20017,7 +23836,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("They are' not matching 'quotes", "<p>They are' not matching 'quotes</p>", "pipetables+smartypants|advanced+smartypants");
         }
     }
+
         // An emphasis starting inside left/right quotes will span over the right quote:
+
     [TestFixture]
     public partial class TestExtensionsSmartyPantsQuotes
     {
@@ -20037,7 +23858,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is \"a *text\" with an emphasis*", "<p>This is &ldquo;a <em>text&rdquo; with an emphasis</em></p>", "pipetables+smartypants|advanced+smartypants");
         }
     }
+
         // ## SmartyPants Separators
+
     [TestFixture]
     public partial class TestExtensionsSmartyPantsSeparators
     {
@@ -20057,6 +23880,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a -- text", "<p>This is a &ndash; text</p>", "pipetables+smartypants|advanced+smartypants");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsSmartyPantsSeparators
     {
@@ -20076,6 +23900,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a --- text", "<p>This is a &mdash; text</p>", "pipetables+smartypants|advanced+smartypants");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsSmartyPantsSeparators
     {
@@ -20095,7 +23920,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a en ellipsis...", "<p>This is a en ellipsis&hellip;</p>", "pipetables+smartypants|advanced+smartypants");
         }
     }
+
         // Check that a smartypants are not breaking pipetable parsing:
+
     [TestFixture]
     public partial class TestExtensionsSmartyPantsSeparators
     {
@@ -20130,7 +23957,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("a  | b\n-- | --\n0  | 1", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "pipetables+smartypants|advanced+smartypants");
         }
     }
+
         // Check quotes and dash:
+
     [TestFixture]
     public partial class TestExtensionsSmartyPantsSeparators
     {
@@ -20150,13 +23979,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("A \"quote\" with a ---", "<p>A &ldquo;quote&rdquo; with a &mdash;</p>", "pipetables+smartypants|advanced+smartypants");
         }
     }
+
         // # Extensions
+
         //
+
         // This section describes the auto identifier extension
+
         //
+
         // ## Heading Auto Identifiers
+
         //
+
         // Allows to automatically creates an identifier for a heading:
+
     [TestFixture]
     public partial class TestExtensionsHeadingAutoIdentifiers
     {
@@ -20176,9 +24013,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("# This is a heading", "<h1 id=\"this-is-a-heading\">This is a heading</h1>", "autoidentifiers|advanced");
         }
     }
+
         // Only punctuation `-`, `_` and `.` is kept, all other non letter characters are discarded.
+
         // Consecutive same character `-`, `_` or `.` are rendered into a single one
+
         // Characters `-`, `_` and `.` at the end of the string are also discarded.
+
     [TestFixture]
     public partial class TestExtensionsHeadingAutoIdentifiers
     {
@@ -20198,7 +24039,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("# This - is a &@! heading _ with . and ! -", "<h1 id=\"this-is-a-heading_with.and\">This - is a &amp;@! heading _ with . and ! -</h1>", "autoidentifiers|advanced");
         }
     }
+
         // Formatting (emphasis) are also discarded:
+
     [TestFixture]
     public partial class TestExtensionsHeadingAutoIdentifiers
     {
@@ -20218,7 +24061,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("# This is a *heading*", "<h1 id=\"this-is-a-heading\">This is a <em>heading</em></h1>", "autoidentifiers|advanced");
         }
     }
+
         // Links are also removed:
+
     [TestFixture]
     public partial class TestExtensionsHeadingAutoIdentifiers
     {
@@ -20238,7 +24083,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("# This is a [heading](/url)", "<h1 id=\"this-is-a-heading\">This is a <a href=\"/url\">heading</a></h1>", "autoidentifiers|advanced");
         }
     }
+
         // If multiple heading have the same text, -1, -2...-n will be postfix to the header id.
+
     [TestFixture]
     public partial class TestExtensionsHeadingAutoIdentifiers
     {
@@ -20260,7 +24107,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("# This is a heading\n# This is a heading", "<h1 id=\"this-is-a-heading\">This is a heading</h1>\n<h1 id=\"this-is-a-heading-1\">This is a heading</h1>", "autoidentifiers|advanced");
         }
     }
+
         // The heading Id will start on the first letter character of the heading, all previous characters will be discarded:
+
     [TestFixture]
     public partial class TestExtensionsHeadingAutoIdentifiers
     {
@@ -20280,7 +24129,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("# 1.0 This is a heading", "<h1 id=\"this-is-a-heading\">1.0 This is a heading</h1>", "autoidentifiers|advanced");
         }
     }
+
         // If the heading is all stripped by the previous rules, the id `section` will be used instead:
+
     [TestFixture]
     public partial class TestExtensionsHeadingAutoIdentifiers
     {
@@ -20302,8 +24153,11 @@ namespace Markdig.Tests
 			TestParser.TestSpec("# 1.0 & ^ % *\n# 1.0 & ^ % *", "<h1 id=\"section\">1.0 &amp; ^ % *</h1>\n<h1 id=\"section-1\">1.0 &amp; ^ % *</h1>", "autoidentifiers|advanced");
         }
     }
+
         // When the options "AutoLink" is setup, it is possible to link to an existing heading by using the
+
         // exact same Label text as the heading:
+
     [TestFixture]
     public partial class TestExtensionsHeadingAutoIdentifiers
     {
@@ -20325,7 +24179,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("# This is a heading\n[This is a heading]", "<h1 id=\"this-is-a-heading\">This is a heading</h1>\n<p><a href=\"#this-is-a-heading\">This is a heading</a></p>", "autoidentifiers|advanced");
         }
     }
+
         // Links before the heading are also working:
+
     [TestFixture]
     public partial class TestExtensionsHeadingAutoIdentifiers
     {
@@ -20347,7 +24203,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[This is a heading]\n# This is a heading", "<p><a href=\"#this-is-a-heading\">This is a heading</a></p>\n<h1 id=\"this-is-a-heading\">This is a heading</h1>", "autoidentifiers|advanced");
         }
     }
+
         // The text of the link can be changed:
+
     [TestFixture]
     public partial class TestExtensionsHeadingAutoIdentifiers
     {
@@ -20369,7 +24227,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[With a new text][This is a heading]\n# This is a heading", "<p><a href=\"#this-is-a-heading\">With a new text</a></p>\n<h1 id=\"this-is-a-heading\">This is a heading</h1>", "autoidentifiers|advanced");
         }
     }
+
         // An autoidentifier should not conflict with an existing link:
+
     [TestFixture]
     public partial class TestExtensionsHeadingAutoIdentifiers
     {
@@ -20392,13 +24252,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("![scenario image][scenario]\n## Scenario\n[scenario]: ./scenario.png", "<p><img src=\"./scenario.png\" alt=\"scenario image\" /></p>\n<h2 id=\"scenario\">Scenario</h2>", "autoidentifiers|advanced");
         }
     }
+
         // # Extensions
+
         //
+
         // Adds support for task lists:
+
         //
+
         // ## TaskLists
+
         //
+
         // A task list item consist of `[ ]` or `[x]` or `[X]` inside a list item (ordered or unordered)
+
     [TestFixture]
     public partial class TestExtensionsTaskLists
     {
@@ -20426,7 +24294,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("- [ ] Item1\n- [x] Item2\n- [ ] Item3\n- Item4", "<ul class=\"contains-task-list\">\n<li class=\"task-list-item\"><input disabled=\"disabled\" type=\"checkbox\" /> Item1</li>\n<li class=\"task-list-item\"><input disabled=\"disabled\" type=\"checkbox\" checked=\"checked\" /> Item2</li>\n<li class=\"task-list-item\"><input disabled=\"disabled\" type=\"checkbox\" /> Item3</li>\n<li>Item4</li>\n</ul>", "tasklists|advanced");
         }
     }
+
         // A task is not recognized outside a list item:
+
     [TestFixture]
     public partial class TestExtensionsTaskLists
     {
@@ -20446,13 +24316,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("[ ] This is not a task list", "<p>[ ] This is not a task list</p>", "tasklists|advanced");
         }
     }
+
         // # Extensions
+
         //
+
         // Adds support for diagrams extension:
+
         //
+
         // ## Mermaid diagrams
+
         //
+
         // Using a fenced code block with the `mermaid` language info will output a `<div class='mermaid'>` instead of a `pre/code` block:
+
     [TestFixture]
     public partial class TestExtensionsMermaiddiagrams
     {
@@ -20483,9 +24361,13 @@ namespace Markdig.Tests
 			TestParser.TestSpec("```mermaid\ngraph TD;\n    A-->B;\n    A-->C;\n    B-->D;\n    C-->D;\n```", "<div class=\"mermaid\">graph TD;\n    A-->B;\n    A-->C;\n    B-->D;\n    C-->D;\n</div>", "diagrams|advanced");
         }
     }
+
         // ## nomnoml diagrams
+
         //
+
         // Using a fenced code block with the `nomnoml` language info will output a `<div class='nomnoml'>` instead of a `pre/code` block:
+
     [TestFixture]
     public partial class TestExtensionsnomnomldiagrams
     {
@@ -20526,14 +24408,23 @@ namespace Markdig.Tests
 			TestParser.TestSpec("```nomnoml\n[example|\n  propertyA: Int\n  propertyB: string\n|\n  methodA()\n  methodB()\n|\n  [subA]--[subB]\n  [subA]-:>[sub C]\n]\n```", "<div class=\"nomnoml\">[example|\n  propertyA: Int\n  propertyB: string\n|\n  methodA()\n  methodB()\n|\n  [subA]--[subB]\n  [subA]-:>[sub C]\n]\n</div>", "diagrams|advanced");
         }
     }
+
         // TODO: Add other text diagram languages
+
         // # Extensions
+
         //
+
         // ## NoHTML
+
         //
+
         // The extension DisableHtml allows to disable the parsing of HTML:
+
         //
+
         // For inline HTML:
+
     [TestFixture]
     public partial class TestExtensionsNoHTML
     {
@@ -20553,7 +24444,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("this is some text</td></tr>", "<p>this is some text&lt;/td&gt;&lt;/tr&gt;</p>", "nohtml");
         }
     }
+
         // For Block HTML:
+
     [TestFixture]
     public partial class TestExtensionsNoHTML
     {
@@ -20577,13 +24470,21 @@ namespace Markdig.Tests
 			TestParser.TestSpec("<div>\nthis is some text\n</div>", "<p>&lt;div&gt;\nthis is some text\n&lt;/div&gt;</p>", "nohtml");
         }
     }
+
         // # Extensions
+
         //
+
         // Adds support for YAML frontmatter parsing:
+
         //
+
         // ## YAML frontmatter discard
+
         //
+
         // If a frontmatter is present, it will not be rendered:
+
     [TestFixture]
     public partial class TestExtensionsYAMLfrontmatterdiscard
     {
@@ -20606,7 +24507,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("---\nthis: is a frontmatter\n---\nThis is a text", "<p>This is a text</p>", "yaml");
         }
     }
+
         // But if a frontmatter doesn't happen on the first line, it will be parse as regular Markdown content
+
     [TestFixture]
     public partial class TestExtensionsYAMLfrontmatterdiscard
     {
@@ -20632,7 +24535,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a text1\n---\nthis: is a frontmatter\n---\nThis is a text2", "<h2>This is a text1</h2>\n<h2>this: is a frontmatter</h2>\n<p>This is a text2</p>", "yaml");
         }
     }
+
         // It expects an exact 3 dashes `---`:
+
     [TestFixture]
     public partial class TestExtensionsYAMLfrontmatterdiscard
     {
@@ -20657,7 +24562,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("----\nthis: is a frontmatter\n----\nThis is a text", "<hr />\n<h2>this: is a frontmatter</h2>\n<p>This is a text</p>", "yaml");
         }
     }
+
         // It can end with three dots `...`:
+
     [TestFixture]
     public partial class TestExtensionsYAMLfrontmatterdiscard
     {
@@ -20681,7 +24588,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("---\nthis: is a frontmatter\n\n...\nThis is a text", "<p>This is a text</p>", "yaml");
         }
     }
+
         // If the end front matter marker (`...` or `---`) is not present, it will render the `---` has a `<hr>`:
+
     [TestFixture]
     public partial class TestExtensionsYAMLfrontmatterdiscard
     {
@@ -20705,7 +24614,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("---\nthis: is a frontmatter\nThis is a text", "<hr />\n<p>this: is a frontmatter\nThis is a text</p>", "yaml");
         }
     }
+
         // It expects exactly three dots `...`:
+
     [TestFixture]
     public partial class TestExtensionsYAMLfrontmatterdiscard
     {
@@ -20731,7 +24642,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("---\nthis: is a frontmatter\n....\nThis is a text", "<hr />\n<p>this: is a frontmatter\n....\nThis is a text</p>", "yaml");
         }
     }
+
         // Front matter ends with the first line containing three dots `...` or three dashes `...`:
+
     [TestFixture]
     public partial class TestExtensionsYAMLfrontmatterdiscard
     {
@@ -20757,7 +24670,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("---\nthis: is a frontmatter\n....\n\nHello\n---\nThis is a text", "<p>This is a text</p>", "yaml");
         }
     }
+
         // It expects whitespace can exist after the leading characters
+
     [TestFixture]
     public partial class TestExtensionsYAMLfrontmatterdiscard
     {
@@ -20780,7 +24695,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("---   \nthis: is a frontmatter\n...\nThis is a text", "<p>This is a text</p>", "yaml");
         }
     }
+
         // It expects whitespace can exist after the trailing characters
+
     [TestFixture]
     public partial class TestExtensionsYAMLfrontmatterdiscard
     {
@@ -20803,18 +24720,31 @@ namespace Markdig.Tests
 			TestParser.TestSpec("---\nthis: is a frontmatter\n...     \nThis is a text", "<p>This is a text</p>", "yaml");
         }
     }
+
         // # Extensions
+
         //
+
         // This section describes the different extensions supported:
+
         //
+
         // ## AutoLinks
+
         //
+
         // Autolinks will format as a HTML link any string that starts by:
+
         //
+
         // - `http://` or `https://`
+
         // - `ftp://`
+
         // - `mailto:`
+
         // - `www.`
+
     [TestFixture]
     public partial class TestExtensionsAutoLinks
     {
@@ -20840,7 +24770,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a http://www.google.com URL and https://www.google.com\nThis is a ftp://test.com\nAnd a mailto:email@toto.com\nAnd a plain www.google.com", "<p>This is a <a href=\"http://www.google.com\">http://www.google.com</a> URL and <a href=\"https://www.google.com\">https://www.google.com</a>\nThis is a <a href=\"ftp://test.com\">ftp://test.com</a>\nAnd a <a href=\"mailto:email@toto.com\">email@toto.com</a>\nAnd a plain <a href=\"http://www.google.com\">www.google.com</a></p>", "autolinks|advanced");
         }
     }
+
         // But incomplete links will not be matched:
+
     [TestFixture]
     public partial class TestExtensionsAutoLinks
     {
@@ -20866,7 +24798,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is not a http:/www.google.com URL and https:/www.google.com\nThis is not a ftp:/test.com\nAnd not a mailto:emailtoto.com\nAnd not a plain www. or a www.x ", "<p>This is not a http:/www.google.com URL and https:/www.google.com\nThis is not a ftp:/test.com\nAnd not a mailto:emailtoto.com\nAnd not a plain www. or a www.x</p>", "autolinks|advanced");
         }
     }
+
         // Previous character must be a punctuation or a valid space (tab, space, new line):
+
     [TestFixture]
     public partial class TestExtensionsAutoLinks
     {
@@ -20886,7 +24820,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is not a nhttp://www.google.com URL but this is (https://www.google.com)", "<p>This is not a nhttp://www.google.com URL but this is (<a href=\"https://www.google.com\">https://www.google.com</a>)</p>", "autolinks|advanced");
         }
     }
+
         // An autolink should not interfere with an `<a>` HTML inline:
+
     [TestFixture]
     public partial class TestExtensionsAutoLinks
     {
@@ -20906,7 +24842,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is an HTML <a href=\"http://www.google.com\">http://www.google.com</a> link", "<p>This is an HTML <a href=\"http://www.google.com\">http://www.google.com</a> link</p>", "autolinks|advanced");
         }
     }
+
         // or even within emphasis:
+
     [TestFixture]
     public partial class TestExtensionsAutoLinks
     {
@@ -20926,7 +24864,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is an HTML <a href=\"http://www.google.com\"> **http://www.google.com** </a> link", "<p>This is an HTML <a href=\"http://www.google.com\"> <strong>http://www.google.com</strong> </a> link</p>", "autolinks|advanced");
         }
     }
+
         // An autolink should not interfere with a markdown link:
+
     [TestFixture]
     public partial class TestExtensionsAutoLinks
     {
@@ -20946,7 +24886,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is an HTML [http://www.google.com](http://www.google.com) link", "<p>This is an HTML <a href=\"http://www.google.com\">http://www.google.com</a> link</p>", "autolinks|advanced");
         }
     }
+
         // A link embraced by pending emphasis should let the emphasis takes precedence if characters are placed at the end of the matched link:
+
     [TestFixture]
     public partial class TestExtensionsAutoLinks
     {
@@ -20966,28 +24908,35 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Check **http://www.a.com** or __http://www.b.com__", "<p>Check <strong><a href=\"http://www.a.com\">http://www.a.com</a></strong> or <strong><a href=\"http://www.b.com\">http://www.b.com</a></strong></p>", "autolinks|advanced");
         }
     }
-        // ### GFM Support
-        //
-        // Extract from [GFM Autolinks extensions specs](https://github.github.com/gfm/#autolinks-extension-)
+
+        // It is not mentioned by the spec, but empty emails won't be matched (only a subset of [RFC2368](https://tools.ietf.org/html/rfc2368) is supported by auto links):
+
     [TestFixture]
-    public partial class TestExtensionsAutoLinksGFMSupport
+    public partial class TestExtensionsAutoLinks
     {
         [Test]
-        public void ExtensionsAutoLinksGFMSupport_Example008()
+        public void ExtensionsAutoLinks_Example008()
         {
             // Example 8
-            // Section: Extensions AutoLinks GFM Support
+            // Section: Extensions AutoLinks
             //
             // The following CommonMark:
-            //     www.commonmark.org
+            //     mailto:email@test.com is okay, but mailto:@test.com is not
             //
             // Should be rendered as:
-            //     <p><a href="http://www.commonmark.org">www.commonmark.org</a></p>
+            //     <p><a href="mailto:email@test.com">email@test.com</a> is okay, but mailto:@test.com is not</p>
 
-            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 8, "Extensions AutoLinks GFM Support");
-			TestParser.TestSpec("www.commonmark.org", "<p><a href=\"http://www.commonmark.org\">www.commonmark.org</a></p>", "autolinks|advanced");
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 8, "Extensions AutoLinks");
+			TestParser.TestSpec("mailto:email@test.com is okay, but mailto:@test.com is not", "<p><a href=\"mailto:email@test.com\">email@test.com</a> is okay, but mailto:@test.com is not</p>", "autolinks|advanced");
         }
     }
+
+        // ### GFM Support
+
+        //
+
+        // Extract from [GFM Autolinks extensions specs](https://github.github.com/gfm/#autolinks-extension-)
+
     [TestFixture]
     public partial class TestExtensionsAutoLinksGFMSupport
     {
@@ -20998,15 +24947,16 @@ namespace Markdig.Tests
             // Section: Extensions AutoLinks GFM Support
             //
             // The following CommonMark:
-            //     Visit www.commonmark.org/help for more information.
+            //     www.commonmark.org
             //
             // Should be rendered as:
-            //     <p>Visit <a href="http://www.commonmark.org/help">www.commonmark.org/help</a> for more information.</p>
+            //     <p><a href="http://www.commonmark.org">www.commonmark.org</a></p>
 
             Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 9, "Extensions AutoLinks GFM Support");
-			TestParser.TestSpec("Visit www.commonmark.org/help for more information.", "<p>Visit <a href=\"http://www.commonmark.org/help\">www.commonmark.org/help</a> for more information.</p>", "autolinks|advanced");
+			TestParser.TestSpec("www.commonmark.org", "<p><a href=\"http://www.commonmark.org\">www.commonmark.org</a></p>", "autolinks|advanced");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsAutoLinksGFMSupport
     {
@@ -21014,6 +24964,26 @@ namespace Markdig.Tests
         public void ExtensionsAutoLinksGFMSupport_Example010()
         {
             // Example 10
+            // Section: Extensions AutoLinks GFM Support
+            //
+            // The following CommonMark:
+            //     Visit www.commonmark.org/help for more information.
+            //
+            // Should be rendered as:
+            //     <p>Visit <a href="http://www.commonmark.org/help">www.commonmark.org/help</a> for more information.</p>
+
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 10, "Extensions AutoLinks GFM Support");
+			TestParser.TestSpec("Visit www.commonmark.org/help for more information.", "<p>Visit <a href=\"http://www.commonmark.org/help\">www.commonmark.org/help</a> for more information.</p>", "autolinks|advanced");
+        }
+    }
+
+    [TestFixture]
+    public partial class TestExtensionsAutoLinksGFMSupport
+    {
+        [Test]
+        public void ExtensionsAutoLinksGFMSupport_Example011()
+        {
+            // Example 11
             // Section: Extensions AutoLinks GFM Support
             //
             // The following CommonMark:
@@ -21025,17 +24995,18 @@ namespace Markdig.Tests
             //     <p>Visit <a href="http://www.commonmark.org">www.commonmark.org</a>.</p>
             //     <p>Visit <a href="http://www.commonmark.org/a.b">www.commonmark.org/a.b</a>.</p>
 
-            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 10, "Extensions AutoLinks GFM Support");
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 11, "Extensions AutoLinks GFM Support");
 			TestParser.TestSpec("Visit www.commonmark.org.\n\nVisit www.commonmark.org/a.b.", "<p>Visit <a href=\"http://www.commonmark.org\">www.commonmark.org</a>.</p>\n<p>Visit <a href=\"http://www.commonmark.org/a.b\">www.commonmark.org/a.b</a>.</p>", "autolinks|advanced");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsAutoLinksGFMSupport
     {
         [Test]
-        public void ExtensionsAutoLinksGFMSupport_Example011()
+        public void ExtensionsAutoLinksGFMSupport_Example012()
         {
-            // Example 11
+            // Example 12
             // Section: Extensions AutoLinks GFM Support
             //
             // The following CommonMark:
@@ -21047,17 +25018,18 @@ namespace Markdig.Tests
             //     <p><a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a></p>
             //     <p>(<a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a>)</p>
 
-            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 11, "Extensions AutoLinks GFM Support");
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 12, "Extensions AutoLinks GFM Support");
 			TestParser.TestSpec("www.google.com/search?q=Markup+(business)\n\n(www.google.com/search?q=Markup+(business))", "<p><a href=\"http://www.google.com/search?q=Markup+(business)\">www.google.com/search?q=Markup+(business)</a></p>\n<p>(<a href=\"http://www.google.com/search?q=Markup+(business)\">www.google.com/search?q=Markup+(business)</a>)</p>", "autolinks|advanced");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsAutoLinksGFMSupport
     {
         [Test]
-        public void ExtensionsAutoLinksGFMSupport_Example012()
+        public void ExtensionsAutoLinksGFMSupport_Example013()
         {
-            // Example 12
+            // Example 13
             // Section: Extensions AutoLinks GFM Support
             //
             // The following CommonMark:
@@ -21069,17 +25041,18 @@ namespace Markdig.Tests
             //     <p><a href="http://www.google.com/search?q=commonmark&amp;hl=en">www.google.com/search?q=commonmark&amp;hl=en</a></p>
             //     <p><a href="http://www.google.com/search?q=commonmark">www.google.com/search?q=commonmark</a>&amp;hl;</p>
 
-            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 12, "Extensions AutoLinks GFM Support");
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 13, "Extensions AutoLinks GFM Support");
 			TestParser.TestSpec("www.google.com/search?q=commonmark&hl=en\n\nwww.google.com/search?q=commonmark&hl;", "<p><a href=\"http://www.google.com/search?q=commonmark&amp;hl=en\">www.google.com/search?q=commonmark&amp;hl=en</a></p>\n<p><a href=\"http://www.google.com/search?q=commonmark\">www.google.com/search?q=commonmark</a>&amp;hl;</p>", "autolinks|advanced");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsAutoLinksGFMSupport
     {
         [Test]
-        public void ExtensionsAutoLinksGFMSupport_Example013()
+        public void ExtensionsAutoLinksGFMSupport_Example014()
         {
-            // Example 13
+            // Example 14
             // Section: Extensions AutoLinks GFM Support
             //
             // The following CommonMark:
@@ -21088,17 +25061,18 @@ namespace Markdig.Tests
             // Should be rendered as:
             //     <p><a href="http://www.commonmark.org/he">www.commonmark.org/he</a>&lt;lp</p>
 
-            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 13, "Extensions AutoLinks GFM Support");
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 14, "Extensions AutoLinks GFM Support");
 			TestParser.TestSpec("www.commonmark.org/he<lp", "<p><a href=\"http://www.commonmark.org/he\">www.commonmark.org/he</a>&lt;lp</p>", "autolinks|advanced");
         }
     }
+
     [TestFixture]
     public partial class TestExtensionsAutoLinksGFMSupport
     {
         [Test]
-        public void ExtensionsAutoLinksGFMSupport_Example014()
+        public void ExtensionsAutoLinksGFMSupport_Example015()
         {
-            // Example 14
+            // Example 15
             // Section: Extensions AutoLinks GFM Support
             //
             // The following CommonMark:
@@ -21113,29 +25087,179 @@ namespace Markdig.Tests
             //     <p>(Visit <a href="https://encrypted.google.com/search?q=Markup+(business)">https://encrypted.google.com/search?q=Markup+(business)</a>)</p>
             //     <p>Anonymous FTP is available at <a href="ftp://foo.bar.baz">ftp://foo.bar.baz</a>.</p>
 
-            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 14, "Extensions AutoLinks GFM Support");
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 15, "Extensions AutoLinks GFM Support");
 			TestParser.TestSpec("http://commonmark.org\n\n(Visit https://encrypted.google.com/search?q=Markup+(business))\n\nAnonymous FTP is available at ftp://foo.bar.baz.", "<p><a href=\"http://commonmark.org\">http://commonmark.org</a></p>\n<p>(Visit <a href=\"https://encrypted.google.com/search?q=Markup+(business)\">https://encrypted.google.com/search?q=Markup+(business)</a>)</p>\n<p>Anonymous FTP is available at <a href=\"ftp://foo.bar.baz\">ftp://foo.bar.baz</a>.</p>", "autolinks|advanced");
         }
     }
+
+        // ### Valid Domain Tests
+
+        //
+
+        // Domain names that have empty segments won't be matched
+
+    [TestFixture]
+    public partial class TestExtensionsAutoLinksValidDomainTests
+    {
+        [Test]
+        public void ExtensionsAutoLinksValidDomainTests_Example016()
+        {
+            // Example 16
+            // Section: Extensions AutoLinks Valid Domain Tests
+            //
+            // The following CommonMark:
+            //     www..
+            //     www..com
+            //     http://test.
+            //     http://.test
+            //     http://.
+            //     http://..
+            //     ftp://test.
+            //     ftp://.test
+            //     mailto:email@test.
+            //     mailto:email@.test
+            //
+            // Should be rendered as:
+            //     <p>www..
+            //     www..com
+            //     http://test.
+            //     http://.test
+            //     http://.
+            //     http://..
+            //     ftp://test.
+            //     ftp://.test
+            //     mailto:email@test.
+            //     mailto:email@.test</p>
+
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 16, "Extensions AutoLinks Valid Domain Tests");
+			TestParser.TestSpec("www..\nwww..com\nhttp://test.\nhttp://.test\nhttp://.\nhttp://..\nftp://test.\nftp://.test\nmailto:email@test.\nmailto:email@.test", "<p>www..\nwww..com\nhttp://test.\nhttp://.test\nhttp://.\nhttp://..\nftp://test.\nftp://.test\nmailto:email@test.\nmailto:email@.test</p>", "autolinks|advanced");
+        }
+    }
+
+        // Domain names with too few segments won't be matched
+
+    [TestFixture]
+    public partial class TestExtensionsAutoLinksValidDomainTests
+    {
+        [Test]
+        public void ExtensionsAutoLinksValidDomainTests_Example017()
+        {
+            // Example 17
+            // Section: Extensions AutoLinks Valid Domain Tests
+            //
+            // The following CommonMark:
+            //     www
+            //     www.com
+            //     http://test
+            //     ftp://test
+            //     mailto:email@test
+            //
+            // Should be rendered as:
+            //     <p>www
+            //     www.com
+            //     http://test
+            //     ftp://test
+            //     mailto:email@test</p>
+
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 17, "Extensions AutoLinks Valid Domain Tests");
+			TestParser.TestSpec("www\nwww.com\nhttp://test\nftp://test\nmailto:email@test", "<p>www\nwww.com\nhttp://test\nftp://test\nmailto:email@test</p>", "autolinks|advanced");
+        }
+    }
+
+        // Domain names that contain an underscores in the last two segments won't be matched
+
+    [TestFixture]
+    public partial class TestExtensionsAutoLinksValidDomainTests
+    {
+        [Test]
+        public void ExtensionsAutoLinksValidDomainTests_Example018()
+        {
+            // Example 18
+            // Section: Extensions AutoLinks Valid Domain Tests
+            //
+            // The following CommonMark:
+            //     www._test.foo.bar is okay, but www._test.foo is not
+            //     
+            //     http://te_st.foo.bar is okay, as is http://test.foo_.bar.foo
+            //     
+            //     But http://te_st.foo, http://test.foo_.bar and http://test._foo are not
+            //     
+            //     ftp://test_.foo.bar is okay, but ftp://test.fo_o is not
+            //     
+            //     mailto:email@_test.foo.bar is okay, but mailto:email@_test.foo is not
+            //
+            // Should be rendered as:
+            //     <p><a href="http://www._test.foo.bar">www._test.foo.bar</a> is okay, but www._test.foo is not</p>
+            //     <p><a href="http://te_st.foo.bar">http://te_st.foo.bar</a> is okay, as is <a href="http://test.foo_.bar.foo">http://test.foo_.bar.foo</a></p>
+            //     <p>But http://te_st.foo, http://test.foo_.bar and http://test._foo are not</p>
+            //     <p><a href="ftp://test_.foo.bar">ftp://test_.foo.bar</a> is okay, but ftp://test.fo_o is not</p>
+            //     <p><a href="mailto:email@_test.foo.bar">email@_test.foo.bar</a> is okay, but mailto:email@_test.foo is not</p>
+
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 18, "Extensions AutoLinks Valid Domain Tests");
+			TestParser.TestSpec("www._test.foo.bar is okay, but www._test.foo is not\n\nhttp://te_st.foo.bar is okay, as is http://test.foo_.bar.foo\n\nBut http://te_st.foo, http://test.foo_.bar and http://test._foo are not\n\nftp://test_.foo.bar is okay, but ftp://test.fo_o is not\n\nmailto:email@_test.foo.bar is okay, but mailto:email@_test.foo is not", "<p><a href=\"http://www._test.foo.bar\">www._test.foo.bar</a> is okay, but www._test.foo is not</p>\n<p><a href=\"http://te_st.foo.bar\">http://te_st.foo.bar</a> is okay, as is <a href=\"http://test.foo_.bar.foo\">http://test.foo_.bar.foo</a></p>\n<p>But http://te_st.foo, http://test.foo_.bar and http://test._foo are not</p>\n<p><a href=\"ftp://test_.foo.bar\">ftp://test_.foo.bar</a> is okay, but ftp://test.fo_o is not</p>\n<p><a href=\"mailto:email@_test.foo.bar\">email@_test.foo.bar</a> is okay, but mailto:email@_test.foo is not</p>", "autolinks|advanced");
+        }
+    }
+
+        // Domain names that contain invalid characters (not AlphaNumberic, -, _ or .) won't be matched
+
+    [TestFixture]
+    public partial class TestExtensionsAutoLinksValidDomainTests
+    {
+        [Test]
+        public void ExtensionsAutoLinksValidDomainTests_Example019()
+        {
+            // Example 19
+            // Section: Extensions AutoLinks Valid Domain Tests
+            //
+            // The following CommonMark:
+            //     https://[your-domain]/api
+            //
+            // Should be rendered as:
+            //     <p>https://[your-domain]/api</p>
+
+            Console.WriteLine("Example {0}" + Environment.NewLine + "Section: {0}" + Environment.NewLine, 19, "Extensions AutoLinks Valid Domain Tests");
+			TestParser.TestSpec("https://[your-domain]/api", "<p>https://[your-domain]/api</p>", "autolinks|advanced");
+        }
+    }
+
         // ## Jira Links
+
         //
+
         // The JiraLinks extension will automatically add links to JIRA issue items within your markdown, e.g. XX-1234. For this to happen, you must configure the extension when adding to the pipeline, e.g.
+
         //
+
         // ```
+
         // var pipeline = new MarkdownPipelineBuilder()
+
         // .UseJiraLinks(new JiraLinkOptions("http://your.company.abc"))
+
         // .Build();
+
         // ```
+
         //
+
         // The rules for detecting a link are:
+
         //
+
         // - The project key must be composed of onre or more capitalised ASCII letter `[A-Z]+`
+
         // - A single hypen `-` must separate the project key and issue number.
+
         // - The issue number is composed of 1 or more digits `[0, 9]+`
+
         // - The reference must be preceeded by either `(` or whitespace or EOF.
+
         // - The reference must be followed by either `)` or whitespace or EOF.
+
         //
+
         // The following are valid examples:
+
     [TestFixture]
     public partial class TestJiraLinks
     {
@@ -21155,6 +25279,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a ABCD-123 issue", "<p>This is a <a href=\"http://your.company.abc/browse/ABCD-123\" target=\"blank\">ABCD-123</a> issue</p>", "jiralinks");
         }
     }
+
     [TestFixture]
     public partial class TestJiraLinks
     {
@@ -21174,6 +25299,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a KIRA-1 issue", "<p>This is a <a href=\"http://your.company.abc/browse/KIRA-1\" target=\"blank\">KIRA-1</a> issue</p>", "jiralinks");
         }
     }
+
     [TestFixture]
     public partial class TestJiraLinks
     {
@@ -21193,7 +25319,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a Z-1 issue", "<p>This is a <a href=\"http://your.company.abc/browse/Z-1\" target=\"blank\">Z-1</a> issue</p>", "jiralinks");
         }
     }
+
         // These are also valid links with `(` and `)`:
+
     [TestFixture]
     public partial class TestJiraLinks
     {
@@ -21213,6 +25341,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a (ABCD-123) issue", "<p>This is a (<a href=\"http://your.company.abc/browse/ABCD-123\" target=\"blank\">ABCD-123</a>) issue</p>", "jiralinks");
         }
     }
+
     [TestFixture]
     public partial class TestJiraLinks
     {
@@ -21232,6 +25361,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a (KIRA-1) issue", "<p>This is a (<a href=\"http://your.company.abc/browse/KIRA-1\" target=\"blank\">KIRA-1</a>) issue</p>", "jiralinks");
         }
     }
+
     [TestFixture]
     public partial class TestJiraLinks
     {
@@ -21251,7 +25381,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is a (Z-1) issue", "<p>This is a (<a href=\"http://your.company.abc/browse/Z-1\" target=\"blank\">Z-1</a>) issue</p>", "jiralinks");
         }
     }
+
         // These are not valid links:
+
     [TestFixture]
     public partial class TestJiraLinks
     {
@@ -21271,6 +25403,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is not aJIRA-123 issue", "<p>This is not aJIRA-123 issue</p>", "jiralinks");
         }
     }
+
     [TestFixture]
     public partial class TestJiraLinks
     {
@@ -21290,6 +25423,7 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is not JIRA-123a issue", "<p>This is not JIRA-123a issue</p>", "jiralinks");
         }
     }
+
     [TestFixture]
     public partial class TestJiraLinks
     {
@@ -21309,18 +25443,31 @@ namespace Markdig.Tests
 			TestParser.TestSpec("This is not JIRA- issue", "<p>This is not JIRA- issue</p>", "jiralinks");
         }
     }
+
         // # Extensions
+
         //
+
         // This section describes the different extensions supported:
+
         //
+
         // ## Globalization
+
         // Adds support for RTL content by adding `dir="rtl"` and `align="right` attributes to the appropriate html elements. Left to right text is not affected by this extension.
+
         //
+
         // Whether a markdown block is marked as RTL or not is determined by the [first strong character](https://en.wikipedia.org/wiki/Bi-directional_text#Strong_characters) of the block.
+
         //
+
         // **Note**: You might need to add `<meta charset="UTF-8">` to the head of the html file to be able to see the result correctly.
+
         //
+
         // Headings and block quotes:
+
     [TestFixture]
     public partial class TestExtensionsGlobalization
     {
@@ -21361,7 +25508,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("# Fruits\nIn botany, a [fruit](https://en.wikipedia.org/wiki/Fruit) is the seed-bearing structure in flowering plants (also known as angiosperms) formed from the ovary after flowering.\n\n> Fruits are good for health\n-- Anonymous\n\n# میوە\n[میوە](https://ckb.wikipedia.org/wiki/%D9%85%DB%8C%D9%88%DB%95) یان مێوە بەروبوومی ڕوەکیە کە ڕوەکەکان ھەڵیان ئەگرن وەک بەرگێک بۆ تۆوەکانیان، بە زۆری جیادەکرێتەوە بە شیرینی یان ترشی لە تامدا و بە بوونی بڕێکی زۆر ئاو\n\n> میوە بۆ تەندروستی باشە\n-- نەزانراو", "<h1 id=\"fruits\">Fruits</h1>\n<p>In botany, a <a href=\"https://en.wikipedia.org/wiki/Fruit\">fruit</a> is the seed-bearing structure in flowering plants (also known as angiosperms) formed from the ovary after flowering.</p>\n<blockquote>\n<p>Fruits are good for health\n-- Anonymous</p>\n</blockquote>\n<h1 id=\"section\" dir=\"rtl\">میوە</h1>\n<p dir=\"rtl\"><a href=\"https://ckb.wikipedia.org/wiki/%D9%85%DB%8C%D9%88%DB%95\" dir=\"rtl\">میوە</a> یان مێوە بەروبوومی ڕوەکیە کە ڕوەکەکان ھەڵیان ئەگرن وەک بەرگێک بۆ تۆوەکانیان، بە زۆری جیادەکرێتەوە بە شیرینی یان ترشی لە تامدا و بە بوونی بڕێکی زۆر ئاو</p>\n<blockquote dir=\"rtl\">\n<p dir=\"rtl\">میوە بۆ تەندروستی باشە\n-- نەزانراو</p>\n</blockquote>", "globalization+advanced+emojis");
         }
     }
+
         // Lists:
+
     [TestFixture]
     public partial class TestExtensionsGlobalization
     {
@@ -21468,7 +25617,9 @@ namespace Markdig.Tests
 			TestParser.TestSpec("## Types of fruits\n- Berries\n  - Strawberry\n  - kiwifruit\n- Citrus\n  - Orange\n  - Lemon\n\n## Examples of fruits :yum:\n1. Apple\n2. Banana\n3. Orange\n\n## Grocery List\n- [X] 􏿽 Watermelon\n- [X] Apricot\n- [ ] Fig \n\n## نموونەی میوە :yum:\n1. ? سێو\n2. 5 مۆز \n3. 􏿽 پرتەقاڵ\n\n## جۆرەکانی میوە\n- توو\n  - فڕاولە\n  - کیوی\n- مزرەمەنی\n  - پڕتەقاڵ\n  - لیمۆ\n\n## لیستی کڕین\n- [X] شووتی\n- [X] قەیسی\n- [ ] هەنجیر", "<h2 id=\"types-of-fruits\">Types of fruits</h2>\n<ul>\n<li>Berries\n<ul>\n<li>Strawberry</li>\n<li>kiwifruit</li>\n</ul>\n</li>\n<li>Citrus\n<ul>\n<li>Orange</li>\n<li>Lemon</li>\n</ul>\n</li>\n</ul>\n<h2 id=\"examples-of-fruits\">Examples of fruits 😋</h2>\n<ol>\n<li>Apple</li>\n<li>Banana</li>\n<li>Orange</li>\n</ol>\n<h2 id=\"grocery-list\">Grocery List</h2>\n<ul class=\"contains-task-list\">\n<li class=\"task-list-item\"><input disabled=\"disabled\" type=\"checkbox\" checked=\"checked\" /> 􏿽 Watermelon</li>\n<li class=\"task-list-item\"><input disabled=\"disabled\" type=\"checkbox\" checked=\"checked\" /> Apricot</li>\n<li class=\"task-list-item\"><input disabled=\"disabled\" type=\"checkbox\" /> Fig</li>\n</ul>\n<h2 id=\"section\" dir=\"rtl\">نموونەی میوە 😋</h2>\n<ol dir=\"rtl\">\n<li>? سێو</li>\n<li>5 مۆز</li>\n<li>􏿽 پرتەقاڵ</li>\n</ol>\n<h2 id=\"section-1\" dir=\"rtl\">جۆرەکانی میوە</h2>\n<ul dir=\"rtl\">\n<li>توو\n<ul dir=\"rtl\">\n<li>فڕاولە</li>\n<li>کیوی</li>\n</ul>\n</li>\n<li>مزرەمەنی\n<ul dir=\"rtl\">\n<li>پڕتەقاڵ</li>\n<li>لیمۆ</li>\n</ul>\n</li>\n</ul>\n<h2 id=\"section-2\" dir=\"rtl\">لیستی کڕین</h2>\n<ul class=\"contains-task-list\" dir=\"rtl\">\n<li class=\"task-list-item\"><input disabled=\"disabled\" type=\"checkbox\" checked=\"checked\" /> شووتی</li>\n<li class=\"task-list-item\"><input disabled=\"disabled\" type=\"checkbox\" checked=\"checked\" /> قەیسی</li>\n<li class=\"task-list-item\"><input disabled=\"disabled\" type=\"checkbox\" /> هەنجیر</li>\n</ul>", "globalization+advanced+emojis");
         }
     }
+
         // Tables:
+
     [TestFixture]
     public partial class TestExtensionsGlobalization
     {
@@ -21537,4 +25688,5 @@ namespace Markdig.Tests
 			TestParser.TestSpec("Nuitrion |Apple | Oranges\n--|-- | --\nCalories|52|47\nSugar|10g|9g\n\n پێکهاتە |سێو | پڕتەقاڵ\n--|-- | --\nکالۆری|٥٢|٤٧\nشەکر| ١٠گ|٩گ", "<table>\n<thead>\n<tr>\n<th>Nuitrion</th>\n<th>Apple</th>\n<th>Oranges</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>Calories</td>\n<td>52</td>\n<td>47</td>\n</tr>\n<tr>\n<td>Sugar</td>\n<td>10g</td>\n<td>9g</td>\n</tr>\n</tbody>\n</table>\n<table dir=\"rtl\" align=\"right\">\n<thead>\n<tr>\n<th>پێکهاتە</th>\n<th>سێو</th>\n<th>پڕتەقاڵ</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>کالۆری</td>\n<td>٥٢</td>\n<td>٤٧</td>\n</tr>\n<tr>\n<td>شەکر</td>\n<td>١٠گ</td>\n<td>٩گ</td>\n</tr>\n</tbody>\n</table>", "globalization+advanced+emojis");
         }
     }
+
 }


### PR DESCRIPTION
#252 

This makes it so AutoLinkParser doesn't match links with domain names, that:
* Have empty segments
* Have less than 2 segments
* Contain invalid characters
* Contain an underscore in the last two segments

This also doesn't match empty emails in mailto: (mailto:@something.com)

@xoofx
I included the Specs.cs file that my VS emits, but it's obviously seriously deformed. Any idea on how to fix it? (I will obviously amend the last commit if I figure that one out)