### PR TITLE
HtmlTableRenderer: writing <tr> attributes

### DIFF
--- a/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
+++ b/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
-// This file is licensed under the BSD-Clause 2 license. 
+// This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
 using System;
@@ -69,7 +69,7 @@ namespace Markdig.Extensions.Tables
                     renderer.WriteLine("<tbody>");
                     hasBody = true;
                 }
-                renderer.WriteLine("<tr>");
+                renderer.Write("<tr").WriteAttributes(row).WriteLine(">");
                 for (int i = 0; i < row.Count; i++)
                 {
                     var cellObj = row[i];


### PR DESCRIPTION
This request adds the ability to write `TableRow` attributes (attributes can be added to rows when accessing the document after parsing).  
I won't take it bad if you're not interested 😄 

