### PR TITLE
Make output of HtmlTableRenderer XML wellformed

### DIFF
--- a/src/Markdig.Tests/Specs/GridTableSpecs.md
+++ b/src/Markdig.Tests/Specs/GridTableSpecs.md
@@ -42,8 +42,8 @@ The following is a valid row separator
 | This is | a table |
 .
 <table>
-<col style="width:50%">
-<col style="width:50%">
+<col style="width:50%" />
+<col style="width:50%" />
 <tbody>
 <tr>
 <td>This is</td>
@@ -74,9 +74,9 @@ A regular row can continue a previous regular row when column separator `|` are 
 | Col1c                       |
 .
 <table>
-<col style="width:33.33%">
-<col style="width:33.33%">
-<col style="width:33.33%">
+<col style="width:33.33%" />
+<col style="width:33.33%" />
+<col style="width:33.33%" />
 <tbody>
 <tr>
 <td>Col1
@@ -105,8 +105,8 @@ A row header is separated using `+========+` instead of `+---------+`:
 +=========+=========+
 .
 <table>
-<col style="width:50%">
-<col style="width:50%">
+<col style="width:50%" />
+<col style="width:50%" />
 <thead>
 <tr>
 <th>This is</th>
@@ -123,8 +123,8 @@ The last column separator `|` may be omitted:
 | This is | a table with a longer text in the second column
 .
 <table>
-<col style="width:50%">
-<col style="width:50%">
+<col style="width:50%" />
+<col style="width:50%" />
 <tbody>
 <tr>
 <td>This is</td>
@@ -150,9 +150,9 @@ So the width would be 4/16 = 25%, 8/16 = 50%, 4/16 = 25%
 +----+--------+----+
 .
 <table>
-<col style="width:25%">
-<col style="width:50%">
-<col style="width:25%">
+<col style="width:25%" />
+<col style="width:50%" />
+<col style="width:25%" />
 <tbody>
 <tr>
 <td>A</td>
@@ -172,9 +172,9 @@ Alignment might be specified on the first row using the character `:`:
 +-----+-----+-----+
 .
 <table>
-<col style="width:33.33%">
-<col style="width:33.33%">
-<col style="width:33.33%">
+<col style="width:33.33%" />
+<col style="width:33.33%" />
+<col style="width:33.33%" />
 <tbody>
 <tr>
 <td>A</td>
@@ -197,9 +197,9 @@ Alignment might be specified on the first row using the character `:`:
 +---+---+---+
 .
 <table>
-<col style="width:33.33%">
-<col style="width:33.33%">
-<col style="width:33.33%">
+<col style="width:33.33%" />
+<col style="width:33.33%" />
+<col style="width:33.33%" />
 <tbody>
 <tr>
 <td colspan="2">AAAAA</td>
@@ -232,9 +232,9 @@ A grid table may have cells with both colspan and rowspan:
 +---+---+---+
 .
 <table>
-<col style="width:33.33%">
-<col style="width:33.33%">
-<col style="width:33.33%">
+<col style="width:33.33%" />
+<col style="width:33.33%" />
+<col style="width:33.33%" />
 <tbody>
 <tr>
 <td colspan="2" rowspan="2">AAAAA

--- a/src/Markdig.Tests/TestPlayParser.cs
+++ b/src/Markdig.Tests/TestPlayParser.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
-// This file is licensed under the BSD-Clause 2 license. 
+// This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 using System;
 using System.Linq;
@@ -19,7 +19,7 @@ namespace Markdig.Tests
             var link = doc.Descendants<ParagraphBlock>().SelectMany(x => x.Inline.Descendants<LinkInline>()).FirstOrDefault(l => l.IsImage);
             Assert.AreEqual("/yoyo", link?.Url);
         }
-        
+
         [Test]
         public void TestListBug2()
         {
@@ -53,7 +53,7 @@ Later in a text we are using HTML and it becomes an abbr tag HTML
         [Test]
         public void TestEmptyLiteral()
         {
-            var text = @"> *some text* 
+            var text = @"> *some text*
 > some other text";
             var doc = Markdown.Parse(text);
 
@@ -195,8 +195,8 @@ Paragraph
 ";
 
             var expected = @"<table class=""table"">
-<col style=""width:50%"">
-<col style=""width:50%"">
+<col style=""width:50%"" />
+<col style=""width:50%"" />
 <thead>
 <tr>
 <th>a</th>
@@ -219,7 +219,7 @@ Paragraph
         {
             var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
 
-            // Reuse the same pipeline 
+            // Reuse the same pipeline
             var result1 = Markdown.ToHtml("This is a \"\"citation\"\"", pipeline);
             var result2 = Markdown.ToHtml("This is a \"\"citation\"\"", pipeline);
 
@@ -269,7 +269,7 @@ Paragraph
         //| Yes                               |
         //| ```                               |
         //+===================================+======================================+
-        //| This is a second line             | 
+        //| This is a second line             |
         //+-----------------------------------+--------------------------------------+
 
         //:::spoiler  {#yessss}

--- a/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
+++ b/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
@@ -41,7 +41,7 @@ namespace Markdig.Extensions.Tables
                 {
                     var width = Math.Round(tableColumnDefinition.Width*100)/100;
                     var widthValue = string.Format(CultureInfo.InvariantCulture, "{0:0.##}", width);
-                    renderer.WriteLine($"<col style=\"width:{widthValue}%\">");
+                    renderer.WriteLine($"<col style=\"width:{widthValue}%\" />");
                 }
             }
 


### PR DESCRIPTION
Allow the output of HtmlTableRenderer to be processed by XML processor.