### PR TITLE
Empty image alt text for link reference definitions

### DIFF
--- a/src/Markdig.Tests/TestImageAltText.cs
+++ b/src/Markdig.Tests/TestImageAltText.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using System.Text.RegularExpressions;
+
+namespace Markdig.Tests
+{
+    [TestFixture]
+    public class TestImageAltText
+    {
+        [Test]
+        [TestCase("![](image.jpg)", "")]
+        [TestCase("![foo](image.jpg)", "foo")]
+        [TestCase("![][1]\n\n[1]: image.jpg", "")]
+        [TestCase("![bar][1]\n\n[1]: image.jpg", "bar")]
+        [TestCase("![](image.jpg 'title')", "")]
+        [TestCase("![foo](image.jpg 'title')", "foo")]
+        [TestCase("![][1]\n\n[1]: image.jpg 'title'", "")]
+        [TestCase("![bar][1]\n\n[1]: image.jpg 'title'", "bar")]
+        public void TestImageHtmlAltText(string markdown, string expectedAltText)
+        {
+            string html = Markdown.ToHtml(markdown);
+            string actualAltText = Regex.Match(html, "alt=\"(.*?)\"").Groups[1].Value;
+            Assert.AreEqual(expectedAltText, actualAltText);
+        }
+    }
+}

--- a/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
@@ -136,7 +136,7 @@ namespace Markdig.Parsers.Inlines
                     {
                         child = new LiteralInline()
                         {
-                            Content = new StringSlice(label),
+                            Content = StringSlice.Empty,
                             IsClosed = true,
                             // Not exact but we leave it like this
                             Span = parent.Span,


### PR DESCRIPTION
#251 
All tests are passing so I don't think it breaks anything else?