### PR TITLE
Add the license expression to the `csproj`

### DIFF
--- a/src/Markdig/Markdig.csproj
+++ b/src/Markdig/Markdig.csproj
@@ -16,7 +16,6 @@
     <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
     <PackageIconUrl>https://raw.githubusercontent.com/lunet-io/markdig/master/img/markdig.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/lunet-io/markdig</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/lunet-io/markdig/blob/master/license.txt</PackageLicenseUrl>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.1' ">1.6.0</NetStandardImplicitPackageVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/Markdig/Markdig.csproj
+++ b/src/Markdig/Markdig.csproj
@@ -13,6 +13,7 @@
     <PackageId Condition="'$(SignAssembly)' == 'true'">Markdig.Signed</PackageId>
     <PackageTags>Markdown CommonMark md html md2html</PackageTags>
     <PackageReleaseNotes>https://github.com/lunet-io/markdig/blob/master/changelog.md</PackageReleaseNotes>
+    <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
     <PackageIconUrl>https://raw.githubusercontent.com/lunet-io/markdig/master/img/markdig.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/lunet-io/markdig</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/lunet-io/markdig/blob/master/license.txt</PackageLicenseUrl>


### PR DESCRIPTION
Chose the license expression based on what GitHub Detects.

A project I work on generates our Third Party notices files using ClearlyDefined.io and they are having trouble finding you license.  They said this would fix that.  This assumes you package based on the csproj not a nuspec that I couldn't find.