### PR TITLE
fixes #196 ensuring line breaks when renderer does not have html enabled

### DIFF
--- a/src/Markdig.Tests/TestConfigureNewLine.cs
+++ b/src/Markdig.Tests/TestConfigureNewLine.cs
@@ -21,5 +21,22 @@ namespace Markdig.Tests
             var actual = Markdown.ToHtml(markdownText, pipeline);
             Assert.AreEqual(expected, actual);
         }
+
+        [Test]
+        [TestCase(/* newLineForWriting: */ "\n",   /* markdownText: */ "*1*\n*2*\n",     /* expected: */ "1\n2\n")]
+        [TestCase(/* newLineForWriting: */ "\n",   /* markdownText: */ "*1*\r\n*2*\r\n", /* expected: */ "1\n2\n")]
+        [TestCase(/* newLineForWriting: */ "\r\n", /* markdownText: */ "*1*\n*2*\n",     /* expected: */ "1\r\n2\r\n")]
+        [TestCase(/* newLineForWriting: */ "\r\n", /* markdownText: */ "*1*\r\n*2*\r\n", /* expected: */ "1\r\n2\r\n")]
+        [TestCase(/* newLineForWriting: */ "!!!", /* markdownText: */ "*1*\n*2*\n",     /* expected: */ "1!!!2!!!")]
+        [TestCase(/* newLineForWriting: */ "!!!", /* markdownText: */ "*1*\r\n*2*\r\n", /* expected: */ "1!!!2!!!")]
+        public void TestPlainOutputWhenConfiguringNewLine(string newLineForWriting, string markdownText, string expected)
+        {
+            var pipeline = new MarkdownPipelineBuilder()
+                .ConfigureNewLine(newLineForWriting)
+                .Build();
+
+            var actual = Markdown.ToPlainText(markdownText, pipeline);
+            Assert.AreEqual(expected, actual);
+        }
     }
 }

--- a/src/Markdig.Tests/TestPlainText.cs
+++ b/src/Markdig.Tests/TestPlainText.cs
@@ -9,9 +9,30 @@ namespace Markdig.Tests
         public void TestPlain()
         {
             var markdownText = "*Hello*, [world](http://example.com)!";
-            var expected = "Hello, world!";
+            var expected = "Hello, world!\n";
             var actual = Markdown.ToPlainText(markdownText);
             Assert.AreEqual(expected, actual);
         }
+
+        [Test]
+        [TestCase(/* markdownText: */ "foo bar", /* expected: */ "foo bar\n")]
+        [TestCase(/* markdownText: */ "foo\nbar", /* expected: */ "foo\nbar\n")]
+        [TestCase(/* markdownText: */ "*foo\nbar*", /* expected: */ "foo\nbar\n")]
+        [TestCase(/* markdownText: */ "[foo\nbar](http://example.com)", /* expected: */ "foo\nbar\n")]
+        [TestCase(/* markdownText: */ "<http://foo.bar.baz>", /* expected: */ "http://foo.bar.baz\n")]
+        [TestCase(/* markdownText: */ "# foo bar", /* expected: */ "foo bar\n")]
+        [TestCase(/* markdownText: */ "# foo\nbar", /* expected: */ "foo\nbar\n")]
+        [TestCase(/* markdownText: */ "> foo", /* expected: */ "foo\n")]
+        [TestCase(/* markdownText: */ "> foo\nbar\n> baz", /* expected: */ "foo\nbar\nbaz\n")]
+        [TestCase(/* markdownText: */ "`foo`", /* expected: */ "foo\n")]        
+        [TestCase(/* markdownText: */ "`foo\nbar`", /* expected: */ "foo bar\n")] // new line within codespan is treated as whitespace (Example317)
+        [TestCase(/* markdownText: */ "```\nfoo bar\n```", /* expected: */ "foo bar\n")]
+        [TestCase(/* markdownText: */ "- foo\n- bar\n- baz", /* expected: */ "foo\nbar\nbaz\n")]
+        public void TestPlainEnsureNewLine(string markdownText, string expected)
+        {            
+            var actual = Markdown.ToPlainText(markdownText);
+            Assert.AreEqual(expected, actual);
+        }
+
     }
 }

--- a/src/Markdig/Renderers/Html/CodeBlockRenderer.cs
+++ b/src/Markdig/Renderers/Html/CodeBlockRenderer.cs
@@ -87,6 +87,8 @@ namespace Markdig.Renderers.Html
                     renderer.WriteLine("</code></pre>");
                 }
             }
+
+            renderer.EnsureLine();
         }
     }
 }

--- a/src/Markdig/Renderers/Html/HeadingRenderer.cs
+++ b/src/Markdig/Renderers/Html/HeadingRenderer.cs
@@ -38,6 +38,8 @@ namespace Markdig.Renderers.Html
             {
                 renderer.Write("</").Write(headingText).WriteLine(">");
             }
+
+            renderer.EnsureLine();
         }
     }
 }

--- a/src/Markdig/Renderers/Html/Inlines/LineBreakInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LineBreakInlineRenderer.cs
@@ -24,15 +24,9 @@ namespace Markdig.Renderers.Html.Inlines
                 {
                     renderer.WriteLine("<br />");
                 }
-                else
-                {
-                    renderer.WriteLine();
-                }
             }
-            else
-            {
-                renderer.Write(" ");
-            }
+
+            renderer.EnsureLine();
         }
     }
 }

--- a/src/Markdig/Renderers/Html/ListRenderer.cs
+++ b/src/Markdig/Renderers/Html/ListRenderer.cs
@@ -59,6 +59,7 @@ namespace Markdig.Renderers.Html
                     renderer.WriteLine("</li>");
                 }
 
+                renderer.EnsureLine();
                 renderer.ImplicitParagraph = previousImplicit;
             }
 
@@ -66,6 +67,8 @@ namespace Markdig.Renderers.Html
             {
                 renderer.WriteLine(listBlock.IsOrdered ? "</ol>" : "</ul>");
             }
+
+            renderer.EnsureLine();
         }
     }
 }

--- a/src/Markdig/Renderers/Html/ParagraphRenderer.cs
+++ b/src/Markdig/Renderers/Html/ParagraphRenderer.cs
@@ -23,9 +23,14 @@ namespace Markdig.Renderers.Html
                 renderer.Write("<p").WriteAttributes(obj).Write(">");
             }
             renderer.WriteLeafInline(obj);
-            if (!renderer.ImplicitParagraph && renderer.EnableHtmlForBlock)
+            if (!renderer.ImplicitParagraph)
             {
-                renderer.WriteLine("</p>");
+                if(renderer.EnableHtmlForBlock)
+                {
+                    renderer.WriteLine("</p>");
+                }
+
+                renderer.EnsureLine();
             }
         }
     }

--- a/src/Markdig/Renderers/Html/QuoteBlockRenderer.cs
+++ b/src/Markdig/Renderers/Html/QuoteBlockRenderer.cs
@@ -26,6 +26,7 @@ namespace Markdig.Renderers.Html
             {
                 renderer.WriteLine("</blockquote>");
             }
+            renderer.EnsureLine();
         }
     }
 }


### PR DESCRIPTION
PR updates the following renderers to ensure a new line:
- CodeBlockRenderer
- HeadingRenderer
- LineBreakInlineRenderer
- ListRenderer
- ParagraphRenderer
- QuoteBlockRenderer

Please let me know if you have any comments or amends. 