### PR TITLE
make dotnet framework ReferenceAssemblies Private

### DIFF
--- a/src/Markdig/Markdig.targets
+++ b/src/Markdig/Markdig.targets
@@ -25,8 +25,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net35' OR '$(TargetFramework)' == 'net40'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
-    <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">


### PR DESCRIPTION
make dotnet framework ReferenceAssemblies Private,
the dotnet framework ReferenceAssemblies are used for build on none-windows platform, should not be used as external dependencies