### PR TITLE
Add missing Descendants<T> api

### DIFF
--- a/src/Markdig.Tests/TestDescendantsOrder.cs
+++ b/src/Markdig.Tests/TestDescendantsOrder.cs
@@ -3,6 +3,7 @@ using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using System.Linq;
 using System.Collections.Generic;
+using Markdig.Helpers;
 
 namespace Markdig.Tests
 {
@@ -12,24 +13,91 @@ namespace Markdig.Tests
         [Test]
         public void TestSchemas()
         {
-            foreach (var markdown in TestParser.SpecsMarkdown)
+            foreach (var syntaxTree in TestParser.SpecsSyntaxTrees)
             {
-                AssertSameDescendantsOrder(markdown);
+                AssertIEnumerablesAreEqual(
+                    Descendants_Legacy(syntaxTree),
+                    syntaxTree.Descendants());
+
+                AssertIEnumerablesAreEqual(
+                    syntaxTree.Descendants().OfType<ParagraphBlock>(),
+                    syntaxTree.Descendants<ParagraphBlock>());
+
+                AssertIEnumerablesAreEqual(
+                    syntaxTree.Descendants().OfType<ParagraphBlock>(),
+                    (syntaxTree as ContainerBlock).Descendants<ParagraphBlock>());
+
+                AssertIEnumerablesAreEqual(
+                    syntaxTree.Descendants().OfType<LiteralInline>(),
+                    syntaxTree.Descendants<LiteralInline>());
+
+                foreach (LiteralInline literalInline in syntaxTree.Descendants<LiteralInline>())
+                {
+                    Assert.AreSame(ArrayHelper<ListBlock>.Empty, literalInline.Descendants<ListBlock>());
+                    Assert.AreSame(ArrayHelper<ParagraphBlock>.Empty, literalInline.Descendants<ParagraphBlock>());
+                    Assert.AreSame(ArrayHelper<ContainerInline>.Empty, literalInline.Descendants<ContainerInline>());
+                }
+
+                foreach (ContainerInline containerInline in syntaxTree.Descendants<ContainerInline>())
+                {
+                    AssertIEnumerablesAreEqual(
+                        containerInline.FindDescendants<LiteralInline>(),
+                        containerInline.Descendants<LiteralInline>());
+
+                    AssertIEnumerablesAreEqual(
+                        containerInline.FindDescendants<LiteralInline>(),
+                        (containerInline as MarkdownObject).Descendants<LiteralInline>());
+
+                    if (containerInline.FirstChild is null)
+                    {
+                        Assert.AreSame(ArrayHelper<LiteralInline>.Empty, containerInline.Descendants<LiteralInline>());
+                        Assert.AreSame(ArrayHelper<LiteralInline>.Empty, containerInline.FindDescendants<LiteralInline>());
+                        Assert.AreSame(ArrayHelper<LiteralInline>.Empty, (containerInline as MarkdownObject).Descendants<LiteralInline>());
+                    }
+
+                    Assert.AreSame(ArrayHelper<ListBlock>.Empty, containerInline.Descendants<ListBlock>());
+                    Assert.AreSame(ArrayHelper<ParagraphBlock>.Empty, containerInline.Descendants<ParagraphBlock>());
+                }
+
+                foreach (ParagraphBlock paragraphBlock in syntaxTree.Descendants<ParagraphBlock>())
+                {
+                    AssertIEnumerablesAreEqual(
+                        (paragraphBlock as MarkdownObject).Descendants<LiteralInline>(),
+                        paragraphBlock.Descendants<LiteralInline>());
+
+                    Assert.AreSame(ArrayHelper<ParagraphBlock>.Empty, paragraphBlock.Descendants<ParagraphBlock>());
+                }
+
+                foreach (ContainerBlock containerBlock in syntaxTree.Descendants<ContainerBlock>())
+                {
+                    AssertIEnumerablesAreEqual(
+                        containerBlock.Descendants<LiteralInline>(),
+                        (containerBlock as MarkdownObject).Descendants<LiteralInline>());
+
+                    AssertIEnumerablesAreEqual(
+                        containerBlock.Descendants<ParagraphBlock>(),
+                        (containerBlock as MarkdownObject).Descendants<ParagraphBlock>());
+
+                    if (containerBlock.Count == 0)
+                    {
+                        Assert.AreSame(ArrayHelper<LiteralInline>.Empty, containerBlock.Descendants<LiteralInline>());
+                        Assert.AreSame(ArrayHelper<LiteralInline>.Empty, (containerBlock as Block).Descendants<LiteralInline>());
+                        Assert.AreSame(ArrayHelper<LiteralInline>.Empty, (containerBlock as MarkdownObject).Descendants<LiteralInline>());
+                    }
+                }
             }
         }
 
-        private void AssertSameDescendantsOrder(string markdown)
+        private static void AssertIEnumerablesAreEqual<T>(IEnumerable<T> first, IEnumerable<T> second)
         {
-            var syntaxTree = Markdown.Parse(markdown, new MarkdownPipelineBuilder().UseAdvancedExtensions().Build());
+            var firstList = new List<T>(first);
+            var secondList = new List<T>(second);
 
-            var descendants_legacy = Descendants_Legacy(syntaxTree).ToList();
-            var descendants_new = syntaxTree.Descendants().ToList();
+            Assert.AreEqual(firstList.Count, secondList.Count);
 
-            Assert.AreEqual(descendants_legacy.Count, descendants_new.Count);
-
-            for (int i = 0; i < descendants_legacy.Count; i++)
+            for (int i = 0; i < firstList.Count; i++)
             {
-                Assert.AreSame(descendants_legacy[i], descendants_new[i]);
+                Assert.AreSame(firstList[i], secondList[i]);
             }
         }
 

--- a/src/Markdig.Tests/TestParser.cs
+++ b/src/Markdig.Tests/TestParser.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Markdig.Extensions.JiraLinks;
+using Markdig.Syntax;
 using NUnit.Framework;
 
 namespace Markdig.Tests
@@ -151,6 +152,11 @@ namespace Markdig.Tests
         /// Contains the markdown source for specification files (order is the same as in <see cref="SpecsFilePaths"/>)
         /// </summary>
         public static readonly string[] SpecsMarkdown;
+        /// <summary>
+        /// Contains the markdown syntax tree for specification files (order is the same as in <see cref="SpecsFilePaths"/>)
+        /// </summary>
+        public static readonly MarkdownDocument[] SpecsSyntaxTrees;
+
         static TestParser()
         {
             SpecsFilePaths = Directory.GetDirectories(TestsDirectory)
@@ -161,10 +167,16 @@ namespace Markdig.Tests
                 .ToArray();
 
             SpecsMarkdown = new string[SpecsFilePaths.Length];
+            SpecsSyntaxTrees = new MarkdownDocument[SpecsFilePaths.Length];
+
+            var pipeline = new MarkdownPipelineBuilder()
+                .UseAdvancedExtensions()
+                .Build();
 
             for (int i = 0; i < SpecsFilePaths.Length; i++)
             {
-                SpecsMarkdown[i] = File.ReadAllText(SpecsFilePaths[i]);
+                string markdown = SpecsMarkdown[i] = File.ReadAllText(SpecsFilePaths[i]);
+                SpecsSyntaxTrees[i] = Markdown.Parse(markdown, pipeline);
             }
         }
     }

--- a/src/Markdig.Tests/TestPlayParser.cs
+++ b/src/Markdig.Tests/TestPlayParser.cs
@@ -57,7 +57,7 @@ Later in a text we are using HTML and it becomes an abbr tag HTML
 > some other text";
             var doc = Markdown.Parse(text);
 
-            Assert.True(doc.Descendants().OfType<LiteralInline>().All(x => !x.Content.IsEmpty),
+            Assert.True(doc.Descendants<LiteralInline>().All(x => !x.Content.IsEmpty),
                 "There should not have any empty literals");
         }
 

--- a/src/Markdig.Tests/TestSourcePosition.cs
+++ b/src/Markdig.Tests/TestSourcePosition.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Markdig.Extensions.Footnotes;
-using Markdig.Helpers;
 using Markdig.Renderers.Html;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
@@ -147,7 +146,7 @@ literal      ( 0, 6)  6-7
         public void TestFootnoteLinkReferenceDefinition()
         {
             //                             01 2 345678
-            var footnote = Markdown.Parse("0\n\n [^1]:", new MarkdownPipelineBuilder().UsePreciseSourceLocation().UseFootnotes().Build()).Descendants().OfType<FootnoteLinkReferenceDefinition>().FirstOrDefault();
+            var footnote = Markdown.Parse("0\n\n [^1]:", new MarkdownPipelineBuilder().UsePreciseSourceLocation().UseFootnotes().Build()).Descendants<FootnoteLinkReferenceDefinition>().FirstOrDefault();
             Assert.NotNull(footnote);
 
             Assert.AreEqual(2, footnote.Line);
@@ -160,7 +159,7 @@ literal      ( 0, 6)  6-7
         {
             //                         0         1
             //                         0123456789012345
-            var link = Markdown.Parse("[234]: /56 'yo' ", new MarkdownPipelineBuilder().UsePreciseSourceLocation().Build()).Descendants().OfType<LinkReferenceDefinition>().FirstOrDefault();
+            var link = Markdown.Parse("[234]: /56 'yo' ", new MarkdownPipelineBuilder().UsePreciseSourceLocation().Build()).Descendants<LinkReferenceDefinition>().FirstOrDefault();
             Assert.NotNull(link);
 
             Assert.AreEqual(0, link.Line);
@@ -175,7 +174,7 @@ literal      ( 0, 6)  6-7
         {
             //                         0          1
             //                         01 2 34567890123456789
-            var link = Markdown.Parse("0\n\n [234]: /56 'yo' ", new MarkdownPipelineBuilder().UsePreciseSourceLocation().Build()).Descendants().OfType<LinkReferenceDefinition>().FirstOrDefault();
+            var link = Markdown.Parse("0\n\n [234]: /56 'yo' ", new MarkdownPipelineBuilder().UsePreciseSourceLocation().Build()).Descendants<LinkReferenceDefinition>().FirstOrDefault();
             Assert.NotNull(link);
 
             Assert.AreEqual(2, link.Line);
@@ -213,7 +212,7 @@ literal      ( 0, 4)  4-5
         {
             //                         0           1
             //                         01 2 3456789012345
-            var link = Markdown.Parse("0\n\n01 [234](/56)", new MarkdownPipelineBuilder().UsePreciseSourceLocation().Build()).Descendants().OfType<LinkInline>().FirstOrDefault();
+            var link = Markdown.Parse("0\n\n01 [234](/56)", new MarkdownPipelineBuilder().UsePreciseSourceLocation().Build()).Descendants<LinkInline>().FirstOrDefault();
             Assert.NotNull(link);
 
             Assert.AreEqual(new SourceSpan(7, 9), link.LabelSpan);
@@ -226,7 +225,7 @@ literal      ( 0, 4)  4-5
         {
             //                         0           1
             //                         01 2 34567890123456789
-            var link = Markdown.Parse("0\n\n01 [234](/56 'yo')", new MarkdownPipelineBuilder().UsePreciseSourceLocation().Build()).Descendants().OfType<LinkInline>().FirstOrDefault();
+            var link = Markdown.Parse("0\n\n01 [234](/56 'yo')", new MarkdownPipelineBuilder().UsePreciseSourceLocation().Build()).Descendants<LinkInline>().FirstOrDefault();
             Assert.NotNull(link);
 
             Assert.AreEqual(new SourceSpan(7, 9), link.LabelSpan);
@@ -240,7 +239,7 @@ literal      ( 0, 4)  4-5
         {
             //                         0           1
             //                         01 2 3456789012345
-            var link = Markdown.Parse("0\n\n01![234](/56)", new MarkdownPipelineBuilder().UsePreciseSourceLocation().Build()).Descendants().OfType<LinkInline>().FirstOrDefault();
+            var link = Markdown.Parse("0\n\n01![234](/56)", new MarkdownPipelineBuilder().UsePreciseSourceLocation().Build()).Descendants<LinkInline>().FirstOrDefault();
             Assert.NotNull(link);
 
             Assert.AreEqual(new SourceSpan(5, 15), link.Span);
@@ -408,7 +407,7 @@ literal      ( 1, 2)  6-6
 6. Bar
 987123. FooBar";
             test = test.Replace("\r\n", "\n");
-            var list = Markdown.Parse(test, new MarkdownPipelineBuilder().UsePreciseSourceLocation().Build()).Descendants().OfType<ListBlock>().FirstOrDefault();
+            var list = Markdown.Parse(test, new MarkdownPipelineBuilder().UsePreciseSourceLocation().Build()).Descendants<ListBlock>().FirstOrDefault();
             Assert.NotNull(list);
 
             Assert.AreEqual(1, list.Line);

--- a/src/Markdig/Extensions/Bootstrap/BootstrapExtension.cs
+++ b/src/Markdig/Extensions/Bootstrap/BootstrapExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
@@ -51,8 +51,7 @@ namespace Markdig.Extensions.Bootstrap
                 }
                 else if (node is Inline)
                 {
-                    var link = node as LinkInline;
-                    if (link != null && link.IsImage)
+                    if (node is LinkInline link && link.IsImage)
                     {
                         link.GetAttributes().AddClass("img-fluid");
                     }

--- a/src/Markdig/Extensions/Globalization/GlobalizationExtension.cs
+++ b/src/Markdig/Extensions/Globalization/GlobalizationExtension.cs
@@ -38,7 +38,7 @@ namespace Markdig.Extensions.Globalization
                     var attributes = node.GetAttributes();
                     attributes.AddPropertyIfNotExist("dir", "rtl");
 
-                    if (node is Table table)
+                    if (node is Table)
                     {
                         attributes.AddPropertyIfNotExist("align", "right");
                     }
@@ -71,19 +71,16 @@ namespace Markdig.Extensions.Globalization
             }
             else if (item is LiteralInline literal)
             {
-                return StartsWithRtlCharacter(literal.ToString());
+                return StartsWithRtlCharacter(literal.Content);
             }
 
-            foreach (var descendant in item.Descendants())
+            foreach (var paragraph in item.Descendants<ParagraphBlock>())
             {
-                if (descendant is ParagraphBlock p)
+                foreach (var inline in paragraph.Inline)
                 {
-                    foreach (var i in p.Inline)
+                    if (inline is LiteralInline literal)
                     {
-                        if (i is LiteralInline l)
-                        {
-                            return StartsWithRtlCharacter(l.ToString());
-                        }
+                        return StartsWithRtlCharacter(literal.Content);
                     }
                 }
             }
@@ -91,9 +88,9 @@ namespace Markdig.Extensions.Globalization
             return false;
         }
 
-        private bool StartsWithRtlCharacter(string text)
+        private bool StartsWithRtlCharacter(StringSlice slice)
         {
-            foreach (var c in CharHelper.ToUtf32(text))
+            foreach (var c in CharHelper.ToUtf32(slice))
             {
                 if (CharHelper.IsRightToLeft(c))
                     return true;

--- a/src/Markdig/Helpers/CharHelper.cs
+++ b/src/Markdig/Helpers/CharHelper.cs
@@ -393,11 +393,11 @@ namespace Markdig.Helpers
             return (((highSurrogate - HighSurrogateStart) * 0x400) + (lowSurrogate - LowSurrogateStart) + UnicodePlane01Start);
         }
 
-        public static IEnumerable<int> ToUtf32(string text)
+        public static IEnumerable<int> ToUtf32(StringSlice text)
         {
-            for (int i = 0; i < text.Length; i++)
+            for (int i = text.Start; i <= text.End; i++)
             {
-                if (IsHighSurrogate(text[i]) && i < text.Length - 1 && IsLowSurrogate(text[i + 1]))
+                if (IsHighSurrogate(text[i]) && i < text.End && IsLowSurrogate(text[i + 1]))
                 {
                     yield return ConvertToUtf32(text[i], text[i + 1]);
                 }

--- a/src/Markdig/Syntax/Inlines/ContainerInline.cs
+++ b/src/Markdig/Syntax/Inlines/ContainerInline.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
+using Markdig.Helpers;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 
 namespace Markdig.Syntax.Inlines
@@ -94,8 +96,20 @@ namespace Markdig.Syntax.Inlines
         /// <returns>An enumeration of T</returns>
         public IEnumerable<T> FindDescendants<T>() where T : Inline
         {
-            // Fast-path an empty container to avoid allocating a Stack
-            if (LastChild == null) yield break;
+            if (FirstChild is null)
+            {
+                return ArrayHelper<T>.Empty;
+            }
+            else
+            {
+                return FindDescendantsInternal<T>();
+            }
+        }
+        internal IEnumerable<T> FindDescendantsInternal<T>() where T : MarkdownObject
+        {
+#if !UAP
+            Debug.Assert(typeof(T).IsSubclassOf(typeof(Inline)));
+#endif
 
             Stack<Inline> stack = new Stack<Inline>();
 

--- a/src/Markdig/Syntax/MarkdownObjectExtensions.cs
+++ b/src/Markdig/Syntax/MarkdownObjectExtensions.cs
@@ -3,6 +3,8 @@
 // See the license.txt file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
+using Markdig.Helpers;
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Syntax
@@ -20,10 +22,6 @@ namespace Markdig.Syntax
         /// <returns>An iteration over the descendant elements</returns>
         public static IEnumerable<MarkdownObject> Descendants(this MarkdownObject markdownObject)
         {
-            // Fast-path an object with no children to avoid allocating Stack objects
-            if (!(markdownObject is ContainerBlock) && !(markdownObject is ContainerInline)) yield break;
-
-            // TODO: A single Stack<(MarkdownObject block, bool push)> when ValueTuples are available
             Stack<MarkdownObject> stack = new Stack<MarkdownObject>();
             Stack<bool> pushStack = new Stack<bool>();
 
@@ -66,7 +64,51 @@ namespace Markdig.Syntax
         }
 
         /// <summary>
-        /// Iterates over the descendant elements for the specified markdown <see cref="Inline" /> element and filters by the type {T}.
+        /// Iterates over the descendant elements for the specified markdown element, including <see cref="Block"/> and <see cref="Inline"/> and filters by the type <typeparamref name="T"/>.
+        /// <para>The descendant elements are returned in DFS-like order.</para>
+        /// </summary>
+        /// <typeparam name="T">Type to use for filtering the descendants</typeparam>
+        /// <param name="markdownObject">The markdown object.</param>
+        /// <returns>An iteration over the descendant elements</returns>
+        public static IEnumerable<T> Descendants<T>(this MarkdownObject markdownObject) where T : MarkdownObject
+        {
+#if UAP
+            foreach (MarkdownObject descendant in markdownObject.Descendants())
+            {
+                if (descendant is T descendantT)
+                {
+                    yield return descendantT;
+                }
+            }
+#else
+            if (typeof(T).IsSubclassOf(typeof(Block)))
+            {
+                if (markdownObject is ContainerBlock containerBlock && containerBlock.Count > 0)
+                {
+                    return BlockDescendantsInternal<T>(containerBlock);
+                }
+            }
+            else // typeof(T).IsSubclassOf(typeof(Inline)))
+            {
+                if (markdownObject is ContainerBlock containerBlock)
+                {
+                    if (containerBlock.Count > 0)
+                    {
+                        return InlineDescendantsInternal<T>(containerBlock);
+                    }
+                }
+                else if (markdownObject is ContainerInline containerInline && containerInline.FirstChild != null)
+                {
+                    return containerInline.FindDescendantsInternal<T>();
+                }
+            }
+
+            return ArrayHelper<T>.Empty;
+#endif
+        }
+
+        /// <summary>
+        /// Iterates over the descendant elements for the specified markdown <see cref="Inline" /> element and filters by the type <typeparamref name="T"/>.
         /// </summary>
         /// <typeparam name="T">Type to use for filtering the descendants</typeparam>
         /// <param name="inline">The inline markdown object.</param>
@@ -77,7 +119,7 @@ namespace Markdig.Syntax
             => inline.FindDescendants<T>();
 
         /// <summary>
-        /// Iterates over the descendant elements for the specified markdown <see cref="Block" /> element and filters by the type {T}.
+        /// Iterates over the descendant elements for the specified markdown <see cref="Block" /> element and filters by the type <typeparamref name="T"/>.
         /// </summary>
         /// <typeparam name="T">Type to use for filtering the descendants</typeparam>
         /// <param name="block">The markdown object.</param>
@@ -86,8 +128,21 @@ namespace Markdig.Syntax
         /// </returns>
         public static IEnumerable<T> Descendants<T>(this ContainerBlock block) where T : Block
         {
-            // Fast-path an empty container to avoid allocating a Stack
-            if (block.Count == 0) yield break;
+            if (block != null && block.Count > 0)
+            {
+                return BlockDescendantsInternal<T>(block);
+            }
+            else
+            {
+                return ArrayHelper<T>.Empty;
+            }
+        }
+
+        private static IEnumerable<T> BlockDescendantsInternal<T>(ContainerBlock block) where T : MarkdownObject
+        {
+#if !UAP
+            Debug.Assert(typeof(T).IsSubclassOf(typeof(Block)));
+#endif
 
             Stack<Block> stack = new Stack<Block>();
 
@@ -112,6 +167,21 @@ namespace Markdig.Syntax
                     {
                         stack.Push(subBlockContainer[childrenCount]);
                     }
+                }
+            }
+        }
+
+        private static IEnumerable<T> InlineDescendantsInternal<T>(ContainerBlock block) where T : MarkdownObject
+        {
+#if !UAP
+            Debug.Assert(typeof(T).IsSubclassOf(typeof(Inline)));
+#endif
+
+            foreach (MarkdownObject descendant in block.Descendants())
+            {
+                if (descendant is T descendantT)
+                {
+                    yield return descendantT;
                 }
             }
         }


### PR DESCRIPTION
We were missing a few conveniance overloads (#63)

```c#
IEnumerable<T> Descendants<T>(this MarkdownObject) where T : Inline
IEnumerable<T> Descendants<T>(this MarkdownObject) where T : Block
```

Since these can't coexist in C#, I added one `where T : MarkdownObject` that then calls the appropriate internal overload for optimal traversal (has the added bonus of not allocating when it's obvious there can't be any descendants).

Added tests for all the different overloads to make sure the traversal logic is correct.