### PR TITLE
Add Bracketing around Math Expressions for improved MathLib Rendering

### DIFF
--- a/src/Markdig.Tests/Specs/MathSpecs.cs
+++ b/src/Markdig.Tests/Specs/MathSpecs.cs
@@ -32,7 +32,7 @@ namespace Markdig.Tests.Specs.Math
             //     <p>This is a <span class="math">math block</span></p>
 
             Console.WriteLine("Example 1\nSection Extensions / Math Inline\n");
-            TestParser.TestSpec("This is a $math block$", "<p>This is a <span class=\"math\">math block</span></p>", "mathematics|advanced");
+            TestParser.TestSpec("This is a $math block$", "<p>This is a <span class=\"math\">\\(math block\\)</span></p>", "mathematics|advanced");
         }
 
         // Or by `$$...$$` embracing it by:
@@ -49,7 +49,7 @@ namespace Markdig.Tests.Specs.Math
             //     <p>This is a <span class="math">math block</span></p>
 
             Console.WriteLine("Example 2\nSection Extensions / Math Inline\n");
-            TestParser.TestSpec("This is a $$math block$$", "<p>This is a <span class=\"math\">math block</span></p>", "mathematics|advanced");
+            TestParser.TestSpec("This is a $$math block$$", "<p>This is a <span class=\"math\">\\(math block\\)</span></p>", "mathematics|advanced");
         }
 
         // Newlines inside an inline math are not allowed:
@@ -68,7 +68,7 @@ namespace Markdig.Tests.Specs.Math
             //     block$$ and? this is a <span class="math">math block</span></p>
 
             Console.WriteLine("Example 3\nSection Extensions / Math Inline\n");
-            TestParser.TestSpec("This is not a $$math \nblock$$ and? this is a $$math block$$", "<p>This is not a $$math\nblock$$ and? this is a <span class=\"math\">math block</span></p>", "mathematics|advanced");
+            TestParser.TestSpec("This is not a $$math \nblock$$ and? this is a $$math block$$", "<p>This is not a $$math\nblock$$ and? this is a <span class=\"math\">\\(math block\\)</span></p>", "mathematics|advanced");
         }
 
         [Test]
@@ -86,7 +86,7 @@ namespace Markdig.Tests.Specs.Math
             //     block$ and? this is a <span class="math">math block</span></p>
 
             Console.WriteLine("Example 4\nSection Extensions / Math Inline\n");
-            TestParser.TestSpec("This is not a $math \nblock$ and? this is a $math block$", "<p>This is not a $math\nblock$ and? this is a <span class=\"math\">math block</span></p>", "mathematics|advanced");
+            TestParser.TestSpec("This is not a $math \nblock$ and? this is a $math block$", "<p>This is not a $math\nblock$ and? this is a <span class=\"math\">\\(math block\\)</span></p>", "mathematics|advanced");
         }
 
         // An opening `$` can be followed by a space if the closing is also preceded by a space `$`:
@@ -103,7 +103,7 @@ namespace Markdig.Tests.Specs.Math
             //     <p>This is a <span class="math">math block</span></p>
 
             Console.WriteLine("Example 5\nSection Extensions / Math Inline\n");
-            TestParser.TestSpec("This is a $ math block $", "<p>This is a <span class=\"math\">math block</span></p>", "mathematics|advanced");
+            TestParser.TestSpec("This is a $ math block $", "<p>This is a <span class=\"math\">\\(math block\\)</span></p>", "mathematics|advanced");
         }
 
         [Test]
@@ -119,7 +119,7 @@ namespace Markdig.Tests.Specs.Math
             //     <p>This is a <span class="math">math block</span> after</p>
 
             Console.WriteLine("Example 6\nSection Extensions / Math Inline\n");
-            TestParser.TestSpec("This is a $    math block     $ after", "<p>This is a <span class=\"math\">math block</span> after</p>", "mathematics|advanced");
+            TestParser.TestSpec("This is a $    math block     $ after", "<p>This is a <span class=\"math\">\\(math block\\)</span> after</p>", "mathematics|advanced");
         }
 
         [Test]
@@ -135,7 +135,7 @@ namespace Markdig.Tests.Specs.Math
             //     <p>This is a <span class="math">math block</span> after</p>
 
             Console.WriteLine("Example 7\nSection Extensions / Math Inline\n");
-            TestParser.TestSpec("This is a $$    math block     $$ after", "<p>This is a <span class=\"math\">math block</span> after</p>", "mathematics|advanced");
+            TestParser.TestSpec("This is a $$    math block     $$ after", "<p>This is a <span class=\"math\">\\(math block\\)</span> after</p>", "mathematics|advanced");
         }
 
         [Test]
@@ -219,7 +219,7 @@ namespace Markdig.Tests.Specs.Math
             //     <p>This is a <span class="math">math \$ block</span></p>
 
             Console.WriteLine("Example 12\nSection Extensions / Math Inline\n");
-            TestParser.TestSpec("This is a $math \\$ block$", "<p>This is a <span class=\"math\">math \\$ block</span></p>", "mathematics|advanced");
+            TestParser.TestSpec("This is a $math \\$ block$", "<p>This is a <span class=\"math\">\\(math \\$ block\\)</span></p>", "mathematics|advanced");
         }
 
         // At most, two `$` will be matched for the opening and closing:
@@ -236,7 +236,7 @@ namespace Markdig.Tests.Specs.Math
             //     <p>This is a <span class="math">$math block$</span></p>
 
             Console.WriteLine("Example 13\nSection Extensions / Math Inline\n");
-            TestParser.TestSpec("This is a $$$math block$$$", "<p>This is a <span class=\"math\">$math block$</span></p>", "mathematics|advanced");
+            TestParser.TestSpec("This is a $$$math block$$$", "<p>This is a <span class=\"math\">\\($math block$\\)</span></p>", "mathematics|advanced");
         }
 
         // Regular text can come both before and after the math inline
@@ -253,7 +253,7 @@ namespace Markdig.Tests.Specs.Math
             //     <p>This is a <span class="math">math block</span> with text on both sides.</p>
 
             Console.WriteLine("Example 14\nSection Extensions / Math Inline\n");
-            TestParser.TestSpec("This is a $math block$ with text on both sides.", "<p>This is a <span class=\"math\">math block</span> with text on both sides.</p>", "mathematics|advanced");
+            TestParser.TestSpec("This is a $math block$ with text on both sides.", "<p>This is a <span class=\"math\">\\(math block\\)</span> with text on both sides.</p>", "mathematics|advanced");
         }
 
         // A mathematic block takes precedence over standard emphasis `*` `_`:
@@ -270,7 +270,7 @@ namespace Markdig.Tests.Specs.Math
             //     <p>This is *a <span class="math">math* block</span></p>
 
             Console.WriteLine("Example 15\nSection Extensions / Math Inline\n");
-            TestParser.TestSpec("This is *a $math* block$", "<p>This is *a <span class=\"math\">math* block</span></p>", "mathematics|advanced");
+            TestParser.TestSpec("This is *a $math* block$", "<p>This is *a <span class=\"math\">\\(math* block\\)</span></p>", "mathematics|advanced");
         }
 
         // An opening $$ at the beginning of a line should not be interpreted as a Math block:
@@ -287,7 +287,7 @@ namespace Markdig.Tests.Specs.Math
             //     <p><span class="math">math</span> starting at a line</p>
 
             Console.WriteLine("Example 16\nSection Extensions / Math Inline\n");
-            TestParser.TestSpec("$$ math $$ starting at a line", "<p><span class=\"math\">math</span> starting at a line</p>", "mathematics|advanced");
+            TestParser.TestSpec("$$ math $$ starting at a line", "<p><span class=\"math\">\\(math\\)</span> starting at a line</p>", "mathematics|advanced");
         }
     }
 
@@ -320,7 +320,7 @@ namespace Markdig.Tests.Specs.Math
             //     </div>
 
             Console.WriteLine("Example 17\nSection Extensions / Math Block\n");
-            TestParser.TestSpec("$$\n\\begin{equation}\n  \\int_0^\\infty \\frac{x^3}{e^x-1}\\,dx = \\frac{\\pi^4}{15}\n  \\label{eq:sample}\n\\end{equation}\n$$", "<div class=\"math\">\\begin{equation}\n  \\int_0^\\infty \\frac{x^3}{e^x-1}\\,dx = \\frac{\\pi^4}{15}\n  \\label{eq:sample}\n\\end{equation}\n</div>", "mathematics|advanced");
+            TestParser.TestSpec("$$\n\\begin{equation}\n  \\int_0^\\infty \\frac{x^3}{e^x-1}\\,dx = \\frac{\\pi^4}{15}\n  \\label{eq:sample}\n\\end{equation}\n$$", "<div class=\"math\">\n\\[\n\\begin{equation}\n  \\int_0^\\infty \\frac{x^3}{e^x-1}\\,dx = \\frac{\\pi^4}{15}\n  \\label{eq:sample}\n\\end{equation}\n\\]</div>", "mathematics|advanced");
         }
     }
 }

--- a/src/Markdig.Tests/Specs/MathSpecs.cs
+++ b/src/Markdig.Tests/Specs/MathSpecs.cs
@@ -1,4 +1,4 @@
-// Generated: 21. 01. 2019 14:26:34
+// Generated: 2/22/2019 8:27:26 PM
 
 // --------------------------------
 //               Math
@@ -29,7 +29,7 @@ namespace Markdig.Tests.Specs.Math
             //     This is a $math block$
             //
             // Should be rendered as:
-            //     <p>This is a <span class="math">math block</span></p>
+            //     <p>This is a <span class="math">\(math block\)</span></p>
 
             Console.WriteLine("Example 1\nSection Extensions / Math Inline\n");
             TestParser.TestSpec("This is a $math block$", "<p>This is a <span class=\"math\">\\(math block\\)</span></p>", "mathematics|advanced");
@@ -46,7 +46,7 @@ namespace Markdig.Tests.Specs.Math
             //     This is a $$math block$$
             //
             // Should be rendered as:
-            //     <p>This is a <span class="math">math block</span></p>
+            //     <p>This is a <span class="math">\(math block\)</span></p>
 
             Console.WriteLine("Example 2\nSection Extensions / Math Inline\n");
             TestParser.TestSpec("This is a $$math block$$", "<p>This is a <span class=\"math\">\\(math block\\)</span></p>", "mathematics|advanced");
@@ -65,7 +65,7 @@ namespace Markdig.Tests.Specs.Math
             //
             // Should be rendered as:
             //     <p>This is not a $$math
-            //     block$$ and? this is a <span class="math">math block</span></p>
+            //     block$$ and? this is a <span class="math">\(math block\)</span></p>
 
             Console.WriteLine("Example 3\nSection Extensions / Math Inline\n");
             TestParser.TestSpec("This is not a $$math \nblock$$ and? this is a $$math block$$", "<p>This is not a $$math\nblock$$ and? this is a <span class=\"math\">\\(math block\\)</span></p>", "mathematics|advanced");
@@ -83,7 +83,7 @@ namespace Markdig.Tests.Specs.Math
             //
             // Should be rendered as:
             //     <p>This is not a $math
-            //     block$ and? this is a <span class="math">math block</span></p>
+            //     block$ and? this is a <span class="math">\(math block\)</span></p>
 
             Console.WriteLine("Example 4\nSection Extensions / Math Inline\n");
             TestParser.TestSpec("This is not a $math \nblock$ and? this is a $math block$", "<p>This is not a $math\nblock$ and? this is a <span class=\"math\">\\(math block\\)</span></p>", "mathematics|advanced");
@@ -100,7 +100,7 @@ namespace Markdig.Tests.Specs.Math
             //     This is a $ math block $
             //
             // Should be rendered as:
-            //     <p>This is a <span class="math">math block</span></p>
+            //     <p>This is a <span class="math">\(math block\)</span></p>
 
             Console.WriteLine("Example 5\nSection Extensions / Math Inline\n");
             TestParser.TestSpec("This is a $ math block $", "<p>This is a <span class=\"math\">\\(math block\\)</span></p>", "mathematics|advanced");
@@ -116,7 +116,7 @@ namespace Markdig.Tests.Specs.Math
             //     This is a $    math block     $ after
             //
             // Should be rendered as:
-            //     <p>This is a <span class="math">math block</span> after</p>
+            //     <p>This is a <span class="math">\(math block\)</span> after</p>
 
             Console.WriteLine("Example 6\nSection Extensions / Math Inline\n");
             TestParser.TestSpec("This is a $    math block     $ after", "<p>This is a <span class=\"math\">\\(math block\\)</span> after</p>", "mathematics|advanced");
@@ -132,7 +132,7 @@ namespace Markdig.Tests.Specs.Math
             //     This is a $$    math block     $$ after
             //
             // Should be rendered as:
-            //     <p>This is a <span class="math">math block</span> after</p>
+            //     <p>This is a <span class="math">\(math block\)</span> after</p>
 
             Console.WriteLine("Example 7\nSection Extensions / Math Inline\n");
             TestParser.TestSpec("This is a $$    math block     $$ after", "<p>This is a <span class=\"math\">\\(math block\\)</span> after</p>", "mathematics|advanced");
@@ -216,7 +216,7 @@ namespace Markdig.Tests.Specs.Math
             //     This is a $math \$ block$
             //
             // Should be rendered as:
-            //     <p>This is a <span class="math">math \$ block</span></p>
+            //     <p>This is a <span class="math">\(math \$ block\)</span></p>
 
             Console.WriteLine("Example 12\nSection Extensions / Math Inline\n");
             TestParser.TestSpec("This is a $math \\$ block$", "<p>This is a <span class=\"math\">\\(math \\$ block\\)</span></p>", "mathematics|advanced");
@@ -233,7 +233,7 @@ namespace Markdig.Tests.Specs.Math
             //     This is a $$$math block$$$
             //
             // Should be rendered as:
-            //     <p>This is a <span class="math">$math block$</span></p>
+            //     <p>This is a <span class="math">\($math block$\)</span></p>
 
             Console.WriteLine("Example 13\nSection Extensions / Math Inline\n");
             TestParser.TestSpec("This is a $$$math block$$$", "<p>This is a <span class=\"math\">\\($math block$\\)</span></p>", "mathematics|advanced");
@@ -250,7 +250,7 @@ namespace Markdig.Tests.Specs.Math
             //     This is a $math block$ with text on both sides.
             //
             // Should be rendered as:
-            //     <p>This is a <span class="math">math block</span> with text on both sides.</p>
+            //     <p>This is a <span class="math">\(math block\)</span> with text on both sides.</p>
 
             Console.WriteLine("Example 14\nSection Extensions / Math Inline\n");
             TestParser.TestSpec("This is a $math block$ with text on both sides.", "<p>This is a <span class=\"math\">\\(math block\\)</span> with text on both sides.</p>", "mathematics|advanced");
@@ -267,7 +267,7 @@ namespace Markdig.Tests.Specs.Math
             //     This is *a $math* block$
             //
             // Should be rendered as:
-            //     <p>This is *a <span class="math">math* block</span></p>
+            //     <p>This is *a <span class="math">\(math* block\)</span></p>
 
             Console.WriteLine("Example 15\nSection Extensions / Math Inline\n");
             TestParser.TestSpec("This is *a $math* block$", "<p>This is *a <span class=\"math\">\\(math* block\\)</span></p>", "mathematics|advanced");
@@ -284,7 +284,7 @@ namespace Markdig.Tests.Specs.Math
             //     $$ math $$ starting at a line
             //
             // Should be rendered as:
-            //     <p><span class="math">math</span> starting at a line</p>
+            //     <p><span class="math">\(math\)</span> starting at a line</p>
 
             Console.WriteLine("Example 16\nSection Extensions / Math Inline\n");
             TestParser.TestSpec("$$ math $$ starting at a line", "<p><span class=\"math\">\\(math\\)</span> starting at a line</p>", "mathematics|advanced");
@@ -313,11 +313,13 @@ namespace Markdig.Tests.Specs.Math
             //     $$
             //
             // Should be rendered as:
-            //     <div class="math">\begin{equation}
+            //     <div class="math">
+            //     \[
+            //     \begin{equation}
             //       \int_0^\infty \frac{x^3}{e^x-1}\,dx = \frac{\pi^4}{15}
             //       \label{eq:sample}
             //     \end{equation}
-            //     </div>
+            //     \]</div>
 
             Console.WriteLine("Example 17\nSection Extensions / Math Block\n");
             TestParser.TestSpec("$$\n\\begin{equation}\n  \\int_0^\\infty \\frac{x^3}{e^x-1}\\,dx = \\frac{\\pi^4}{15}\n  \\label{eq:sample}\n\\end{equation}\n$$", "<div class=\"math\">\n\\[\n\\begin{equation}\n  \\int_0^\\infty \\frac{x^3}{e^x-1}\\,dx = \\frac{\\pi^4}{15}\n  \\label{eq:sample}\n\\end{equation}\n\\]</div>", "mathematics|advanced");

--- a/src/Markdig.Tests/Specs/MathSpecs.md
+++ b/src/Markdig.Tests/Specs/MathSpecs.md
@@ -35,26 +35,26 @@ This is not a $math
 block$ and? this is a $math block$
 .
 <p>This is not a $math
-block$ and? this is a <span class="math">(\math block\)</span></p>
+block$ and? this is a <span class="math">\(math block\)</span></p>
 ````````````````````````````````
 An opening `$` can be followed by a space if the closing is also preceded by a space `$`:
 
 ```````````````````````````````` example
 This is a $ math block $
 .
-<p>This is a <span class="math">math block</span></p>
+<p>This is a <span class="math">\(math block\)</span></p>
 ````````````````````````````````
 
 ```````````````````````````````` example
 This is a $    math block     $ after
 .
-<p>This is a <span class="math">math block</span> after</p>
+<p>This is a <span class="math">\(math block\)</span> after</p>
 ````````````````````````````````
 
 ```````````````````````````````` example
 This is a $$    math block     $$ after
 .
-<p>This is a <span class="math">math block</span> after</p>
+<p>This is a <span class="math">\(math block\)</span> after</p>
 ````````````````````````````````
 
 ```````````````````````````````` example
@@ -92,7 +92,7 @@ A `$` can be escaped between a math inline block by using the escape `\\`
 ```````````````````````````````` example
 This is a $math \$ block$
 .
-<p>This is a <span class="math">math \$ block</span></p>
+<p>This is a <span class="math">\(math \$ block\)</span></p>
 ````````````````````````````````
 
 At most, two `$` will be matched for the opening and closing:
@@ -100,7 +100,7 @@ At most, two `$` will be matched for the opening and closing:
 ```````````````````````````````` example
 This is a $$$math block$$$
 .
-<p>This is a <span class="math">$math block$</span></p>
+<p>This is a <span class="math">\($math block$\)</span></p>
 ````````````````````````````````
 
 Regular text can come both before and after the math inline
@@ -108,21 +108,21 @@ Regular text can come both before and after the math inline
 ```````````````````````````````` example
 This is a $math block$ with text on both sides.
 .
-<p>This is a <span class="math">math block</span> with text on both sides.</p>
+<p>This is a <span class="math">\(math block\)</span> with text on both sides.</p>
 ````````````````````````````````
 A mathematic block takes precedence over standard emphasis `*` `_`:
 
 ```````````````````````````````` example
 This is *a $math* block$
 .
-<p>This is *a <span class="math">math* block</span></p>
+<p>This is *a <span class="math">\(math* block\)</span></p>
 ````````````````````````````````
 An opening $$ at the beginning of a line should not be interpreted as a Math block:
 
 ```````````````````````````````` example
 $$ math $$ starting at a line
 .
-<p><span class="math">math</span> starting at a line</p>
+<p><span class="math">\(math\)</span> starting at a line</p>
 ````````````````````````````````
 
 ## Math Block
@@ -138,9 +138,11 @@ $$
 \end{equation}
 $$
 .
-<div class="math">\begin{equation}
+<div class="math">
+\[
+\begin{equation}
   \int_0^\infty \frac{x^3}{e^x-1}\,dx = \frac{\pi^4}{15}
   \label{eq:sample}
 \end{equation}
-</div>
+\]</div>
 ````````````````````````````````

--- a/src/Markdig.Tests/Specs/MathSpecs.md
+++ b/src/Markdig.Tests/Specs/MathSpecs.md
@@ -9,7 +9,7 @@ Allows to define a mathematic block embraced by `$...$`
 ```````````````````````````````` example
 This is a $math block$
 .
-<p>This is a <span class="math">math block</span></p>
+<p>This is a <span class="math">\(math block\)</span></p>
 ````````````````````````````````
 
 Or by `$$...$$` embracing it by:
@@ -17,7 +17,7 @@ Or by `$$...$$` embracing it by:
 ```````````````````````````````` example
 This is a $$math block$$
 .
-<p>This is a <span class="math">math block</span></p>
+<p>This is a <span class="math">\(math block\)</span></p>
 ````````````````````````````````
 
 Newlines inside an inline math are not allowed:
@@ -27,7 +27,7 @@ This is not a $$math
 block$$ and? this is a $$math block$$
 .
 <p>This is not a $$math
-block$$ and? this is a <span class="math">math block</span></p>
+block$$ and? this is a <span class="math">\(math block\)</span></p>
 ````````````````````````````````
 
 ```````````````````````````````` example
@@ -35,7 +35,7 @@ This is not a $math
 block$ and? this is a $math block$
 .
 <p>This is not a $math
-block$ and? this is a <span class="math">math block</span></p>
+block$ and? this is a <span class="math">(\math block\)</span></p>
 ````````````````````````````````
 An opening `$` can be followed by a space if the closing is also preceded by a space `$`:
 

--- a/src/Markdig.Tests/TestParser.cs
+++ b/src/Markdig.Tests/TestParser.cs
@@ -98,6 +98,74 @@ namespace Markdig.Tests
             }
         }
 
+
+        [Test]
+        public void VisualizeMathExpressions()
+        {
+            string math = @"Math expressions
+
+$\frac{n!}{k!(n-k)!} = \binom{n}{k}$
+
+$$\frac{n!}{k!(n-k)!} = \binom{n}{k}$$
+
+$$
+\frac{n!}{k!(n-k)!} = \binom{n}{k}
+$$
+
+<div class=""math"">
+\begin{align}
+\sqrt{37} & = \sqrt{\frac{73^2-1}{12^2}} \\
+ & = \sqrt{\frac{73^2}{12^2}\cdot\frac{73^2-1}{73^2}} \\ 
+ & = \sqrt{\frac{73^2}{12^2}}\sqrt{\frac{73^2-1}{73^2}} \\
+ & = \frac{73}{12}\sqrt{1 - \frac{1}{73^2}} \\ 
+ & \approx \frac{73}{12}\left(1 - \frac{1}{2\cdot73^2}\right)
+\end{align}
+</div>
+";
+            Console.WriteLine("Math Expressions:\n");
+
+            var pl = new MarkdownPipelineBuilder().UseMathematics().Build(); // UseEmphasisExtras(EmphasisExtraOptions.Subscript).Build()
+
+
+            var html = Markdown.ToHtml(math, pl);
+            Console.WriteLine(html);
+        }
+
+        [Test]
+        public void InlineMathExpression()
+        {
+            string math = @"Math expressions
+
+$\frac{n!}{k!(n-k)!} = \binom{n}{k}$
+";
+            var pl = new MarkdownPipelineBuilder().UseMathematics().Build(); // UseEmphasisExtras(EmphasisExtraOptions.Subscript).Build()
+
+            var html = Markdown.ToHtml(math, pl);
+            Console.WriteLine(html);
+
+            Assert.IsTrue(html.Contains("<p><span class=\"math\">\\("),"Leading bracket missing");
+            Assert.IsTrue(html.Contains("\\)</span></p>"), "Trailing bracket missing");
+        }
+
+        [Test]
+        public void BlockMathExpression()
+        {
+            string math = @"Math expressions
+
+$$
+\frac{n!}{k!(n-k)!} = \binom{n}{k}
+$$
+";
+            var pl = new MarkdownPipelineBuilder().UseMathematics().Build(); // UseEmphasisExtras(EmphasisExtraOptions.Subscript).Build()
+
+            var html = Markdown.ToHtml(math, pl);
+            Console.WriteLine(html);
+
+            Assert.IsTrue(html.Contains("<div class=\"math\">\n\\["), "Leading bracket missing");
+            Assert.IsTrue(html.Contains("\\]</div>"), "Trailing bracket missing");
+        }
+
+
         public static void TestSpec(string inputText, string expectedOutputText, string extensions = null)
         {
             foreach (var pipeline in GetPipeline(extensions))

--- a/src/Markdig/Extensions/Mathematics/HtmlMathBlockRenderer.cs
+++ b/src/Markdig/Extensions/Mathematics/HtmlMathBlockRenderer.cs
@@ -15,8 +15,10 @@ namespace Markdig.Extensions.Mathematics
         protected override void Write(HtmlRenderer renderer, MathBlock obj)
         {
             renderer.EnsureLine();
-            renderer.Write("<div").WriteAttributes(obj).Write(">");
+            renderer.Write("<div").WriteAttributes(obj).WriteLine(">");
+            renderer.WriteLine("\\[");
             renderer.WriteLeafRawLines(obj, true, true);
+            renderer.Write("\\]");
             renderer.WriteLine("</div>");
         }
     }

--- a/src/Markdig/Extensions/Mathematics/HtmlMathInlineRenderer.cs
+++ b/src/Markdig/Extensions/Mathematics/HtmlMathInlineRenderer.cs
@@ -14,9 +14,9 @@ namespace Markdig.Extensions.Mathematics
     {
         protected override void Write(HtmlRenderer renderer, MathInline obj)
         {
-            renderer.Write("<span").WriteAttributes(obj).Write(">");
+            renderer.Write("<span").WriteAttributes(obj).Write(">\\(");
             renderer.WriteEscape(ref obj.Content);
-            renderer.Write("</span>");
+            renderer.Write("\\)</span>");
         }
     }
 }


### PR DESCRIPTION
Added bracketing to math expressions for better rendering support without fixups in various math libraries. 
- bracket  `\(` and `\)`  for inline expressions
- bracket `\[` and `\]` for block expressions

References Issue #307

For reference with other parsers (primarily PanDoc):

[BabelMark Specs](https://johnmacfarlane.net/babelmark2/?text=Math+expressions%0A%0A%24%5Cfrac%7Bn!%7D%7Bk!(n-k)!%7D+%3D+%5Cbinom%7Bn%7D%7Bk%7D%24%0A%0A%24%24%5Cfrac%7Bn!%7D%7Bk!(n-k)!%7D+%3D+%5Cbinom%7Bn%7D%7Bk%7D%24%24%0A%0A%24%24%0A%5Cfrac%7Bn!%7D%7Bk!(n-k)!%7D+%3D+%5Cbinom%7Bn%7D%7Bk%7D%0A%24%24%0A)