### PR TITLE
Use HashSet<T> instead of Dictionary<TKey, TValue> in CharacterMap<T>

### DIFF
--- a/src/Markdig/Helpers/CharacterMap.cs
+++ b/src/Markdig/Helpers/CharacterMap.cs
@@ -27,18 +27,14 @@ namespace Markdig.Helpers
         public CharacterMap(IEnumerable<KeyValuePair<char, T>> maps)
         {
             if (maps == null) throw new ArgumentNullException(nameof(maps));
-            var charCounter = new Dictionary<char, int>();
+            var charSet = new HashSet<char>();
             int maxChar = 0;
 
             foreach (var map in maps)
             {
                 var openingChar = map.Key;
 
-                if (!charCounter.ContainsKey(openingChar))
-                {
-                    charCounter[openingChar] = 0;
-                }
-                charCounter[openingChar]++;
+                charSet.Add(openingChar);
 
                 if (openingChar < 127 && openingChar > maxChar)
                 {
@@ -50,7 +46,7 @@ namespace Markdig.Helpers
                     nonAsciiMap = new Dictionary<char, T>();
                 }
             }
-            OpeningCharacters = charCounter.Keys.ToArray();
+            OpeningCharacters = charSet.ToArray();
             Array.Sort(OpeningCharacters);
 
             asciiMap = new T[maxChar + 1];


### PR DESCRIPTION
The `CharacterMap<T>` constructor counts the occurrence of each opening character, but doesn't use the actual count.

This PR replaces the `Dictionary<char, int>` by a `HashSet<char>`. The dictionary used to be indexed three or four times per iteration though the loop, the hashSet is indexed once per iteration.