### PR TITLE
Rewrite Descendants iteratively

### DIFF
--- a/src/Markdig.Tests/Markdig.Tests.csproj
+++ b/src/Markdig.Tests/Markdig.Tests.csproj
@@ -58,6 +58,7 @@
     </Compile>
     <Compile Include="Specs\TestEmphasisPlus.cs" />
     <Compile Include="TestEmphasisExtraOptions.cs" />
+    <Compile Include="TestDescendantsOrder.cs" />
     <Compile Include="TestConfigureNewLine.cs" />
     <Compile Include="TestHtmlAttributes.cs" />
     <Compile Include="TestHtmlHelper.cs" />

--- a/src/Markdig.Tests/TestDescendantsOrder.cs
+++ b/src/Markdig.Tests/TestDescendantsOrder.cs
@@ -1,0 +1,79 @@
+using NUnit.Framework;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Markdig.Tests
+{
+    [TestFixture]
+    public class TestDescendantsOrder
+    {
+        [Test]
+        [TestCase("Foo *bar* ***foo***\n\nHello world\n\n# Header 123\n\n`Something`\n\n1. Test `abc` *def*\n2. ghi\n```c#\nEmpty\n```\nTest\n")]
+        // Note - Tested agains the entire tests dataset when implemented
+        public void AssertSameDescendantsOrder(string markdown)
+        {
+            var syntaxTree = Markdown.Parse(markdown, new MarkdownPipelineBuilder().UseAdvancedExtensions().Build());
+
+            var descendants_legacy = Descendants_Legacy(syntaxTree).ToList();
+            var descendants_new = syntaxTree.Descendants().ToList();
+
+            Assert.AreEqual(descendants_legacy.Count, descendants_new.Count);
+
+            for (int i = 0; i < descendants_legacy.Count; i++)
+            {
+                Assert.AreSame(descendants_legacy[i], descendants_new[i]);
+            }
+        }
+
+        private static IEnumerable<MarkdownObject> Descendants_Legacy(MarkdownObject markdownObject)
+        {
+            // TODO: implement a recursiveless method
+
+            var block = markdownObject as ContainerBlock;
+            if (block != null)
+            {
+                foreach (var subBlock in block)
+                {
+                    yield return subBlock;
+
+                    foreach (var sub in Descendants_Legacy(subBlock))
+                    {
+                        yield return sub;
+                    }
+
+                    // Visit leaf block that have inlines
+                    var leafBlock = subBlock as LeafBlock;
+                    if (leafBlock?.Inline != null)
+                    {
+                        foreach (var subInline in Descendants_Legacy(leafBlock.Inline))
+                        {
+                            yield return subInline;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                var inline = markdownObject as ContainerInline;
+                if (inline != null)
+                {
+                    var child = inline.FirstChild;
+                    while (child != null)
+                    {
+                        var next = child.NextSibling;
+                        yield return child;
+
+                        foreach (var sub in Descendants_Legacy(child))
+                        {
+                            yield return sub;
+                        }
+
+                        child = next;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Markdig/Syntax/MarkdownObjectExtensions.cs
+++ b/src/Markdig/Syntax/MarkdownObjectExtensions.cs
@@ -77,29 +77,7 @@ namespace Markdig.Syntax
         /// An iteration over the descendant elements
         /// </returns>
         public static IEnumerable<T> Descendants<T>(this ContainerInline inline) where T : Inline
-        {
-            var child = inline.FirstChild;
-            while (child != null)
-            {
-                var next = child.NextSibling;
-                T childT = child as T;
-                if (childT != null)
-                {
-                    yield return childT;
-                }
-
-                ContainerInline subContainer = child as ContainerInline;
-                if (subContainer != null)
-                {
-                    foreach (var sub in subContainer.Descendants<T>())
-                    {
-                        yield return sub;
-                    }
-                }
-
-                child = next;
-            }
-        }
+            => inline.FindDescendants<T>();
 
         /// <summary>
         /// Iterates over the descendant elements for the specified markdown <see cref="Block" /> element and filters by the type {T}.


### PR DESCRIPTION
I rewrote the `Descendants` extension methods to eliminate recursion. **The order of returned elements is kept the same.**

This comes with a significant memory allocation reduction when using `Descendants` over the entire AST like I do in my project.

Benchmarking between the recursive and iterative approaches I get this:

Iterative:

|              Method |     Mean | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|-------------------- |---------:|------------:|------------:|------------:|--------------------:|
|             Markdig | 212.9 ms |  99333.3333 |           - |           - |            74.89 MB |
| Markdig_Descendants | 228.8 ms |  98000.0000 |   2000.0000 |           - |            78.22 MB |

Recursive:

|              Method |     Mean | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|-------------------- |---------:|------------:|------------:|------------:|--------------------:|
|             Markdig | 215.8 ms |  99333.3333 |           - |           - |            74.89 MB |
| Markdig_Descendants | 242.9 ms |  98000.0000 | 119000.0000 |   6000.0000 |            104.3 MB |

Where `Markdig` is only parsing to the AST while `Markdig_Descendants` parses to AST and loops over descendants once.

I have tested that the order is not modified when calling descending anywhere in the test suite.

I don't have tests for `Descendants<T>` of `ContainerInline `and `ContainerBlock `as they appear to not be used anywhere in Markdig itself, but I have included iterative implementations for those as well.

In the future, a few bytes could be shaved off by using ValueTuple instead of two stacks.