### PR TITLE
Ignore backticks in GFM AutoLinks

### DIFF
--- a/src/Markdig.Tests/MiscTests.cs
+++ b/src/Markdig.Tests/MiscTests.cs
@@ -9,6 +9,16 @@ namespace Markdig.Tests
     public class MiscTests
     {
         [Test]
+        public void IsIssue356Corrected()
+        {
+            string input = @"https://foo.bar/path/\#m4mv5W0GYKZpGvfA.97";
+            string expected = @"<p><a href=""https://foo.bar/path/%5C#m4mv5W0GYKZpGvfA.97"">https://foo.bar/path/\#m4mv5W0GYKZpGvfA.97</a></p>";
+
+            TestParser.TestSpec($"<{input}>", expected);
+            TestParser.TestSpec(input, expected, "autolinks|advanced");
+        }
+
+        [Test]
         public void TestAltTextIsCorrectlyEscaped()
         {
             TestParser.TestSpec(

--- a/src/Markdig/Helpers/LinkHelper.cs
+++ b/src/Markdig/Helpers/LinkHelper.cs
@@ -597,20 +597,23 @@ namespace Markdig.Helpers
                         }
                     }
 
-                    if (hasEscape && !c.IsAsciiPunctuation())
+                    if (!isAutoLink)
                     {
-                        buffer.Append('\\');
-                    }
+                        if (hasEscape && !c.IsAsciiPunctuation())
+                        {
+                            buffer.Append('\\');
+                        }
 
-                    // If we have an escape
-                    if (c == '\\')
-                    {
-                        hasEscape = true;
-                        c = text.NextChar();
-                        continue;
-                    }
+                        // If we have an escape
+                        if (c == '\\')
+                        {
+                            hasEscape = true;
+                            c = text.NextChar();
+                            continue;
+                        }
 
-                    hasEscape = false;
+                        hasEscape = false;
+                    }
 
                     if (IsEndOfUri(c, isAutoLink))
                     {
@@ -622,10 +625,7 @@ namespace Markdig.Helpers
                     {
                         if (c == '&')
                         {
-                            int entityNameStart;
-                            int entityNameLength;
-                            int entityValue;
-                            if (HtmlHelper.ScanEntity(text, out entityValue, out entityNameStart, out entityNameLength) > 0)
+                            if (HtmlHelper.ScanEntity(text, out _, out _, out _) > 0)
                             {
                                 isValid = true;
                                 break;


### PR DESCRIPTION
Fixes #356 


The cause for the last character disappearing stems from [this span calculation](https://github.com/lunet-io/markdig/blob/master/src/Markdig/Extensions/AutoLinks/AutoLinkParser.cs#L170) that uses `link.Length` even though backticks could be removed from the string.
This honors the difference between links and autolinks as stated [in CommonMark](https://spec.commonmark.org/0.29/#example-306) and does not allow backtick escaping in automatic autolinks.