### PR TITLE
AutoIdentifierOptions clarification

### DIFF
--- a/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierOptions.cs
+++ b/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierOptions.cs
@@ -12,7 +12,7 @@ namespace Markdig.Extensions.AutoIdentifiers
     public enum AutoIdentifierOptions
     {
         /// <summary>
-        /// No options
+        /// No options: does not apply any additional formatting and/or tranformations.  
         /// </summary>
         None = 0,
 

--- a/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierOptions.cs
+++ b/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierOptions.cs
@@ -12,7 +12,7 @@ namespace Markdig.Extensions.AutoIdentifiers
     public enum AutoIdentifierOptions
     {
         /// <summary>
-        /// No options: does not apply any additional formatting and/or tranformations.  
+        /// No options: does not apply any additional formatting and/or transformations.  
         /// </summary>
         None = 0,
 


### PR DESCRIPTION
Clarified 'None' option in the options for the auto-identifiers extension. Fixes #266 .