### PR TITLE
Fix regression from #315

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.userosscache
 *.sln.docstates
 *.nuget.props
+*.nuget.targets
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## WIP
+- Fix regression when escaping HTML characters ([(PR #340)](https://github.com/lunet-io/markdig/pull/340))
+
 ## 0.17.0 (10 May 2019)
 - Update to latest CommonMark specs 0.29 ([(PR #327)](https://github.com/lunet-io/markdig/pull/327))
 - Add `AutoLinkOptions` with `OpenInNewWindow`, `UseHttpsForWWWLinks` ([(PR #327)](https://github.com/lunet-io/markdig/pull/327))

--- a/src/Markdig.Tests/MiscTests.cs
+++ b/src/Markdig.Tests/MiscTests.cs
@@ -9,6 +9,14 @@ namespace Markdig.Tests
     public class MiscTests
     {
         [Test]
+        public void TestAltTextIsCorrectlyEscaped()
+        {
+            TestParser.TestSpec(
+                @"![This is image alt text with quotation ' and double quotation ""hello"" world](girl.png)",
+                @"<p><img src=""girl.png"" alt=""This is image alt text with quotation ' and double quotation &quot;hello&quot; world"" /></p>");
+        }
+
+        [Test]
         public void TestChangelogPRLinksMatchDescription()
         {
             string solutionFolder = Path.GetFullPath(Path.Combine(TestParser.TestsDirectory, "../.."));

--- a/src/Markdig/Markdown.cs
+++ b/src/Markdig/Markdown.cs
@@ -184,7 +184,8 @@ namespace Markdig
             var renderer = new HtmlRenderer(writer)
             {
                 EnableHtmlForBlock = false,
-                EnableHtmlForInline = false
+                EnableHtmlForInline = false,
+                EnableHtmlEscape = false,
             };
             pipeline.Setup(renderer);
 

--- a/src/Markdig/Renderers/Html/Inlines/HtmlEntityInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/HtmlEntityInlineRenderer.cs
@@ -13,7 +13,7 @@ namespace Markdig.Renderers.Html.Inlines
     {
         protected override void Write(HtmlRenderer renderer, HtmlEntityInline obj)
         {
-            if (renderer.EnableHtmlForInline)
+            if (renderer.EnableHtmlEscape)
             {
                 renderer.WriteEscape(obj.Transcoded);
             }

--- a/src/Markdig/Renderers/Html/Inlines/LiteralInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LiteralInlineRenderer.cs
@@ -13,13 +13,13 @@ namespace Markdig.Renderers.Html.Inlines
     {
         protected override void Write(HtmlRenderer renderer, LiteralInline obj)
         {
-            if (renderer.EnableHtmlForInline)
+            if (renderer.EnableHtmlEscape)
             {
-                renderer.WriteEscape(obj.Content);
+                renderer.WriteEscape(ref obj.Content);
             }
             else
             {
-                renderer.Write(obj.Content);
+                renderer.Write(ref obj.Content);
             }
         }
     }


### PR DESCRIPTION
`EnableHtmlEscape` should have been used instead of `EnableHtmlForInline`.

Caught by a test from docfx.