### PR TITLE
Add IReadOnlyList interface to ContainerBlock to unify and simplify e…

### DIFF
--- a/src/Markdig/Syntax/ContainerBlock.cs
+++ b/src/Markdig/Syntax/ContainerBlock.cs
@@ -17,7 +17,7 @@ namespace Markdig.Syntax
     /// </summary>
     /// <seealso cref="Markdig.Syntax.Block" />
     [DebuggerDisplay("{GetType().Name} Count = {Count}")]
-    public abstract class ContainerBlock : Block, IList<Block>
+    public abstract class ContainerBlock : Block, IList<Block>, IReadOnlyList<Block>
     {
         private Block[] children;
 


### PR DESCRIPTION
Problem: `ContainerBlock` implements the  `IList<Block>` interface, but this interface does not contain the `IReadOnlyList<Block>`

In order to simplify and unify the enumeration of child items, add the `IReadOnlyList<Block>` interface to  `ContainerBlock`. `ContainerBlock` already contains the neccessary implementations of the `IReadOnlyList<Block>` interface.