### PR TITLE
Fix ToPlainText with htmlentity

### DIFF
--- a/src/Markdig.Tests/TestPlainText.cs
+++ b/src/Markdig.Tests/TestPlainText.cs
@@ -28,6 +28,8 @@ namespace Markdig.Tests
         [TestCase(/* markdownText: */ "`foo\nbar`", /* expected: */ "foo bar\n")] // new line within codespan is treated as whitespace (Example317)
         [TestCase(/* markdownText: */ "```\nfoo bar\n```", /* expected: */ "foo bar\n")]
         [TestCase(/* markdownText: */ "- foo\n- bar\n- baz", /* expected: */ "foo\nbar\nbaz\n")]
+        [TestCase(/* markdownText: */ "- foo<baz", /* expected: */ "foo<baz\n")]
+        [TestCase(/* markdownText: */ "- foo&lt;baz", /* expected: */ "foo<baz\n")]
         public void TestPlainEnsureNewLine(string markdownText, string expected)
         {            
             var actual = Markdown.ToPlainText(markdownText);

--- a/src/Markdig/Renderers/Html/Inlines/HtmlEntityInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/HtmlEntityInlineRenderer.cs
@@ -13,7 +13,10 @@ namespace Markdig.Renderers.Html.Inlines
     {
         protected override void Write(HtmlRenderer renderer, HtmlEntityInline obj)
         {
-            renderer.WriteEscape(obj.Transcoded);
+            if (renderer.EnableHtmlForInline)
+                renderer.WriteEscape(obj.Transcoded);
+            else
+                renderer.Write(obj.Transcoded);
         }
     }
 }

--- a/src/Markdig/Renderers/Html/Inlines/HtmlEntityInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/HtmlEntityInlineRenderer.cs
@@ -14,9 +14,13 @@ namespace Markdig.Renderers.Html.Inlines
         protected override void Write(HtmlRenderer renderer, HtmlEntityInline obj)
         {
             if (renderer.EnableHtmlForInline)
+            {
                 renderer.WriteEscape(obj.Transcoded);
+            }
             else
+            {
                 renderer.Write(obj.Transcoded);
+            }
         }
     }
 }

--- a/src/Markdig/Renderers/Html/Inlines/LiteralInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LiteralInlineRenderer.cs
@@ -13,7 +13,10 @@ namespace Markdig.Renderers.Html.Inlines
     {
         protected override void Write(HtmlRenderer renderer, LiteralInline obj)
         {
-            renderer.WriteEscape(ref obj.Content);
+            if (renderer.EnableHtmlForInline)
+                renderer.WriteEscape(obj.Content);
+            else
+                renderer.Write(obj.Content);
         }
     }
 }

--- a/src/Markdig/Renderers/Html/Inlines/LiteralInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LiteralInlineRenderer.cs
@@ -14,9 +14,13 @@ namespace Markdig.Renderers.Html.Inlines
         protected override void Write(HtmlRenderer renderer, LiteralInline obj)
         {
             if (renderer.EnableHtmlForInline)
+            {
                 renderer.WriteEscape(obj.Content);
+            }
             else
+            {
                 renderer.Write(obj.Content);
+            }
         }
     }
 }


### PR DESCRIPTION
The `ToPlainText` should not resulted in html entities.

Current version:
```cs
> Markdig.Markdown.ToPlainText("foo<bar")
"foo&lt;bar\n"
> Markdig.Markdown.ToPlainText("foo&lt;bar")
"foo&lt;bar\n"
```

Expacted:
```cs
> Markdig.Markdown.ToPlainText("foo<bar")
"foo<bar\n"
> Markdig.Markdown.ToPlainText("foo&lt;bar")
"foo<bar\n"
```