### PR TITLE
Fixed a bug in HeadingRenderer

### DIFF
--- a/src/Markdig/Renderers/Html/HeadingRenderer.cs
+++ b/src/Markdig/Renderers/Html/HeadingRenderer.cs
@@ -23,9 +23,10 @@ namespace Markdig.Renderers.Html
 
         protected override void Write(HtmlRenderer renderer, HeadingBlock obj)
         {
-            var headingText = obj.Level > 0 && obj.Level <= 6
-                ? HeadingTexts[obj.Level - 1]
-                : "<h" + obj.Level.ToString(CultureInfo.InvariantCulture);
+            int index = obj.Level - 1;
+            string headingText = ((uint)index < (uint)HeadingTexts.Length)
+                ? HeadingTexts[index]
+                : "h" + obj.Level.ToString(CultureInfo.InvariantCulture);
 
             if (renderer.EnableHtmlForBlock)
             {


### PR DESCRIPTION
The rendered HTML for Heading level 7 and above was incorrect.

This PR fixes that.

In addition, a minor optimization removes the range check over the array bounds.