### PR TITLE
Cleanup

### DIFF
--- a/src/Markdig.Benchmarks/Program.cs
+++ b/src/Markdig.Benchmarks/Program.cs
@@ -55,7 +55,7 @@ namespace Testamina.Markdig.Benchmarks
             //CommonMark.CommonMarkConverter.Parse(reader);
             //reader.Dispose();
             //var writer = new StringWriter();
-            global::CommonMark.CommonMarkConverter.Convert(text);
+            CommonMark.CommonMarkConverter.Convert(text);
             //writer.Flush();
             //writer.ToString();
         }

--- a/src/Markdig.Benchmarks/Program.cs
+++ b/src/Markdig.Benchmarks/Program.cs
@@ -5,14 +5,9 @@ extern alias newcmark;
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Text;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Diagnostics;
-using BenchmarkDotNet.Diagnostics.Windows;
-using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
-using newcmark::CommonMark.Extension;
 using Markdig;
 
 

--- a/src/Markdig.Benchmarks/TestMatchPerf.cs
+++ b/src/Markdig.Benchmarks/TestMatchPerf.cs
@@ -2,13 +2,9 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using BenchmarkDotNet.Attributes;
-using Markdig.Helpers;
 
 namespace Testamina.Markdig.Benchmarks
 {

--- a/src/Markdig.Tests/TestCustomEmojis.cs
+++ b/src/Markdig.Tests/TestCustomEmojis.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using Markdig.Extensions.Emoji;
 using NUnit.Framework;

--- a/src/Markdig.Tests/TestLineReader.cs
+++ b/src/Markdig.Tests/TestLineReader.cs
@@ -2,7 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-using System.IO;
 using NUnit.Framework;
 using Markdig.Helpers;
 

--- a/src/Markdig.Tests/TestLinkHelper.cs
+++ b/src/Markdig.Tests/TestLinkHelper.cs
@@ -15,8 +15,7 @@ namespace Markdig.Tests
         public void TestUrlSimple()
         {
             var text = new StringSlice("toto tutu");
-            string link;
-            Assert.True(LinkHelper.TryParseUrl(ref text, out link));
+            Assert.True(LinkHelper.TryParseUrl(ref text, out string link));
             Assert.AreEqual("toto", link);
             Assert.AreEqual(' ', text.CurrentChar);
         }
@@ -25,8 +24,7 @@ namespace Markdig.Tests
         public void TestUrlUrl()
         {
             var text = new StringSlice("http://google.com)");
-            string link;
-            Assert.True(LinkHelper.TryParseUrl(ref text, out link));
+            Assert.True(LinkHelper.TryParseUrl(ref text, out string link));
             Assert.AreEqual("http://google.com", link);
             Assert.AreEqual(')', text.CurrentChar);
         }
@@ -37,8 +35,7 @@ namespace Markdig.Tests
         public void TestUrlTrailingFullStop(string uri)
         {
             var text = new StringSlice(uri);
-            string link;
-            Assert.True(LinkHelper.TryParseUrl(ref text, out link, true));
+            Assert.True(LinkHelper.TryParseUrl(ref text, out string link, true));
             Assert.AreEqual("http://google.com", link);
             Assert.AreEqual('.', text.CurrentChar);
         }
@@ -47,8 +44,7 @@ namespace Markdig.Tests
         public void TestUrlNestedParenthesis()
         {
             var text = new StringSlice("(toto)tutu(tata) nooo");
-            string link;
-            Assert.True(LinkHelper.TryParseUrl(ref text, out link));
+            Assert.True(LinkHelper.TryParseUrl(ref text, out string link));
             Assert.AreEqual("(toto)tutu(tata)", link);
             Assert.AreEqual(' ', text.CurrentChar);
         }
@@ -57,8 +53,7 @@ namespace Markdig.Tests
         public void TestUrlAlternate()
         {
             var text = new StringSlice("<toto_tata_tutu> nooo");
-            string link;
-            Assert.True(LinkHelper.TryParseUrl(ref text, out link));
+            Assert.True(LinkHelper.TryParseUrl(ref text, out string link));
             Assert.AreEqual("toto_tata_tutu", link);
             Assert.AreEqual(' ', text.CurrentChar);
         }
@@ -67,16 +62,14 @@ namespace Markdig.Tests
         public void TestUrlAlternateInvalid()
         {
             var text = new StringSlice("<toto_tata_tutu");
-            string link;
-            Assert.False(LinkHelper.TryParseUrl(ref text, out link));
+            Assert.False(LinkHelper.TryParseUrl(ref text, out string link));
         }
 
         [Test]
         public void TestTitleSimple()
         {
             var text = new StringSlice(@"'tata\tutu\''");
-            string title;
-            Assert.True(LinkHelper.TryParseTitle(ref text, out title));
+            Assert.True(LinkHelper.TryParseTitle(ref text, out string title));
             Assert.AreEqual(@"tata\tutu'", title);
         }
 
@@ -84,8 +77,7 @@ namespace Markdig.Tests
         public void TestTitleSimpleAlternate()
         {
             var text = new StringSlice(@"""tata\tutu\"""" ");
-            string title;
-            Assert.True(LinkHelper.TryParseTitle(ref text, out title));
+            Assert.True(LinkHelper.TryParseTitle(ref text, out string title));
             Assert.AreEqual(@"tata\tutu""", title);
             Assert.AreEqual(' ', text.CurrentChar);
         }
@@ -96,11 +88,7 @@ namespace Markdig.Tests
             //                           0         1         2         3
             //                           0123456789012345678901234567890123456789
             var text = new StringSlice(@"(http://google.com 'this is a title')ABC");
-            string link;
-            string title;
-            SourceSpan linkSpan;
-            SourceSpan titleSpan;
-            Assert.True(LinkHelper.TryParseInlineLink(ref text, out link, out title, out linkSpan, out titleSpan));
+            Assert.True(LinkHelper.TryParseInlineLink(ref text, out string link, out string title, out SourceSpan linkSpan, out SourceSpan titleSpan));
             Assert.AreEqual("http://google.com", link);
             Assert.AreEqual("this is a title", title);
             Assert.AreEqual(new SourceSpan(1, 17), linkSpan);
@@ -113,11 +101,7 @@ namespace Markdig.Tests
         {
             //                           01234
             var text = new StringSlice(@"(<>)A");
-            string link;
-            string title;
-            SourceSpan linkSpan;
-            SourceSpan titleSpan;
-            Assert.True(LinkHelper.TryParseInlineLink(ref text, out link, out title, out linkSpan, out titleSpan));
+            Assert.True(LinkHelper.TryParseInlineLink(ref text, out string link, out string title, out SourceSpan linkSpan, out SourceSpan titleSpan));
             Assert.AreEqual(string.Empty, link);
             Assert.AreEqual(string.Empty, title);
             Assert.AreEqual(new SourceSpan(1, 2), linkSpan);
@@ -130,11 +114,7 @@ namespace Markdig.Tests
         {
             //                           012345
             var text = new StringSlice(@"( <> )A");
-            string link;
-            string title;
-            SourceSpan linkSpan;
-            SourceSpan titleSpan;
-            Assert.True(LinkHelper.TryParseInlineLink(ref text, out link, out title, out linkSpan, out titleSpan));
+            Assert.True(LinkHelper.TryParseInlineLink(ref text, out string link, out string title, out SourceSpan linkSpan, out SourceSpan titleSpan));
             Assert.AreEqual(string.Empty, link);
             Assert.AreEqual(string.Empty, title);
             Assert.AreEqual(new SourceSpan(2, 3), linkSpan);
@@ -149,11 +129,7 @@ namespace Markdig.Tests
             //                           0         1         2
             //                           0123456789012345678901234567
             var text = new StringSlice(@"(   <>      'toto'       )A");
-            string link;
-            string title;
-            SourceSpan linkSpan;
-            SourceSpan titleSpan;
-            Assert.True(LinkHelper.TryParseInlineLink(ref text, out link, out title, out linkSpan, out titleSpan));
+            Assert.True(LinkHelper.TryParseInlineLink(ref text, out string link, out string title, out SourceSpan linkSpan, out SourceSpan titleSpan));
             Assert.AreEqual(string.Empty, link);
             Assert.AreEqual("toto", title);
             Assert.AreEqual(new SourceSpan(4, 5), linkSpan);
@@ -165,11 +141,7 @@ namespace Markdig.Tests
         public void TestUrlEmpty()
         {
             var text = new StringSlice(@"()A");
-            string link;
-            string title;
-            SourceSpan linkSpan;
-            SourceSpan titleSpan;
-            Assert.True(LinkHelper.TryParseInlineLink(ref text, out link, out title, out linkSpan, out titleSpan));
+            Assert.True(LinkHelper.TryParseInlineLink(ref text, out string link, out string title, out SourceSpan linkSpan, out SourceSpan titleSpan));
             Assert.AreEqual(string.Empty, link);
             Assert.AreEqual(string.Empty, title);
             Assert.AreEqual(SourceSpan.Empty, linkSpan);
@@ -183,11 +155,7 @@ namespace Markdig.Tests
             //                          0          1         2          3
             //                          01 2345678901234567890 1234567890123456789
             var text = new StringSlice("(\n<http://google.com>\n    'toto' )A");
-            string link;
-            string title;
-            SourceSpan linkSpan;
-            SourceSpan titleSpan;
-            Assert.True(LinkHelper.TryParseInlineLink(ref text, out link, out title, out linkSpan, out titleSpan));
+            Assert.True(LinkHelper.TryParseInlineLink(ref text, out string link, out string title, out SourceSpan linkSpan, out SourceSpan titleSpan));
             Assert.AreEqual("http://google.com", link);
             Assert.AreEqual("toto", title);
             Assert.AreEqual(new SourceSpan(2, 20), linkSpan);
@@ -200,9 +168,7 @@ namespace Markdig.Tests
         {
             //                          01234
             var text = new StringSlice("[foo]");
-            string label;
-            SourceSpan labelSpan;
-            Assert.True(LinkHelper.TryParseLabel(ref text, out label, out labelSpan));
+            Assert.True(LinkHelper.TryParseLabel(ref text, out string label, out SourceSpan labelSpan));
             Assert.AreEqual(new SourceSpan(1, 3), labelSpan);
             Assert.AreEqual("foo", label);
         }
@@ -212,9 +178,7 @@ namespace Markdig.Tests
         {
             //                           012345678
             var text = new StringSlice(@"[fo\[\]o]");
-            string label;
-            SourceSpan labelSpan;
-            Assert.True(LinkHelper.TryParseLabel(ref text, out label, out labelSpan));
+            Assert.True(LinkHelper.TryParseLabel(ref text, out string label, out SourceSpan labelSpan));
             Assert.AreEqual(new SourceSpan(1, 7), labelSpan);
             Assert.AreEqual(@"fo[]o", label);
         }
@@ -224,9 +188,7 @@ namespace Markdig.Tests
         {
             //                           0123
             var text = new StringSlice(@"[\]]");
-            string label;
-            SourceSpan labelSpan;
-            Assert.True(LinkHelper.TryParseLabel(ref text, out label, out labelSpan));
+            Assert.True(LinkHelper.TryParseLabel(ref text, out string label, out SourceSpan labelSpan));
             Assert.AreEqual(new SourceSpan(1, 2), labelSpan);
             Assert.AreEqual(@"]", label);
         }
@@ -234,8 +196,7 @@ namespace Markdig.Tests
         [Test]
         public void TestLabelInvalids()
         {
-            string label;
-            Assert.False(LinkHelper.TryParseLabel(new StringSlice(@"a"), out label));
+            Assert.False(LinkHelper.TryParseLabel(new StringSlice(@"a"), out string label));
             Assert.False(LinkHelper.TryParseLabel(new StringSlice(@"["), out label));
             Assert.False(LinkHelper.TryParseLabel(new StringSlice(@"[\x]"), out label));
             Assert.False(LinkHelper.TryParseLabel(new StringSlice(@"[[]"), out label));
@@ -249,9 +210,7 @@ namespace Markdig.Tests
             //                           0         1         2         3
             //                           0123456789012345678901234567890123456789
             var text = new StringSlice(@"[     fo    o    z     ]");
-            string label;
-            SourceSpan labelSpan;
-            Assert.True(LinkHelper.TryParseLabel(ref text, out label, out labelSpan));
+            Assert.True(LinkHelper.TryParseLabel(ref text, out string label, out SourceSpan labelSpan));
             Assert.AreEqual(new SourceSpan(6, 17), labelSpan);
             Assert.AreEqual(@"fo o z", label);
         }
@@ -262,13 +221,7 @@ namespace Markdig.Tests
             //                           0         1         2         3
             //                           0123456789012345678901234567890123456789
             var text = new StringSlice(@"[foo]: /toto 'title'");
-            string label;
-            string url;
-            string title;
-            SourceSpan labelSpan;
-            SourceSpan urlSpan;
-            SourceSpan titleSpan;
-            Assert.True(LinkHelper.TryParseLinkReferenceDefinition(ref text, out label, out url, out title, out labelSpan, out urlSpan, out titleSpan));
+            Assert.True(LinkHelper.TryParseLinkReferenceDefinition(ref text, out string label, out string url, out string title, out SourceSpan labelSpan, out SourceSpan urlSpan, out SourceSpan titleSpan));
             Assert.AreEqual(@"foo", label);
             Assert.AreEqual(@"/toto", url);
             Assert.AreEqual(@"title", title);
@@ -282,9 +235,7 @@ namespace Markdig.Tests
         public void TestAutoLinkUrlSimple()
         {
             var text = new StringSlice(@"<http://google.com>");
-            string url;
-            bool isEmail;
-            Assert.True(LinkHelper.TryParseAutolink(ref text, out url, out isEmail));
+            Assert.True(LinkHelper.TryParseAutolink(ref text, out string url, out bool isEmail));
             Assert.False(isEmail);
             Assert.AreEqual("http://google.com", url);
         }
@@ -293,9 +244,7 @@ namespace Markdig.Tests
         public void TestAutoLinkEmailSimple()
         {
             var text = new StringSlice(@"<user@host.com>");
-            string email;
-            bool isEmail;
-            Assert.True(LinkHelper.TryParseAutolink(ref text, out email, out isEmail));
+            Assert.True(LinkHelper.TryParseAutolink(ref text, out string email, out bool isEmail));
             Assert.True(isEmail);
             Assert.AreEqual("user@host.com", email);
         }
@@ -303,9 +252,7 @@ namespace Markdig.Tests
         [Test]
         public void TestAutolinkInvalid()
         {
-            string text;
-            bool isEmail;
-            Assert.False(LinkHelper.TryParseAutolink(new StringSlice(@""), out text, out isEmail));
+            Assert.False(LinkHelper.TryParseAutolink(new StringSlice(@""), out string text, out bool isEmail));
             Assert.False(LinkHelper.TryParseAutolink(new StringSlice(@"<"), out text, out isEmail));
             Assert.False(LinkHelper.TryParseAutolink(new StringSlice(@"<ab"), out text, out isEmail));
             Assert.False(LinkHelper.TryParseAutolink(new StringSlice(@"<user@>"), out text, out isEmail));

--- a/src/Markdig.Tests/TestLinkHelper.cs
+++ b/src/Markdig.Tests/TestLinkHelper.cs
@@ -2,7 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-using System.Security;
 using NUnit.Framework;
 using Markdig.Helpers;
 using Markdig.Syntax;

--- a/src/Markdig.Tests/TestPragmaLines.cs
+++ b/src/Markdig.Tests/TestPragmaLines.cs
@@ -2,7 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-using Markdig.Renderers;
 using Markdig.Syntax;
 using NUnit.Framework;
 

--- a/src/Markdig.Tests/TestStringSliceList.cs
+++ b/src/Markdig.Tests/TestStringSliceList.cs
@@ -1,8 +1,6 @@
 using NUnit.Framework;
-using System.Collections.Generic;
 using System.Text;
 using Markdig.Helpers;
-using Markdig.Syntax;
 using System;
 
 namespace Markdig.Tests

--- a/src/Markdig.WebApp/Program.cs
+++ b/src/Markdig.WebApp/Program.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Builder;
 

--- a/src/Markdig.WebApp/Startup.cs
+++ b/src/Markdig.WebApp/Startup.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;

--- a/src/Markdig/Extensions/Abbreviations/Abbreviation.cs
+++ b/src/Markdig/Extensions/Abbreviations/Abbreviation.cs
@@ -12,7 +12,7 @@ namespace Markdig.Extensions.Abbreviations
     /// <summary>
     /// An abbreviation object stored at the document level. See extension methods in <see cref="AbbreviationHelper"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.LeafBlock" />
+    /// <seealso cref="LeafBlock" />
     [DebuggerDisplay("Abbr {Label} => {Text}")]
     public class Abbreviation : LeafBlock
     {

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationExtension.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
@@ -19,8 +19,7 @@ namespace Markdig.Extensions.Abbreviations
 
         public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
         {
-            var htmlRenderer = renderer as HtmlRenderer;
-            if (htmlRenderer != null && !htmlRenderer.ObjectRenderers.Contains<HtmlAbbreviationRenderer>())
+            if (renderer is HtmlRenderer htmlRenderer && !htmlRenderer.ObjectRenderers.Contains<HtmlAbbreviationRenderer>())
             {
                 // Must be inserted before CodeBlockRenderer
                 htmlRenderer.ObjectRenderers.Insert(0, new HtmlAbbreviationRenderer());

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationExtension.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationExtension.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.Abbreviations
     /// <summary>
     /// Extension to allow abbreviations.
     /// </summary>
-    /// <seealso cref="Markdig.IMarkdownExtension" />
+    /// <seealso cref="IMarkdownExtension" />
     public class AbbreviationExtension : IMarkdownExtension
     {
         public void Setup(MarkdownPipelineBuilder pipeline)

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationHelper.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationHelper.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
-using System;
 using System.Collections.Generic;
 using Markdig.Helpers;
 using Markdig.Syntax;

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationHelper.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationHelper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System.Collections.Generic;
 using Markdig.Helpers;
 using Markdig.Syntax;

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationInline.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationInline.cs
@@ -10,7 +10,7 @@ namespace Markdig.Extensions.Abbreviations
     /// <summary>
     /// The inline abbreviation.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Inlines.LeafInline" />
+    /// <seealso cref="LeafInline" />
     [DebuggerDisplay("{Abbreviation}")]
     public class AbbreviationInline : LeafInline
     {

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using Markdig.Helpers;

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
@@ -41,8 +41,7 @@ namespace Markdig.Extensions.Abbreviations
                 return BlockState.None;
             }
 
-            SourceSpan labelSpan;
-            if (!LinkHelper.TryParseLabel(ref slice, out string label, out labelSpan))
+            if (!LinkHelper.TryParseLabel(ref slice, out string label, out SourceSpan labelSpan))
             {
                 return BlockState.None;
             }

--- a/src/Markdig/Extensions/Abbreviations/HtmlAbbreviationRenderer.cs
+++ b/src/Markdig/Extensions/Abbreviations/HtmlAbbreviationRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.Abbreviations
     /// <summary>
     /// A HTML renderer for a <see cref="AbbreviationInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{CustomContainer}" />
+    /// <seealso cref="HtmlObjectRenderer{CustomContainer}" />
     public class HtmlAbbreviationRenderer : HtmlObjectRenderer<AbbreviationInline>
     {
         protected override void Write(HtmlRenderer renderer, AbbreviationInline obj)

--- a/src/Markdig/Extensions/Abbreviations/HtmlAbbreviationRenderer.cs
+++ b/src/Markdig/Extensions/Abbreviations/HtmlAbbreviationRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 

--- a/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierExtension.cs
+++ b/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierExtension.cs
@@ -2,7 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using Markdig.Helpers;

--- a/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierExtension.cs
+++ b/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierExtension.cs
@@ -62,8 +62,7 @@ namespace Markdig.Extensions.AutoIdentifiers
         private void HeadingBlockParser_Closed(BlockProcessor processor, Block block)
         {
             // We may have a ParagraphBlock here as we have a hook on the ParagraphBlockParser
-            var headingBlock = block as HeadingBlock;
-            if (headingBlock == null)
+            if (!(block is HeadingBlock headingBlock))
             {
                 return;
             }

--- a/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierExtension.cs
+++ b/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierExtension.cs
@@ -17,7 +17,7 @@ namespace Markdig.Extensions.AutoIdentifiers
     /// <summary>
     /// The auto-identifier extension
     /// </summary>
-    /// <seealso cref="Markdig.IMarkdownExtension" />
+    /// <seealso cref="IMarkdownExtension" />
     public class AutoIdentifierExtension : IMarkdownExtension
     {
         private const string AutoIdentifierKey = "AutoIdentifier";

--- a/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierOptions.cs
+++ b/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System;
 
 namespace Markdig.Extensions.AutoIdentifiers

--- a/src/Markdig/Extensions/AutoIdentifiers/HeadingLinkReferenceDefinition.cs
+++ b/src/Markdig/Extensions/AutoIdentifiers/HeadingLinkReferenceDefinition.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax;
 
 namespace Markdig.Extensions.AutoIdentifiers

--- a/src/Markdig/Extensions/AutoIdentifiers/HeadingLinkReferenceDefinition.cs
+++ b/src/Markdig/Extensions/AutoIdentifiers/HeadingLinkReferenceDefinition.cs
@@ -8,7 +8,7 @@ namespace Markdig.Extensions.AutoIdentifiers
     /// <summary>
     /// A link reference definition to a <see cref="HeadingBlock"/> stored at the <see cref="MarkdownDocument"/> level.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.LinkReferenceDefinition" />
+    /// <seealso cref="LinkReferenceDefinition" />
     public class HeadingLinkReferenceDefinition : LinkReferenceDefinition
     {
         /// <summary>

--- a/src/Markdig/Extensions/AutoLinks/AutoLinkExtension.cs
+++ b/src/Markdig/Extensions/AutoLinks/AutoLinkExtension.cs
@@ -5,6 +5,7 @@
 using Markdig.Renderers;
 using Markdig.Renderers.Normalize;
 using Markdig.Renderers.Normalize.Inlines;
+using Markdig.Syntax.Inlines;
 
 namespace Markdig.Extensions.AutoLinks
 {

--- a/src/Markdig/Extensions/AutoLinks/AutoLinkOptions.cs
+++ b/src/Markdig/Extensions/AutoLinks/AutoLinkOptions.cs
@@ -1,3 +1,7 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license. 
+// See the license.txt file in the project root for more information.
+
 namespace Markdig.Extensions.AutoLinks
 {
     public class AutoLinkOptions

--- a/src/Markdig/Extensions/AutoLinks/NormalizeAutoLinkRenderer.cs
+++ b/src/Markdig/Extensions/AutoLinks/NormalizeAutoLinkRenderer.cs
@@ -15,10 +15,10 @@ namespace Markdig.Extensions.AutoLinks
         {
             if (base.Accept(renderer, obj))
             {
-                var normalizeRenderer = renderer as NormalizeRenderer;
-                var link = obj as LinkInline;
-
-                return normalizeRenderer != null && link != null && !normalizeRenderer.Options.ExpandAutoLinks && link.IsAutoLink;
+                return renderer is NormalizeRenderer normalizeRenderer
+                    && obj is LinkInline link
+                    && !normalizeRenderer.Options.ExpandAutoLinks
+                    && link.IsAutoLink;
             }
             else
             {

--- a/src/Markdig/Extensions/AutoLinks/NormalizeAutoLinkRenderer.cs
+++ b/src/Markdig/Extensions/AutoLinks/NormalizeAutoLinkRenderer.cs
@@ -1,3 +1,7 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license. 
+// See the license.txt file in the project root for more information.
+
 using Markdig.Renderers;
 using Markdig.Renderers.Normalize;
 using Markdig.Syntax;

--- a/src/Markdig/Extensions/Bootstrap/BootstrapExtension.cs
+++ b/src/Markdig/Extensions/Bootstrap/BootstrapExtension.cs
@@ -12,7 +12,7 @@ namespace Markdig.Extensions.Bootstrap
     /// <summary>
     /// Extension for tagging some HTML elements with bootstrap classes.
     /// </summary>
-    /// <seealso cref="Markdig.IMarkdownExtension" />
+    /// <seealso cref="IMarkdownExtension" />
     public class BootstrapExtension : IMarkdownExtension
     {
         public void Setup(MarkdownPipelineBuilder pipeline)

--- a/src/Markdig/Extensions/CustomContainers/CustomContainer.cs
+++ b/src/Markdig/Extensions/CustomContainers/CustomContainer.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Extensions/CustomContainers/CustomContainer.cs
+++ b/src/Markdig/Extensions/CustomContainers/CustomContainer.cs
@@ -9,8 +9,8 @@ namespace Markdig.Extensions.CustomContainers
     /// <summary>
     /// A block custom container.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.ContainerBlock" />
-    /// <seealso cref="Markdig.Syntax.IFencedBlock" />
+    /// <seealso cref="ContainerBlock" />
+    /// <seealso cref="IFencedBlock" />
     public class CustomContainer : ContainerBlock, IFencedBlock
     {
         /// <summary>

--- a/src/Markdig/Extensions/CustomContainers/CustomContainerInline.cs
+++ b/src/Markdig/Extensions/CustomContainers/CustomContainerInline.cs
@@ -8,8 +8,8 @@ namespace Markdig.Extensions.CustomContainers
     /// <summary>
     /// An inline custom container
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Inlines.ContainerInline" />
-    /// <seealso cref="Markdig.Syntax.Inlines.EmphasisInline" />
+    /// <seealso cref="ContainerInline" />
+    /// <seealso cref="EmphasisInline" />
     public class CustomContainerInline : EmphasisInline
     {
     }

--- a/src/Markdig/Extensions/CustomContainers/CustomContainerInline.cs
+++ b/src/Markdig/Extensions/CustomContainers/CustomContainerInline.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Extensions.CustomContainers

--- a/src/Markdig/Extensions/CustomContainers/CustomContainerParser.cs
+++ b/src/Markdig/Extensions/CustomContainers/CustomContainerParser.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 
 namespace Markdig.Extensions.CustomContainers

--- a/src/Markdig/Extensions/CustomContainers/CustomContainerParser.cs
+++ b/src/Markdig/Extensions/CustomContainers/CustomContainerParser.cs
@@ -8,7 +8,7 @@ namespace Markdig.Extensions.CustomContainers
     /// <summary>
     /// The block parser for a <see cref="CustomContainer"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.FencedBlockParserBase{Markdig.Extensions.CustomContainers.CustomContainer}" />
+    /// <seealso cref="Parsers.FencedBlockParserBase{CustomContainers.CustomContainer}" />
     public class CustomContainerParser : FencedBlockParserBase<CustomContainer>
     {
         /// <summary>

--- a/src/Markdig/Extensions/CustomContainers/CustomContainerParser.cs
+++ b/src/Markdig/Extensions/CustomContainers/CustomContainerParser.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.CustomContainers
     /// <summary>
     /// The block parser for a <see cref="CustomContainer"/>.
     /// </summary>
-    /// <seealso cref="Parsers.FencedBlockParserBase{CustomContainers.CustomContainer}" />
+    /// <seealso cref="FencedBlockParserBase{CustomContainer}" />
     public class CustomContainerParser : FencedBlockParserBase<CustomContainer>
     {
         /// <summary>

--- a/src/Markdig/Extensions/CustomContainers/HtmlCustomContainerInlineRenderer.cs
+++ b/src/Markdig/Extensions/CustomContainers/HtmlCustomContainerInlineRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.CustomContainers
     /// <summary>
     /// A HTML renderer for a <see cref="CustomContainerInline"/>.
     /// </summary>
-    /// <seealso cref="Renderers.Html.HtmlObjectRenderer{CustomContainerInline}" />
+    /// <seealso cref="HtmlObjectRenderer{CustomContainerInline}" />
     public class HtmlCustomContainerInlineRenderer : HtmlObjectRenderer<CustomContainerInline>
     {
         protected override void Write(HtmlRenderer renderer, CustomContainerInline obj)

--- a/src/Markdig/Extensions/CustomContainers/HtmlCustomContainerInlineRenderer.cs
+++ b/src/Markdig/Extensions/CustomContainers/HtmlCustomContainerInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 

--- a/src/Markdig/Extensions/CustomContainers/HtmlCustomContainerRenderer.cs
+++ b/src/Markdig/Extensions/CustomContainers/HtmlCustomContainerRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 

--- a/src/Markdig/Extensions/CustomContainers/HtmlCustomContainerRenderer.cs
+++ b/src/Markdig/Extensions/CustomContainers/HtmlCustomContainerRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.CustomContainers
     /// <summary>
     /// A HTML renderer for a <see cref="CustomContainer"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{CustomContainer}" />
+    /// <seealso cref="HtmlObjectRenderer{CustomContainer}" />
     public class HtmlCustomContainerRenderer : HtmlObjectRenderer<CustomContainer>
     {
         protected override void Write(HtmlRenderer renderer, CustomContainer obj)

--- a/src/Markdig/Extensions/DefinitionLists/DefinitionItem.cs
+++ b/src/Markdig/Extensions/DefinitionLists/DefinitionItem.cs
@@ -1,3 +1,7 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license. 
+// See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Extensions/DefinitionLists/DefinitionItem.cs
+++ b/src/Markdig/Extensions/DefinitionLists/DefinitionItem.cs
@@ -7,7 +7,7 @@ namespace Markdig.Extensions.DefinitionLists
     /// A definition item contains zero to multiple <see cref="DefinitionTerm"/> 
     /// and definitions (any <see cref="Block"/>)
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.ContainerBlock" />
+    /// <seealso cref="ContainerBlock" />
     public class DefinitionItem : ContainerBlock
     {
         /// <summary>

--- a/src/Markdig/Extensions/DefinitionLists/DefinitionList.cs
+++ b/src/Markdig/Extensions/DefinitionLists/DefinitionList.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Extensions/DefinitionLists/DefinitionList.cs
+++ b/src/Markdig/Extensions/DefinitionLists/DefinitionList.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.DefinitionLists
     /// <summary>
     /// A definition list contains <see cref="DefinitionItem"/> children.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.ContainerBlock" />
+    /// <seealso cref="ContainerBlock" />
     public class DefinitionList : ContainerBlock
     {
         /// <summary>

--- a/src/Markdig/Extensions/DefinitionLists/DefinitionListExtension.cs
+++ b/src/Markdig/Extensions/DefinitionLists/DefinitionListExtension.cs
@@ -8,7 +8,7 @@ namespace Markdig.Extensions.DefinitionLists
     /// <summary>
     /// Extension to allow definition lists
     /// </summary>
-    /// <seealso cref="Markdig.IMarkdownExtension" />
+    /// <seealso cref="IMarkdownExtension" />
     public class DefinitionListExtension : IMarkdownExtension
     {
         public void Setup(MarkdownPipelineBuilder pipeline)

--- a/src/Markdig/Extensions/DefinitionLists/DefinitionListExtension.cs
+++ b/src/Markdig/Extensions/DefinitionLists/DefinitionListExtension.cs
@@ -23,8 +23,7 @@ namespace Markdig.Extensions.DefinitionLists
 
         public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
         {
-            var htmlRenderer = renderer as HtmlRenderer;
-            if (htmlRenderer != null)
+            if (renderer is HtmlRenderer htmlRenderer)
             {
                 if (!htmlRenderer.ObjectRenderers.Contains<HtmlDefinitionListRenderer>())
                 {

--- a/src/Markdig/Extensions/DefinitionLists/DefinitionListExtension.cs
+++ b/src/Markdig/Extensions/DefinitionLists/DefinitionListExtension.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Renderers;
 
 namespace Markdig.Extensions.DefinitionLists

--- a/src/Markdig/Extensions/DefinitionLists/DefinitionListParser.cs
+++ b/src/Markdig/Extensions/DefinitionLists/DefinitionListParser.cs
@@ -11,7 +11,7 @@ namespace Markdig.Extensions.DefinitionLists
     /// <summary>
     /// The block parser for a <see cref="DefinitionList"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.BlockParser" />
+    /// <seealso cref="BlockParser" />
     public class DefinitionListParser : BlockParser
     {
         /// <summary>

--- a/src/Markdig/Extensions/DefinitionLists/DefinitionTerm.cs
+++ b/src/Markdig/Extensions/DefinitionLists/DefinitionTerm.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.DefinitionLists
     /// <summary>
     /// A definition term contains a single line with the term to define.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.LeafBlock" />
+    /// <seealso cref="LeafBlock" />
     public class DefinitionTerm : LeafBlock
     {
         /// <summary>

--- a/src/Markdig/Extensions/DefinitionLists/DefinitionTerm.cs
+++ b/src/Markdig/Extensions/DefinitionLists/DefinitionTerm.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Extensions/DefinitionLists/HtmlDefinitionListRenderer.cs
+++ b/src/Markdig/Extensions/DefinitionLists/HtmlDefinitionListRenderer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 

--- a/src/Markdig/Extensions/DefinitionLists/HtmlDefinitionListRenderer.cs
+++ b/src/Markdig/Extensions/DefinitionLists/HtmlDefinitionListRenderer.cs
@@ -11,7 +11,7 @@ namespace Markdig.Extensions.DefinitionLists
     /// <summary>
     /// A HTML renderer for <see cref="DefinitionList"/>, <see cref="DefinitionItem"/> and <see cref="DefinitionTerm"/>.
     /// </summary>
-    /// <seealso cref="Renderers.Html.HtmlObjectRenderer{DefinitionLists.DefinitionList}" />
+    /// <seealso cref="HtmlObjectRenderer{DefinitionList}" />
     public class HtmlDefinitionListRenderer : HtmlObjectRenderer<DefinitionList>
     {
         protected override void Write(HtmlRenderer renderer, DefinitionList list)

--- a/src/Markdig/Extensions/DefinitionLists/HtmlDefinitionListRenderer.cs
+++ b/src/Markdig/Extensions/DefinitionLists/HtmlDefinitionListRenderer.cs
@@ -11,7 +11,7 @@ namespace Markdig.Extensions.DefinitionLists
     /// <summary>
     /// A HTML renderer for <see cref="DefinitionList"/>, <see cref="DefinitionItem"/> and <see cref="DefinitionTerm"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Extensions.DefinitionLists.DefinitionList}" />
+    /// <seealso cref="Renderers.Html.HtmlObjectRenderer{DefinitionLists.DefinitionList}" />
     public class HtmlDefinitionListRenderer : HtmlObjectRenderer<DefinitionList>
     {
         protected override void Write(HtmlRenderer renderer, DefinitionList list)

--- a/src/Markdig/Extensions/Diagrams/DiagramExtension.cs
+++ b/src/Markdig/Extensions/Diagrams/DiagramExtension.cs
@@ -10,7 +10,7 @@ namespace Markdig.Extensions.Diagrams
     /// <summary>
     /// Extension to allow diagrams.
     /// </summary>
-    /// <seealso cref="Markdig.IMarkdownExtension" />
+    /// <seealso cref="IMarkdownExtension" />
     public class DiagramExtension : IMarkdownExtension
     {
         public void Setup(MarkdownPipelineBuilder pipeline)

--- a/src/Markdig/Extensions/Diagrams/DiagramExtension.cs
+++ b/src/Markdig/Extensions/Diagrams/DiagramExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
@@ -19,8 +19,7 @@ namespace Markdig.Extensions.Diagrams
 
         public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
         {
-            var htmlRenderer = renderer as HtmlRenderer;
-            if (htmlRenderer != null)
+            if (renderer is HtmlRenderer htmlRenderer)
             {
                 var codeRenderer = htmlRenderer.ObjectRenderers.FindExact<CodeBlockRenderer>();
                 // TODO: Add other well known diagram languages

--- a/src/Markdig/Extensions/Emoji/EmojiExtension.cs
+++ b/src/Markdig/Extensions/Emoji/EmojiExtension.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.Emoji
     /// <summary>
     /// Extension to allow emoji shortcodes and smileys replacement.
     /// </summary>
-    /// <seealso cref="Markdig.IMarkdownExtension" />
+    /// <seealso cref="IMarkdownExtension" />
     public class EmojiExtension : IMarkdownExtension
     {
         public EmojiExtension(EmojiMapping emojiMapping)

--- a/src/Markdig/Extensions/Emoji/EmojiInline.cs
+++ b/src/Markdig/Extensions/Emoji/EmojiInline.cs
@@ -10,7 +10,7 @@ namespace Markdig.Extensions.Emoji
     /// <summary>
     /// An emoji inline.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Inlines.Inline" />
+    /// <seealso cref="Inline" />
     public class EmojiInline : LiteralInline
     {
         // Inherit from LiteralInline so that rendering is already handled by default

--- a/src/Markdig/Extensions/Emoji/EmojiMapping.cs
+++ b/src/Markdig/Extensions/Emoji/EmojiMapping.cs
@@ -2,7 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Markdig.Helpers;
 

--- a/src/Markdig/Extensions/Figures/Figure.cs
+++ b/src/Markdig/Extensions/Figures/Figure.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.Figures
     /// <summary>
     /// Defines a figure container.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.ContainerBlock" />
+    /// <seealso cref="ContainerBlock" />
     public class Figure : ContainerBlock
     {
         /// <summary>

--- a/src/Markdig/Extensions/Figures/Figure.cs
+++ b/src/Markdig/Extensions/Figures/Figure.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Extensions/Figures/FigureBlockParser.cs
+++ b/src/Markdig/Extensions/Figures/FigureBlockParser.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.Figures
     /// <summary>
     /// The block parser for a <see cref="Figure"/> block.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.BlockParser" />
+    /// <seealso cref="BlockParser" />
     public class FigureBlockParser : BlockParser
     { 
         /// <summary>

--- a/src/Markdig/Extensions/Figures/FigureBlockParser.cs
+++ b/src/Markdig/Extensions/Figures/FigureBlockParser.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Extensions/Figures/FigureCaption.cs
+++ b/src/Markdig/Extensions/Figures/FigureCaption.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Extensions/Figures/FigureCaption.cs
+++ b/src/Markdig/Extensions/Figures/FigureCaption.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.Figures
     /// <summary>
     /// Defines a figure caption.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.LeafBlock" />
+    /// <seealso cref="LeafBlock" />
     public class FigureCaption : LeafBlock
     {
         /// <summary>

--- a/src/Markdig/Extensions/Figures/FigureExtension.cs
+++ b/src/Markdig/Extensions/Figures/FigureExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
@@ -31,8 +31,7 @@ namespace Markdig.Extensions.Figures
 
         public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
         {
-            var htmlRenderer = renderer as HtmlRenderer;
-            if (htmlRenderer != null)
+            if (renderer is HtmlRenderer htmlRenderer)
             {
                 htmlRenderer.ObjectRenderers.AddIfNotAlready<HtmlFigureRenderer>();
                 htmlRenderer.ObjectRenderers.AddIfNotAlready<HtmlFigureCaptionRenderer>();

--- a/src/Markdig/Extensions/Figures/FigureExtension.cs
+++ b/src/Markdig/Extensions/Figures/FigureExtension.cs
@@ -10,7 +10,7 @@ namespace Markdig.Extensions.Figures
     /// <summary>
     /// Extension to allow usage of figures and figure captions.
     /// </summary>
-    /// <seealso cref="Markdig.IMarkdownExtension" />
+    /// <seealso cref="IMarkdownExtension" />
     public class FigureExtension : IMarkdownExtension
     {
         public void Setup(MarkdownPipelineBuilder pipeline)

--- a/src/Markdig/Extensions/Figures/HtmlFigureCaptionRenderer.cs
+++ b/src/Markdig/Extensions/Figures/HtmlFigureCaptionRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 

--- a/src/Markdig/Extensions/Figures/HtmlFigureCaptionRenderer.cs
+++ b/src/Markdig/Extensions/Figures/HtmlFigureCaptionRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.Figures
     /// <summary>
     /// A HTML renderer for a <see cref="FigureCaption"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{FigureCaption}" />
+    /// <seealso cref="HtmlObjectRenderer{FigureCaption}" />
     public class HtmlFigureCaptionRenderer : HtmlObjectRenderer<FigureCaption>
     {
         protected override void Write(HtmlRenderer renderer, FigureCaption obj)

--- a/src/Markdig/Extensions/Figures/HtmlFigureRenderer.cs
+++ b/src/Markdig/Extensions/Figures/HtmlFigureRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.Figures
     /// <summary>
     /// A HTML renderer for a <see cref="Figure"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Figure}" />
+    /// <seealso cref="HtmlObjectRenderer{Figure}" />
     public class HtmlFigureRenderer : HtmlObjectRenderer<Figure>
     {
         protected override void Write(HtmlRenderer renderer, Figure obj)

--- a/src/Markdig/Extensions/Figures/HtmlFigureRenderer.cs
+++ b/src/Markdig/Extensions/Figures/HtmlFigureRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 

--- a/src/Markdig/Extensions/Footers/FooterBlock.cs
+++ b/src/Markdig/Extensions/Footers/FooterBlock.cs
@@ -10,7 +10,7 @@ namespace Markdig.Extensions.Footers
     /// <summary>
     /// A block element for a footer.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.ContainerBlock" />
+    /// <seealso cref="ContainerBlock" />
     public class FooterBlock : ContainerBlock
     {
         /// <summary>

--- a/src/Markdig/Extensions/Footers/FooterBlockParser.cs
+++ b/src/Markdig/Extensions/Footers/FooterBlockParser.cs
@@ -11,7 +11,7 @@ namespace Markdig.Extensions.Footers
     /// <summary>
     /// A block parser for a <see cref="FooterBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.BlockParser" />
+    /// <seealso cref="BlockParser" />
     public class FooterBlockParser : BlockParser
     {
         /// <summary>

--- a/src/Markdig/Extensions/Footers/FooterExtension.cs
+++ b/src/Markdig/Extensions/Footers/FooterExtension.cs
@@ -10,7 +10,7 @@ namespace Markdig.Extensions.Footers
     /// <summary>
     /// Extension that provides footer.
     /// </summary>
-    /// <seealso cref="Markdig.IMarkdownExtension" />
+    /// <seealso cref="IMarkdownExtension" />
     public class FooterExtension : IMarkdownExtension
     {
         public void Setup(MarkdownPipelineBuilder pipeline)

--- a/src/Markdig/Extensions/Footers/FooterExtension.cs
+++ b/src/Markdig/Extensions/Footers/FooterExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
@@ -31,8 +31,7 @@ namespace Markdig.Extensions.Footers
 
         public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
         {
-            var htmlRenderer = renderer as HtmlRenderer;
-            if (htmlRenderer != null)
+            if (renderer is HtmlRenderer htmlRenderer)
             {
                 htmlRenderer.ObjectRenderers.AddIfNotAlready(new HtmlFooterBlockRenderer());
             }

--- a/src/Markdig/Extensions/Footers/HtmlFooterRenderer.cs
+++ b/src/Markdig/Extensions/Footers/HtmlFooterRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.Footers
     /// <summary>
     /// A HTML renderer for a <see cref="FooterBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Extensions.Footers.FooterBlock}" />
+    /// <seealso cref="Renderers.Html.HtmlObjectRenderer{Footers.FooterBlock}" />
     public class HtmlFooterBlockRenderer : HtmlObjectRenderer<FooterBlock>
     {
         protected override void Write(HtmlRenderer renderer, FooterBlock footer)

--- a/src/Markdig/Extensions/Footers/HtmlFooterRenderer.cs
+++ b/src/Markdig/Extensions/Footers/HtmlFooterRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 

--- a/src/Markdig/Extensions/Footers/HtmlFooterRenderer.cs
+++ b/src/Markdig/Extensions/Footers/HtmlFooterRenderer.cs
@@ -10,7 +10,7 @@ namespace Markdig.Extensions.Footers
     /// <summary>
     /// A HTML renderer for a <see cref="FooterBlock"/>.
     /// </summary>
-    /// <seealso cref="Renderers.Html.HtmlObjectRenderer{Footers.FooterBlock}" />
+    /// <seealso cref="HtmlObjectRenderer{FooterBlock}" />
     public class HtmlFooterBlockRenderer : HtmlObjectRenderer<FooterBlock>
     {
         protected override void Write(HtmlRenderer renderer, FooterBlock footer)

--- a/src/Markdig/Extensions/Footnotes/Footnote.cs
+++ b/src/Markdig/Extensions/Footnotes/Footnote.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System.Collections.Generic;
 using Markdig.Parsers;
 using Markdig.Syntax;

--- a/src/Markdig/Extensions/Footnotes/Footnote.cs
+++ b/src/Markdig/Extensions/Footnotes/Footnote.cs
@@ -10,7 +10,7 @@ namespace Markdig.Extensions.Footnotes
     /// <summary>
     /// A block for a footnote.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.ContainerBlock" />
+    /// <seealso cref="ContainerBlock" />
     public class Footnote : ContainerBlock
     {
         public Footnote(BlockParser parser) : base(parser)

--- a/src/Markdig/Extensions/Footnotes/FootnoteExtension.cs
+++ b/src/Markdig/Extensions/Footnotes/FootnoteExtension.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Renderers;
 
 namespace Markdig.Extensions.Footnotes

--- a/src/Markdig/Extensions/Footnotes/FootnoteExtension.cs
+++ b/src/Markdig/Extensions/Footnotes/FootnoteExtension.cs
@@ -23,8 +23,7 @@ namespace Markdig.Extensions.Footnotes
 
         public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
         {
-            var htmlRenderer = renderer as HtmlRenderer;
-            if (htmlRenderer != null)
+            if (renderer is HtmlRenderer htmlRenderer)
             {
                 htmlRenderer.ObjectRenderers.AddIfNotAlready(new HtmlFootnoteGroupRenderer());
                 htmlRenderer.ObjectRenderers.AddIfNotAlready(new HtmlFootnoteLinkRenderer());

--- a/src/Markdig/Extensions/Footnotes/FootnoteExtension.cs
+++ b/src/Markdig/Extensions/Footnotes/FootnoteExtension.cs
@@ -8,7 +8,7 @@ namespace Markdig.Extensions.Footnotes
     /// <summary>
     /// Extension to allow footnotes.
     /// </summary>
-    /// <seealso cref="Markdig.IMarkdownExtension" />
+    /// <seealso cref="IMarkdownExtension" />
     public class FootnoteExtension : IMarkdownExtension
     {
         public void Setup(MarkdownPipelineBuilder pipeline)

--- a/src/Markdig/Extensions/Footnotes/FootnoteGroup.cs
+++ b/src/Markdig/Extensions/Footnotes/FootnoteGroup.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.Footnotes
     /// <summary>
     /// A block that contains all the footnotes at the end of a <see cref="MarkdownDocument"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.ContainerBlock" />
+    /// <seealso cref="ContainerBlock" />
     public class FootnoteGroup : ContainerBlock
     {
         /// <summary>

--- a/src/Markdig/Extensions/Footnotes/FootnoteGroup.cs
+++ b/src/Markdig/Extensions/Footnotes/FootnoteGroup.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Extensions/Footnotes/FootnoteLink.cs
+++ b/src/Markdig/Extensions/Footnotes/FootnoteLink.cs
@@ -8,7 +8,7 @@ namespace Markdig.Extensions.Footnotes
     /// <summary>
     /// A inline link to a <see cref="Footnote"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Inlines.Inline" />
+    /// <seealso cref="Inline" />
     public class FootnoteLink : Inline
     {
         /// <summary>

--- a/src/Markdig/Extensions/Footnotes/FootnoteLink.cs
+++ b/src/Markdig/Extensions/Footnotes/FootnoteLink.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Extensions.Footnotes

--- a/src/Markdig/Extensions/Footnotes/FootnoteLinkReferenceDefinition.cs
+++ b/src/Markdig/Extensions/Footnotes/FootnoteLinkReferenceDefinition.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax;
 
 namespace Markdig.Extensions.Footnotes

--- a/src/Markdig/Extensions/Footnotes/FootnoteLinkReferenceDefinition.cs
+++ b/src/Markdig/Extensions/Footnotes/FootnoteLinkReferenceDefinition.cs
@@ -8,7 +8,7 @@ namespace Markdig.Extensions.Footnotes
     /// <summary>
     /// A link reference definition stored at the <see cref="MarkdownDocument"/> level.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.LinkReferenceDefinition" />
+    /// <seealso cref="LinkReferenceDefinition" />
     public class FootnoteLinkReferenceDefinition : LinkReferenceDefinition
     {
         /// <summary>

--- a/src/Markdig/Extensions/Footnotes/FootnoteParser.cs
+++ b/src/Markdig/Extensions/Footnotes/FootnoteParser.cs
@@ -12,7 +12,7 @@ namespace Markdig.Extensions.Footnotes
     /// <summary>
     /// The block parser for a <see cref="Footnote"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.BlockParser" />
+    /// <seealso cref="BlockParser" />
     public class FootnoteParser : BlockParser
     {
         /// <summary>

--- a/src/Markdig/Extensions/Footnotes/FootnoteParser.cs
+++ b/src/Markdig/Extensions/Footnotes/FootnoteParser.cs
@@ -40,10 +40,8 @@ namespace Markdig.Extensions.Footnotes
             }
 
             var saved = processor.Column;
-            string label;
             int start = processor.Start;
-            SourceSpan labelSpan;
-            if (!LinkHelper.TryParseLabel(ref processor.Line, false, out label, out labelSpan) || !label.StartsWith("^") || processor.CurrentChar != ':')
+            if (!LinkHelper.TryParseLabel(ref processor.Line, false, out string label, out SourceSpan labelSpan) || !label.StartsWith("^") || processor.CurrentChar != ':')
             {
                 processor.GoToColumn(saved);
                 return BlockState.None;

--- a/src/Markdig/Extensions/Footnotes/HtmlFootnoteGroupRenderer.cs
+++ b/src/Markdig/Extensions/Footnotes/HtmlFootnoteGroupRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.Footnotes
     /// <summary>
     /// A HTML renderer for a <see cref="FootnoteGroup"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Extensions.Footnotes.FootnoteGroup}" />
+    /// <seealso cref="Renderers.Html.HtmlObjectRenderer{Footnotes.FootnoteGroup}" />
     public class HtmlFootnoteGroupRenderer : HtmlObjectRenderer<FootnoteGroup>
     {
         /// <summary>

--- a/src/Markdig/Extensions/Footnotes/HtmlFootnoteGroupRenderer.cs
+++ b/src/Markdig/Extensions/Footnotes/HtmlFootnoteGroupRenderer.cs
@@ -10,7 +10,7 @@ namespace Markdig.Extensions.Footnotes
     /// <summary>
     /// A HTML renderer for a <see cref="FootnoteGroup"/>.
     /// </summary>
-    /// <seealso cref="Renderers.Html.HtmlObjectRenderer{Footnotes.FootnoteGroup}" />
+    /// <seealso cref="HtmlObjectRenderer{FootnoteGroup}" />
     public class HtmlFootnoteGroupRenderer : HtmlObjectRenderer<FootnoteGroup>
     {
         /// <summary>

--- a/src/Markdig/Extensions/Footnotes/HtmlFootnoteGroupRenderer.cs
+++ b/src/Markdig/Extensions/Footnotes/HtmlFootnoteGroupRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 

--- a/src/Markdig/Extensions/Footnotes/HtmlFootnoteLinkRenderer.cs
+++ b/src/Markdig/Extensions/Footnotes/HtmlFootnoteLinkRenderer.cs
@@ -10,7 +10,7 @@ namespace Markdig.Extensions.Footnotes
     /// <summary>
     /// A HTML renderer for a <see cref="FootnoteLink"/>.
     /// </summary>
-    /// <seealso cref="Renderers.Html.HtmlObjectRenderer{Footnotes.FootnoteLink}" />
+    /// <seealso cref="HtmlObjectRenderer{FootnoteLink}" />
     public class HtmlFootnoteLinkRenderer : HtmlObjectRenderer<FootnoteLink>
     {
         public HtmlFootnoteLinkRenderer()

--- a/src/Markdig/Extensions/Footnotes/HtmlFootnoteLinkRenderer.cs
+++ b/src/Markdig/Extensions/Footnotes/HtmlFootnoteLinkRenderer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
-using Markdig.Helpers;
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 

--- a/src/Markdig/Extensions/Footnotes/HtmlFootnoteLinkRenderer.cs
+++ b/src/Markdig/Extensions/Footnotes/HtmlFootnoteLinkRenderer.cs
@@ -10,7 +10,7 @@ namespace Markdig.Extensions.Footnotes
     /// <summary>
     /// A HTML renderer for a <see cref="FootnoteLink"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Extensions.Footnotes.FootnoteLink}" />
+    /// <seealso cref="Renderers.Html.HtmlObjectRenderer{Footnotes.FootnoteLink}" />
     public class HtmlFootnoteLinkRenderer : HtmlObjectRenderer<FootnoteLink>
     {
         public HtmlFootnoteLinkRenderer()

--- a/src/Markdig/Extensions/Footnotes/HtmlFootnoteLinkRenderer.cs
+++ b/src/Markdig/Extensions/Footnotes/HtmlFootnoteLinkRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 

--- a/src/Markdig/Extensions/GenericAttributes/GenericAttributesExtension.cs
+++ b/src/Markdig/Extensions/GenericAttributes/GenericAttributesExtension.cs
@@ -2,7 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-using System;
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Renderers;

--- a/src/Markdig/Extensions/Hardlines/SoftlineBreakAsHardlineExtension.cs
+++ b/src/Markdig/Extensions/Hardlines/SoftlineBreakAsHardlineExtension.cs
@@ -10,7 +10,7 @@ namespace Markdig.Extensions.Hardlines
     /// <summary>
     /// Extension to generate hardline break for softline breaks.
     /// </summary>
-    /// <seealso cref="Markdig.IMarkdownExtension" />
+    /// <seealso cref="IMarkdownExtension" />
     public class SoftlineBreakAsHardlineExtension : IMarkdownExtension
     {
         public void Setup(MarkdownPipelineBuilder pipeline)

--- a/src/Markdig/Extensions/JiraLinks/JiraLink.cs
+++ b/src/Markdig/Extensions/JiraLinks/JiraLink.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System.Diagnostics;
 using Markdig.Helpers;
 using Markdig.Syntax.Inlines;

--- a/src/Markdig/Extensions/JiraLinks/JiraLinkExtension.cs
+++ b/src/Markdig/Extensions/JiraLinks/JiraLinkExtension.cs
@@ -35,8 +35,7 @@ namespace Markdig.Extensions.JiraLinks
         {
             // No HTML renderer required, since JiraLink type derives from InlineLink (which already has an HTML renderer)
 
-            var normalizeRenderer = renderer as NormalizeRenderer;
-            if (normalizeRenderer != null && !normalizeRenderer.ObjectRenderers.Contains<NormalizeJiraLinksRenderer>())
+            if (renderer is NormalizeRenderer normalizeRenderer && !normalizeRenderer.ObjectRenderers.Contains<NormalizeJiraLinksRenderer>())
             {
                 normalizeRenderer.ObjectRenderers.InsertBefore<LinkInlineRenderer>(new NormalizeJiraLinksRenderer());
             }

--- a/src/Markdig/Extensions/JiraLinks/JiraLinkExtension.cs
+++ b/src/Markdig/Extensions/JiraLinks/JiraLinkExtension.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers.Inlines;
 using Markdig.Renderers;
 using Markdig.Renderers.Normalize.Inlines;

--- a/src/Markdig/Extensions/JiraLinks/JiraLinkInlineParser.cs
+++ b/src/Markdig/Extensions/JiraLinks/JiraLinkInlineParser.cs
@@ -75,14 +75,11 @@ namespace Markdig.Extensions.JiraLinks
                 return false;
             }
 
-            int line;
-            int column;
-
             var jiraLink = new JiraLink() //create the link at the relevant position
             {
                 Span =
                 {
-                    Start = processor.GetSourcePosition(slice.Start, out line, out column)
+                    Start = processor.GetSourcePosition(slice.Start, out int line, out int column)
                 },
                 Line = line,
                 Column = column,

--- a/src/Markdig/Extensions/JiraLinks/JiraLinkInlineParser.cs
+++ b/src/Markdig/Extensions/JiraLinks/JiraLinkInlineParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System;
 using Markdig.Helpers;
 using Markdig.Parsers;

--- a/src/Markdig/Extensions/JiraLinks/JiraLinkInlineParser.cs
+++ b/src/Markdig/Extensions/JiraLinks/JiraLinkInlineParser.cs
@@ -2,7 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 using System;
-using System.Text;
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Renderers.Html;

--- a/src/Markdig/Extensions/JiraLinks/JiraLinkOptions.cs
+++ b/src/Markdig/Extensions/JiraLinks/JiraLinkOptions.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System.Text;
 
 namespace Markdig.Extensions.JiraLinks

--- a/src/Markdig/Extensions/JiraLinks/NormalizeJiraLinksRenderer.cs
+++ b/src/Markdig/Extensions/JiraLinks/NormalizeJiraLinksRenderer.cs
@@ -1,8 +1,4 @@
 using Markdig.Renderers.Normalize;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Markdig.Extensions.JiraLinks
 {

--- a/src/Markdig/Extensions/JiraLinks/NormalizeJiraLinksRenderer.cs
+++ b/src/Markdig/Extensions/JiraLinks/NormalizeJiraLinksRenderer.cs
@@ -1,3 +1,7 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license. 
+// See the license.txt file in the project root for more information.
+
 using Markdig.Renderers.Normalize;
 
 namespace Markdig.Extensions.JiraLinks

--- a/src/Markdig/Extensions/ListExtras/ListExtraExtension.cs
+++ b/src/Markdig/Extensions/ListExtras/ListExtraExtension.cs
@@ -10,7 +10,7 @@ namespace Markdig.Extensions.ListExtras
     /// <summary>
     /// Extension for adding new type of list items (a., A., i., I.)
     /// </summary>
-    /// <seealso cref="Markdig.IMarkdownExtension" />
+    /// <seealso cref="IMarkdownExtension" />
     public class ListExtraExtension : IMarkdownExtension
     {
         public void Setup(MarkdownPipelineBuilder pipeline)

--- a/src/Markdig/Extensions/ListExtras/ListExtraItemParser.cs
+++ b/src/Markdig/Extensions/ListExtras/ListExtraItemParser.cs
@@ -69,8 +69,7 @@ namespace Markdig.Extensions.ListExtras
             }
 
             // Finally we expect to always have a delimiter '.' or ')'
-            char orderedDelimiter;
-            if (!TryParseDelimiter(state, out orderedDelimiter))
+            if (!TryParseDelimiter(state, out char orderedDelimiter))
             {
                 return false;
             }

--- a/src/Markdig/Extensions/ListExtras/ListExtraItemParser.cs
+++ b/src/Markdig/Extensions/ListExtras/ListExtraItemParser.cs
@@ -15,7 +15,7 @@ namespace Markdig.Extensions.ListExtras
     /// <remarks>
     /// Note that we don't validate roman numbers.
     /// </remarks>
-    /// <seealso cref="Markdig.Parsers.OrderedListItemParser" />
+    /// <seealso cref="OrderedListItemParser" />
     public class ListExtraItemParser : OrderedListItemParser
     {
         /// <summary>

--- a/src/Markdig/Extensions/Mathematics/HtmlMathBlockRenderer.cs
+++ b/src/Markdig/Extensions/Mathematics/HtmlMathBlockRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 

--- a/src/Markdig/Extensions/Mathematics/HtmlMathBlockRenderer.cs
+++ b/src/Markdig/Extensions/Mathematics/HtmlMathBlockRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.Mathematics
     /// <summary>
     /// A HTML renderer for a <see cref="MathBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{T}" />
+    /// <seealso cref="HtmlObjectRenderer{T}" />
     public class HtmlMathBlockRenderer : HtmlObjectRenderer<MathBlock>
     {
         protected override void Write(HtmlRenderer renderer, MathBlock obj)

--- a/src/Markdig/Extensions/Mathematics/HtmlMathInlineRenderer.cs
+++ b/src/Markdig/Extensions/Mathematics/HtmlMathInlineRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.Mathematics
     /// <summary>
     /// A HTML renderer for a <see cref="MathInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Figure}" />
+    /// <seealso cref="HtmlObjectRenderer{Figure}" />
     public class HtmlMathInlineRenderer : HtmlObjectRenderer<MathInline>
     {
         protected override void Write(HtmlRenderer renderer, MathInline obj)

--- a/src/Markdig/Extensions/Mathematics/HtmlMathInlineRenderer.cs
+++ b/src/Markdig/Extensions/Mathematics/HtmlMathInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 

--- a/src/Markdig/Extensions/Mathematics/MathBlock.cs
+++ b/src/Markdig/Extensions/Mathematics/MathBlock.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.Mathematics
     /// <summary>
     /// A math block.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.FencedCodeBlock" />
+    /// <seealso cref="FencedCodeBlock" />
     public class MathBlock : FencedCodeBlock
     {
         /// <summary>

--- a/src/Markdig/Extensions/Mathematics/MathBlock.cs
+++ b/src/Markdig/Extensions/Mathematics/MathBlock.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Extensions/Mathematics/MathBlockParser.cs
+++ b/src/Markdig/Extensions/Mathematics/MathBlockParser.cs
@@ -47,11 +47,9 @@ namespace Markdig.Extensions.Mathematics
 
         private static bool NoInfoParser(BlockProcessor state, ref StringSlice line, IFencedBlock fenced, char openingCharacter)
         {
-            var c = line.CurrentChar;
             for (int i = line.Start; i <= line.End; i++)
             {
-                c = line.Text[i];
-                if (!c.IsSpaceOrTab())
+                if (!line.Text[i].IsSpaceOrTab())
                 {
                     return false;
                 }

--- a/src/Markdig/Extensions/Mathematics/MathExtension.cs
+++ b/src/Markdig/Extensions/Mathematics/MathExtension.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
-using Markdig.Parsers.Inlines;
 using Markdig.Renderers;
-using Markdig.Renderers.Html.Inlines;
 
 namespace Markdig.Extensions.Mathematics
 {

--- a/src/Markdig/Extensions/Mathematics/MathExtension.cs
+++ b/src/Markdig/Extensions/Mathematics/MathExtension.cs
@@ -30,8 +30,7 @@ namespace Markdig.Extensions.Mathematics
 
         public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
         {
-            var htmlRenderer = renderer as HtmlRenderer;
-            if (htmlRenderer != null)
+            if (renderer is HtmlRenderer htmlRenderer)
             {
                 if (!htmlRenderer.ObjectRenderers.Contains<HtmlMathInlineRenderer>())
                 {

--- a/src/Markdig/Extensions/Mathematics/MathExtension.cs
+++ b/src/Markdig/Extensions/Mathematics/MathExtension.cs
@@ -10,7 +10,7 @@ namespace Markdig.Extensions.Mathematics
     /// <summary>
     /// Extension for adding inline mathematics $...$
     /// </summary>
-    /// <seealso cref="Markdig.IMarkdownExtension" />
+    /// <seealso cref="IMarkdownExtension" />
     public class MathExtension : IMarkdownExtension
     {
         public void Setup(MarkdownPipelineBuilder pipeline)

--- a/src/Markdig/Extensions/Mathematics/MathExtension.cs
+++ b/src/Markdig/Extensions/Mathematics/MathExtension.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Renderers;
 
 namespace Markdig.Extensions.Mathematics

--- a/src/Markdig/Extensions/Mathematics/MathInline.cs
+++ b/src/Markdig/Extensions/Mathematics/MathInline.cs
@@ -10,7 +10,7 @@ namespace Markdig.Extensions.Mathematics
     /// <summary>
     /// A math inline element.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Inlines.EmphasisInline" />
+    /// <seealso cref="EmphasisInline" />
     public class MathInline : LeafInline
     {
         /// <summary>

--- a/src/Markdig/Extensions/Mathematics/MathInlineParser.cs
+++ b/src/Markdig/Extensions/Mathematics/MathInlineParser.cs
@@ -50,13 +50,9 @@ namespace Markdig.Extensions.Mathematics
                 c = slice.NextChar();
             }
 
-            bool openPrevIsPunctuation;
-            bool openPrevIsWhiteSpace;
-            bool openNextIsPunctuation;
-            bool openNextIsWhiteSpace;
             bool openNextIsDigit = c.IsDigit();
-            pc.CheckUnicodeCategory(out openPrevIsWhiteSpace, out openPrevIsPunctuation);
-            c.CheckUnicodeCategory(out openNextIsWhiteSpace, out openNextIsPunctuation);
+            pc.CheckUnicodeCategory(out bool openPrevIsWhiteSpace, out bool openPrevIsPunctuation);
+            c.CheckUnicodeCategory(out bool openNextIsWhiteSpace, out _);
 
             // Check that opening $/$$ is correct, using the different heuristics than for emphasis delimiters
             // If a $/$$ is not preceded by a whitespace or punctuation, or followed by a digit
@@ -138,12 +134,8 @@ namespace Markdig.Extensions.Mathematics
 
             if (closeDollars >= openDollars)
             {
-                bool closePrevIsPunctuation;
-                bool closePrevIsWhiteSpace;
-                bool closeNextIsPunctuation;
-                bool closeNextIsWhiteSpace;
-                pc.CheckUnicodeCategory(out closePrevIsWhiteSpace, out closePrevIsPunctuation);
-                c.CheckUnicodeCategory(out closeNextIsWhiteSpace, out closeNextIsPunctuation);
+                pc.CheckUnicodeCategory(out bool closePrevIsWhiteSpace, out _);
+                c.CheckUnicodeCategory(out bool closeNextIsWhiteSpace, out bool closeNextIsPunctuation);
 
                 // A closing $/$$ should be followed by at least a punctuation or a whitespace
                 // and if the character after an opening $/$$ was a whitespace, it should be
@@ -163,11 +155,9 @@ namespace Markdig.Extensions.Mathematics
                 }
 
                 // Create a new MathInline
-                int line;
-                int column;
                 var inline = new MathInline()
                 {
-                    Span = new SourceSpan(processor.GetSourcePosition(startPosition, out line, out column), processor.GetSourcePosition(slice.End)),
+                    Span = new SourceSpan(processor.GetSourcePosition(startPosition, out int line, out int column), processor.GetSourcePosition(slice.End)),
                     Line = line,
                     Column = column,
                     Delimiter = match,

--- a/src/Markdig/Extensions/Mathematics/MathInlineParser.cs
+++ b/src/Markdig/Extensions/Mathematics/MathInlineParser.cs
@@ -12,7 +12,7 @@ namespace Markdig.Extensions.Mathematics
     /// <summary>
     /// An inline parser for <see cref="MathInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.InlineParser" />
+    /// <seealso cref="InlineParser" />
     /// <seealso cref="IPostInlineProcessor" />
     public class MathInlineParser : InlineParser
     {

--- a/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
+++ b/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
@@ -3,7 +3,6 @@
 // See the license.txt file in the project root for more information.
 
 using System;
-using System.Linq;
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 using Markdig.Renderers.Html.Inlines;

--- a/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
+++ b/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
@@ -14,7 +14,7 @@ namespace Markdig.Extensions.MediaLinks
     /// <summary>
     /// Extension for extending image Markdown links in case a video or an audio file is linked and output proper link.
     /// </summary>
-    /// <seealso cref="Markdig.IMarkdownExtension" />
+    /// <seealso cref="IMarkdownExtension" />
     public class MediaLinkExtension : IMarkdownExtension
     {
         public MediaLinkExtension() : this(new MediaOptions())

--- a/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
+++ b/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
@@ -33,8 +33,7 @@ namespace Markdig.Extensions.MediaLinks
 
         public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
         {
-            var htmlRenderer = renderer as HtmlRenderer;
-            if (htmlRenderer != null)
+            if (renderer is HtmlRenderer htmlRenderer)
             {
                 var inlineRenderer = htmlRenderer.ObjectRenderers.FindExact<LinkInlineRenderer>();
                 if (inlineRenderer != null)
@@ -52,10 +51,9 @@ namespace Markdig.Extensions.MediaLinks
                 return false;
             }
 
-            Uri uri;
             bool isSchemaRelative = false;
             // Only process absolute Uri
-            if (!Uri.TryCreate(linkInline.Url, UriKind.RelativeOrAbsolute, out uri) || !uri.IsAbsoluteUri)
+            if (!Uri.TryCreate(linkInline.Url, UriKind.RelativeOrAbsolute, out Uri uri) || !uri.IsAbsoluteUri)
             {
                 // see https://tools.ietf.org/html/rfc3986#section-4.2
                 // since relative uri doesn't support many properties, "http" is used as a placeholder here.
@@ -98,10 +96,9 @@ namespace Markdig.Extensions.MediaLinks
         {
             var path = uri.GetComponents(UriComponents.Path, UriFormat.Unescaped);
             // Otherwise try to detect if we have an audio/video from the file extension
-            string mimeType;
             var lastDot = path.LastIndexOf('.');
             if (lastDot >= 0 &&
-                Options.ExtensionToMimeType.TryGetValue(path.Substring(lastDot), out mimeType))
+                Options.ExtensionToMimeType.TryGetValue(path.Substring(lastDot), out string mimeType))
             {
                 var htmlAttributes = GetHtmlAttributes(linkInline);
                 var isAudio = mimeType.StartsWith("audio");

--- a/src/Markdig/Extensions/NonAsciiNoEscape/NonAsciiNoEscapeExtension.cs
+++ b/src/Markdig/Extensions/NonAsciiNoEscape/NonAsciiNoEscapeExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
@@ -17,8 +17,7 @@ namespace Markdig.Extensions.NonAsciiNoEscape
 
         public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
         {
-            var htmlRenderer = renderer as HtmlRenderer;
-            if (htmlRenderer != null)
+            if (renderer is HtmlRenderer htmlRenderer)
             {
                 htmlRenderer.UseNonAsciiNoEscape = true;
             }

--- a/src/Markdig/Extensions/PragmaLines/PragmaLineExtension.cs
+++ b/src/Markdig/Extensions/PragmaLines/PragmaLineExtension.cs
@@ -14,7 +14,7 @@ namespace Markdig.Extensions.PragmaLines
     /// <summary>
     /// Extension to a span for each line containing the original line id (using id = pragma-line#line_number_zero_based)
     /// </summary>
-    /// <seealso cref="Markdig.IMarkdownExtension" />
+    /// <seealso cref="IMarkdownExtension" />
     public class PragmaLineExtension : IMarkdownExtension
     {
         public void Setup(MarkdownPipelineBuilder pipeline)

--- a/src/Markdig/Extensions/PragmaLines/PragmaLineExtension.cs
+++ b/src/Markdig/Extensions/PragmaLines/PragmaLineExtension.cs
@@ -2,7 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-using System;
 using Markdig.Helpers;
 using Markdig.Renderers;
 using Markdig.Renderers.Html;

--- a/src/Markdig/Extensions/SelfPipeline/SelfPipelineExtension.cs
+++ b/src/Markdig/Extensions/SelfPipeline/SelfPipelineExtension.cs
@@ -23,7 +23,7 @@ namespace Markdig.Extensions.SelfPipeline
         /// </summary>
         /// <param name="tag">The matching start tag.</param>
         /// <param name="defaultExtensions">The default extensions.</param>
-        /// <exception cref="System.ArgumentException">Tag cannot contain `<`  or `>` characters</exception>
+        /// <exception cref="ArgumentException">Tag cannot contain `<`  or `>` characters</exception>
         public SelfPipelineExtension(string tag = null, string defaultExtensions = null)
         {
             tag = tag?.Trim();
@@ -72,7 +72,7 @@ namespace Markdig.Extensions.SelfPipeline
         /// </summary>
         /// <param name="inputText">The input text.</param>
         /// <returns>The pipeline configured from the input</returns>
-        /// <exception cref="System.ArgumentNullException"></exception>
+        /// <exception cref="ArgumentNullException"></exception>
         public MarkdownPipeline CreatePipelineFromInput(string inputText)
         {
             if (inputText == null) ThrowHelper.ArgumentNullException(nameof(inputText));

--- a/src/Markdig/Extensions/SelfPipeline/SelfPipelineExtension.cs
+++ b/src/Markdig/Extensions/SelfPipeline/SelfPipelineExtension.cs
@@ -23,12 +23,12 @@ namespace Markdig.Extensions.SelfPipeline
         /// </summary>
         /// <param name="tag">The matching start tag.</param>
         /// <param name="defaultExtensions">The default extensions.</param>
-        /// <exception cref="ArgumentException">Tag cannot contain `<`  or `>` characters</exception>
+        /// <exception cref="ArgumentException">Tag cannot contain angle brackets</exception>
         public SelfPipelineExtension(string tag = null, string defaultExtensions = null)
         {
             tag = tag?.Trim();
             tag = string.IsNullOrEmpty(tag) ? DefaultTag : tag;
-            if (tag.IndexOfAny(new []{'<', '>'}) >= 0)
+            if (tag.AsSpan().IndexOfAny('<', '>') >= 0)
             {
                 ThrowHelper.ArgumentException("Tag cannot contain `<`  or `>` characters", nameof(tag));
             }

--- a/src/Markdig/Extensions/SmartyPants/SmartyPant.cs
+++ b/src/Markdig/Extensions/SmartyPants/SmartyPant.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System.Diagnostics;
 using Markdig.Syntax.Inlines;
 

--- a/src/Markdig/Extensions/SmartyPants/SmartyPantOptions.cs
+++ b/src/Markdig/Extensions/SmartyPants/SmartyPantOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System.Collections.Generic;
 
 namespace Markdig.Extensions.SmartyPants

--- a/src/Markdig/Extensions/SmartyPants/SmartyPantType.cs
+++ b/src/Markdig/Extensions/SmartyPants/SmartyPantType.cs
@@ -15,12 +15,12 @@ namespace Markdig.Extensions.SmartyPants
         Quote = 1,
 
         /// <summary>
-        /// This is a left single quote ' -gt; &lsquo;
+        /// This is a left single quote ' -gt; lsquo;
         /// </summary>
         LeftQuote,
 
         /// <summary>
-        /// This is a right single quote ' -gt; &rsquo;
+        /// This is a right single quote ' -gt; rsquo;
         /// </summary>
         RightQuote,
 
@@ -30,37 +30,37 @@ namespace Markdig.Extensions.SmartyPants
         DoubleQuote,
 
         /// <summary>
-        /// This is a left double quote " -gt; &ldquo;
+        /// This is a left double quote " -gt; ldquo;
         /// </summary>
         LeftDoubleQuote,
 
         /// <summary>
-        /// This is a right double quote " -gt; &rdquo;
+        /// This is a right double quote " -gt; rdquo;
         /// </summary>
         RightDoubleQuote,
 
         /// <summary>
-        /// This is a right double quote &lt;&lt; -gt; &laquo;
+        /// This is a right double quote &lt;&lt; -gt; laquo;
         /// </summary>
         LeftAngleQuote,
 
         /// <summary>
-        /// This is a right angle quote >> -gt;  &raquo;
+        /// This is a right angle quote >> -gt;  raquo;
         /// </summary>
         RightAngleQuote,
 
         /// <summary>
-        /// This is an ellipsis ... -gt; &hellip;
+        /// This is an ellipsis ... -gt; hellip;
         /// </summary>
         Ellipsis,
 
         /// <summary>
-        /// This is a ndash -- -gt; &ndash;
+        /// This is a ndash -- -gt; ndash;
         /// </summary>
         Dash2,
 
         /// <summary>
-        /// This is a mdash --- -gt; &mdash;
+        /// This is a mdash --- -gt; mdash;
         /// </summary>
         Dash3,
     }

--- a/src/Markdig/Extensions/SmartyPants/SmartyPantType.cs
+++ b/src/Markdig/Extensions/SmartyPants/SmartyPantType.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 namespace Markdig.Extensions.SmartyPants
 {
     /// <summary>

--- a/src/Markdig/Extensions/SmartyPants/SmartyPantsInlineParser.cs
+++ b/src/Markdig/Extensions/SmartyPants/SmartyPantsInlineParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
+
 using System.Collections.Generic;
 using Markdig.Helpers;
 using Markdig.Parsers;

--- a/src/Markdig/Extensions/SmartyPants/SmartyPantsInlineParser.cs
+++ b/src/Markdig/Extensions/SmartyPants/SmartyPantsInlineParser.cs
@@ -184,8 +184,7 @@ namespace Markdig.Extensions.SmartyPants
 
         private ListSmartyPants GetOrCreateState(InlineProcessor processor)
         {
-            var quotePants = processor.ParserStates[Index] as ListSmartyPants;
-            if (quotePants == null)
+            if (!(processor.ParserStates[Index] is ListSmartyPants quotePants))
             {
                 processor.ParserStates[Index] = quotePants = new ListSmartyPants();
             }

--- a/src/Markdig/Extensions/Tables/GridTableExtension.cs
+++ b/src/Markdig/Extensions/Tables/GridTableExtension.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Renderers;
 
 namespace Markdig.Extensions.Tables

--- a/src/Markdig/Extensions/Tables/GridTableExtension.cs
+++ b/src/Markdig/Extensions/Tables/GridTableExtension.cs
@@ -8,7 +8,7 @@ namespace Markdig.Extensions.Tables
     /// <summary>
     /// Extension that allows to use grid tables.
     /// </summary>
-    /// <seealso cref="Markdig.IMarkdownExtension" />
+    /// <seealso cref="IMarkdownExtension" />
     public class GridTableExtension : IMarkdownExtension
     {
         public void Setup(MarkdownPipelineBuilder pipeline)

--- a/src/Markdig/Extensions/Tables/GridTableExtension.cs
+++ b/src/Markdig/Extensions/Tables/GridTableExtension.cs
@@ -22,8 +22,7 @@ namespace Markdig.Extensions.Tables
 
         public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
         {
-            var htmlRenderer = renderer as HtmlRenderer;
-            if (htmlRenderer != null && !htmlRenderer.ObjectRenderers.Contains<HtmlTableRenderer>())
+            if (renderer is HtmlRenderer htmlRenderer && !htmlRenderer.ObjectRenderers.Contains<HtmlTableRenderer>())
             {
                 htmlRenderer.ObjectRenderers.Add(new HtmlTableRenderer());
             }

--- a/src/Markdig/Extensions/Tables/GridTableParser.cs
+++ b/src/Markdig/Extensions/Tables/GridTableParser.cs
@@ -1,7 +1,7 @@
-
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System.Collections.Generic;
 using Markdig.Helpers;
 using Markdig.Parsers;

--- a/src/Markdig/Extensions/Tables/GridTableParser.cs
+++ b/src/Markdig/Extensions/Tables/GridTableParser.cs
@@ -44,13 +44,12 @@ namespace Markdig.Extensions.Tables
                 }
 
                 // Parse a column alignment
-                TableColumnAlign? columnAlign;
-                if (!TableHelper.ParseColumnHeader(ref line, '-', out columnAlign))
+                if (!TableHelper.ParseColumnHeader(ref line, '-', out TableColumnAlign? columnAlign))
                 {
                     return BlockState.None;
                 }
 
-                tableState = tableState ?? new GridTableState { Start = processor.Start, ExpectRow = true };
+                tableState ??= new GridTableState { Start = processor.Start, ExpectRow = true };
                 tableState.AddColumn(columnStart - lineStart, line.Start - lineStart, columnAlign);
 
                 c = line.CurrentChar;
@@ -114,9 +113,8 @@ namespace Markdig.Extensions.Tables
 
         private BlockState HandleNewRow(BlockProcessor processor, GridTableState tableState, Table gridTable)
         {
-            bool isHeaderRow, hasRowSpan;
             var columns = tableState.ColumnSlices;
-            SetRowSpanState(columns, processor.Line, out isHeaderRow, out hasRowSpan);
+            SetRowSpanState(columns, processor.Line, out bool isHeaderRow, out bool hasRowSpan);
             SetColumnSpanState(columns, processor.Line);
             TerminateCurrentRow(processor, tableState, gridTable, false);
             if (isHeaderRow)

--- a/src/Markdig/Extensions/Tables/GridTableState.cs
+++ b/src/Markdig/Extensions/Tables/GridTableState.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System.Collections.Generic;
 using Markdig.Helpers;
 using Markdig.Parsers;

--- a/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
+++ b/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
@@ -12,7 +12,7 @@ namespace Markdig.Extensions.Tables
     /// <summary>
     /// A HTML renderer for a <see cref="Table"/>
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Extensions.Tables.TableBlock}" />
+    /// <seealso cref="Renderers.Html.HtmlObjectRenderer{Tables.TableBlock}" />
     public class HtmlTableRenderer : HtmlObjectRenderer<Table>
     {
         protected override void Write(HtmlRenderer renderer, Table table)

--- a/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
+++ b/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
@@ -12,7 +12,7 @@ namespace Markdig.Extensions.Tables
     /// <summary>
     /// A HTML renderer for a <see cref="Table"/>
     /// </summary>
-    /// <seealso cref="Renderers.Html.HtmlObjectRenderer{Tables.TableBlock}" />
+    /// <seealso cref="HtmlObjectRenderer{TableBlock}" />
     public class HtmlTableRenderer : HtmlObjectRenderer<Table>
     {
         protected override void Write(HtmlRenderer renderer, Table table)

--- a/src/Markdig/Extensions/Tables/PipeTableBlockParser.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableBlockParser.cs
@@ -14,7 +14,7 @@ namespace Markdig.Extensions.Tables
     /// that starts by a '-' and have at least a '|' (and have optional spaces) and is a continuation of a
     /// paragraph.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.BlockParser" />
+    /// <seealso cref="BlockParser" />
     public class PipeTableBlockParser : BlockParser
     {
         /// <summary>

--- a/src/Markdig/Extensions/Tables/PipeTableDelimiterInline.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableDelimiterInline.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 using Markdig.Syntax.Inlines;
 

--- a/src/Markdig/Extensions/Tables/PipeTableDelimiterInline.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableDelimiterInline.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.Tables
     /// <summary>
     /// The delimiter used to separate the columns of a pipe table.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Inlines.DelimiterInline" />
+    /// <seealso cref="DelimiterInline" />
     public class PipeTableDelimiterInline : DelimiterInline
     {
         public PipeTableDelimiterInline(InlineParser parser) : base(parser)

--- a/src/Markdig/Extensions/Tables/PipeTableExtension.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableExtension.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.Tables
     /// <summary>
     /// Extension that allows to use pipe tables.
     /// </summary>
-    /// <seealso cref="Markdig.IMarkdownExtension" />
+    /// <seealso cref="IMarkdownExtension" />
     public class PipeTableExtension : IMarkdownExtension
     {
         /// <summary>

--- a/src/Markdig/Extensions/Tables/PipeTableExtension.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableExtension.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers.Inlines;
 using Markdig.Renderers;
 

--- a/src/Markdig/Extensions/Tables/PipeTableExtension.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableExtension.cs
@@ -44,8 +44,7 @@ namespace Markdig.Extensions.Tables
 
         public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
         {
-            var htmlRenderer = renderer as HtmlRenderer;
-            if (htmlRenderer != null && !htmlRenderer.ObjectRenderers.Contains<HtmlTableRenderer>())
+            if (renderer is HtmlRenderer htmlRenderer && !htmlRenderer.ObjectRenderers.Contains<HtmlTableRenderer>())
             {
                 htmlRenderer.ObjectRenderers.Add(new HtmlTableRenderer());
             }

--- a/src/Markdig/Extensions/Tables/PipeTableOptions.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 namespace Markdig.Extensions.Tables
 {
     /// <summary>

--- a/src/Markdig/Extensions/Tables/PipeTableParser.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableParser.cs
@@ -56,9 +56,7 @@ namespace Markdig.Extensions.Tables
             bool isFirstLineEmpty = false;
 
 
-            int globalLineIndex;
-            int column;
-            var position = processor.GetSourcePosition(slice.Start, out globalLineIndex, out column);
+            var position = processor.GetSourcePosition(slice.Start, out int globalLineIndex, out int column);
             var localLineIndex = globalLineIndex - processor.LineIndex;
 
             if (tableState == null)

--- a/src/Markdig/Extensions/Tables/PipeTableParser.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableParser.cs
@@ -17,7 +17,7 @@ namespace Markdig.Extensions.Tables
     /// <summary>
     /// The inline parser used to transform a <see cref="ParagraphBlock"/> into a <see cref="Table"/> at inline parsing time.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.InlineParser" />
+    /// <seealso cref="InlineParser" />
     /// <seealso cref="IPostInlineProcessor" />
     public class PipeTableParser : InlineParser, IPostInlineProcessor
     {

--- a/src/Markdig/Extensions/Tables/Table.cs
+++ b/src/Markdig/Extensions/Tables/Table.cs
@@ -11,7 +11,7 @@ namespace Markdig.Extensions.Tables
     /// <summary>
     /// Defines a table that contains an optional <see cref="TableRow"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.ContainerBlock" />
+    /// <seealso cref="ContainerBlock" />
     public class Table : ContainerBlock
     {
         /// <summary>

--- a/src/Markdig/Extensions/Tables/TableCell.cs
+++ b/src/Markdig/Extensions/Tables/TableCell.cs
@@ -10,7 +10,7 @@ namespace Markdig.Extensions.Tables
     /// <summary>
     /// Defines a cell in a <see cref="TableRow"/>
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.LeafBlock" />
+    /// <seealso cref="LeafBlock" />
     public class TableCell : ContainerBlock
     {
         /// <summary>

--- a/src/Markdig/Extensions/Tables/TableColumnAlign.cs
+++ b/src/Markdig/Extensions/Tables/TableColumnAlign.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 namespace Markdig.Extensions.Tables
 {
     /// <summary>

--- a/src/Markdig/Extensions/Tables/TableRow.cs
+++ b/src/Markdig/Extensions/Tables/TableRow.cs
@@ -8,7 +8,7 @@ namespace Markdig.Extensions.Tables
     /// <summary>
     /// Defines a row in a <see cref="Table"/>, contains <see cref="TableCell"/>, parent is <see cref="Table"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.ContainerBlock" />
+    /// <seealso cref="ContainerBlock" />
     public class TableRow : ContainerBlock
     {
         /// <summary>

--- a/src/Markdig/Extensions/Tables/TableRow.cs
+++ b/src/Markdig/Extensions/Tables/TableRow.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax;
 
 namespace Markdig.Extensions.Tables

--- a/src/Markdig/Extensions/TaskLists/HtmlTaskListRenderer.cs
+++ b/src/Markdig/Extensions/TaskLists/HtmlTaskListRenderer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
-using System;
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 

--- a/src/Markdig/Extensions/TaskLists/HtmlTaskListRenderer.cs
+++ b/src/Markdig/Extensions/TaskLists/HtmlTaskListRenderer.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 

--- a/src/Markdig/Extensions/TaskLists/HtmlTaskListRenderer.cs
+++ b/src/Markdig/Extensions/TaskLists/HtmlTaskListRenderer.cs
@@ -10,7 +10,7 @@ namespace Markdig.Extensions.TaskLists
     /// <summary>
     /// A HTML renderer for a <see cref="TaskList"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{TaskList}" />
+    /// <seealso cref="HtmlObjectRenderer{TaskList}" />
     public class HtmlTaskListRenderer : HtmlObjectRenderer<TaskList>
     {
         protected override void Write(HtmlRenderer renderer, TaskList obj)

--- a/src/Markdig/Extensions/TaskLists/NormalizeTaskListRenderer.cs
+++ b/src/Markdig/Extensions/TaskLists/NormalizeTaskListRenderer.cs
@@ -1,3 +1,7 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license. 
+// See the license.txt file in the project root for more information.
+
 using Markdig.Renderers.Normalize;
 
 namespace Markdig.Extensions.TaskLists

--- a/src/Markdig/Extensions/TaskLists/TaskList.cs
+++ b/src/Markdig/Extensions/TaskLists/TaskList.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System.Diagnostics;
 using Markdig.Syntax.Inlines;
 

--- a/src/Markdig/Extensions/TaskLists/TaskListExtension.cs
+++ b/src/Markdig/Extensions/TaskLists/TaskListExtension.cs
@@ -24,14 +24,12 @@ namespace Markdig.Extensions.TaskLists
 
         public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
         {
-            var htmlRenderer = renderer as HtmlRenderer;
-            if (htmlRenderer != null)
+            if (renderer is HtmlRenderer htmlRenderer)
             {
                 htmlRenderer.ObjectRenderers.AddIfNotAlready<HtmlTaskListRenderer>();
             }
 
-            var normalizeRenderer = renderer as NormalizeRenderer;
-            if (normalizeRenderer != null)
+            if (renderer is NormalizeRenderer normalizeRenderer)
             {
                 normalizeRenderer.ObjectRenderers.AddIfNotAlready<NormalizeTaskListRenderer>();
             }

--- a/src/Markdig/Extensions/TaskLists/TaskListInlineParser.cs
+++ b/src/Markdig/Extensions/TaskLists/TaskListInlineParser.cs
@@ -40,9 +40,7 @@ namespace Markdig.Extensions.TaskLists
             // [ ]
             // or [x] or [X]
 
-            var listItemBlock = processor.Block.Parent as ListItemBlock;
-
-            if (listItemBlock == null)
+            if (!(processor.Block.Parent is ListItemBlock listItemBlock))
             {
                 return false;
             }
@@ -61,11 +59,9 @@ namespace Markdig.Extensions.TaskLists
             slice.NextChar();
 
             // Create the TaskList
-            int line;
-            int column;
             var taskItem = new TaskList()
             {
-                Span = { Start = processor.GetSourcePosition(startingPosition, out line, out column)},
+                Span = { Start = processor.GetSourcePosition(startingPosition, out int line, out int column) },
                 Line = line,
                 Column = column,
                 Checked = !c.IsSpace()

--- a/src/Markdig/Extensions/TaskLists/TaskListInlineParser.cs
+++ b/src/Markdig/Extensions/TaskLists/TaskListInlineParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Renderers.Html;

--- a/src/Markdig/Extensions/TextRenderer/ConfigureNewLineExtension.cs
+++ b/src/Markdig/Extensions/TextRenderer/ConfigureNewLineExtension.cs
@@ -1,3 +1,7 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license. 
+// See the license.txt file in the project root for more information.
+
 using Markdig.Renderers;
 
 namespace Markdig.Extensions.TextRenderer

--- a/src/Markdig/Extensions/TextRenderer/ConfigureNewLineExtension.cs
+++ b/src/Markdig/Extensions/TextRenderer/ConfigureNewLineExtension.cs
@@ -26,13 +26,10 @@ namespace Markdig.Extensions.TextRenderer
 
         public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
         {
-            var textRenderer = renderer as TextRendererBase;
-            if (textRenderer == null)
+            if (renderer is TextRendererBase textRenderer)
             {
-                return;
+                textRenderer.Writer.NewLine = newLine;
             }
-
-            textRenderer.Writer.NewLine = newLine;
         }
     }
 }

--- a/src/Markdig/Extensions/TextRenderer/ConfigureNewLineExtension.cs
+++ b/src/Markdig/Extensions/TextRenderer/ConfigureNewLineExtension.cs
@@ -4,9 +4,9 @@ namespace Markdig.Extensions.TextRenderer
 {
     /// <summary>
     /// Extension that allows setting line-endings for any IMarkdownRenderer
-    /// that inherits from <see cref="Markdig.Renderers.TextRendererBase"/>
+    /// that inherits from <see cref="TextRendererBase"/>
     /// </summary>
-    /// <seealso cref="Markdig.IMarkdownExtension" />
+    /// <seealso cref="IMarkdownExtension" />
     public class ConfigureNewLineExtension : IMarkdownExtension
     {
         private readonly string newLine;

--- a/src/Markdig/Extensions/Yaml/YamlFrontMatterBlock.cs
+++ b/src/Markdig/Extensions/Yaml/YamlFrontMatterBlock.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.Yaml
     /// <summary>
     /// A YAML frontmatter block.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.CodeBlock" />
+    /// <seealso cref="CodeBlock" />
     public class YamlFrontMatterBlock : CodeBlock
     {
         /// <summary>

--- a/src/Markdig/Extensions/Yaml/YamlFrontMatterBlock.cs
+++ b/src/Markdig/Extensions/Yaml/YamlFrontMatterBlock.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Extensions/Yaml/YamlFrontMatterParser.cs
+++ b/src/Markdig/Extensions/Yaml/YamlFrontMatterParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Syntax;

--- a/src/Markdig/Extensions/Yaml/YamlFrontMatterRenderer.cs
+++ b/src/Markdig/Extensions/Yaml/YamlFrontMatterRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 

--- a/src/Markdig/Extensions/Yaml/YamlFrontMatterRenderer.cs
+++ b/src/Markdig/Extensions/Yaml/YamlFrontMatterRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Extensions.Yaml
     /// <summary>
     /// Empty renderer for a <see cref="YamlFrontMatterBlock"/>
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{YamlFrontMatterBlock}" />
+    /// <seealso cref="HtmlObjectRenderer{YamlFrontMatterBlock}" />
     public class YamlFrontMatterRenderer : HtmlObjectRenderer<YamlFrontMatterBlock>
     {
         protected override void Write(HtmlRenderer renderer, YamlFrontMatterBlock obj)

--- a/src/Markdig/Helpers/CharNormalizer.cs
+++ b/src/Markdig/Helpers/CharNormalizer.cs
@@ -20,8 +20,7 @@ namespace Markdig.Helpers
         /// <returns>The simple ASCII string or null if the char itself cannot be simplified</returns>
         public static string ConvertToAscii(char c)
         {
-            string str;
-            return CodeToAscii.TryGetValue(c, out str) ? str : null;
+            return CodeToAscii.TryGetValue(c, out string str) ? str : null;
         }
 
         static CharNormalizer()

--- a/src/Markdig/Helpers/CharacterMap.cs
+++ b/src/Markdig/Helpers/CharacterMap.cs
@@ -24,7 +24,7 @@ namespace Markdig.Helpers
         /// Initializes a new instance of the <see cref="CharacterMap{T}"/> class.
         /// </summary>
         /// <param name="maps">The states.</param>
-        /// <exception cref="System.ArgumentNullException"></exception>
+        /// <exception cref="ArgumentNullException"></exception>
         public CharacterMap(IEnumerable<KeyValuePair<char, T>> maps)
         {
             if (maps == null) ThrowHelper.ArgumentNullException(nameof(maps));

--- a/src/Markdig/Helpers/CustomArrayPool.cs
+++ b/src/Markdig/Helpers/CustomArrayPool.cs
@@ -1,3 +1,7 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license. 
+// See the license.txt file in the project root for more information.
+
 using System.Threading;
 
 namespace Markdig.Helpers

--- a/src/Markdig/Helpers/DefaultObjectCache.cs
+++ b/src/Markdig/Helpers/DefaultObjectCache.cs
@@ -11,7 +11,7 @@ namespace Markdig.Helpers
     /// A default object cache that expect the type {T} to provide a parameter less constructor
     /// </summary>
     /// <typeparam name="T">The type of item to cache</typeparam>
-    /// <seealso cref="Markdig.Helpers.ObjectCache{T}" />
+    /// <seealso cref="ObjectCache{T}" />
     public abstract class DefaultObjectCache<T> : ObjectCache<T> where T : class, new()
     {
         protected override T NewInstance()

--- a/src/Markdig/Helpers/DefaultObjectCache.cs
+++ b/src/Markdig/Helpers/DefaultObjectCache.cs
@@ -2,9 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-using System.Collections;
-using System.Collections.Generic;
-
 namespace Markdig.Helpers
 {
     /// <summary>

--- a/src/Markdig/Helpers/LinkHelper.cs
+++ b/src/Markdig/Helpers/LinkHelper.cs
@@ -333,9 +333,7 @@ namespace Markdig.Helpers
 
         public static bool TryParseInlineLink(ref StringSlice text, out string link, out string title)
         {
-            SourceSpan linkSpan;
-            SourceSpan titleSpan;
-            return TryParseInlineLink(ref text, out link, out title, out linkSpan, out titleSpan);
+            return TryParseInlineLink(ref text, out link, out title, out SourceSpan linkSpan, out SourceSpan titleSpan);
         }
 
         public static bool TryParseInlineLink(ref StringSlice text, out string link, out string title, out SourceSpan linkSpan, out SourceSpan titleSpan)
@@ -370,8 +368,7 @@ namespace Markdig.Helpers
                         linkSpan = SourceSpan.Empty;
                     }
 
-                    int spaceCount;
-                    text.TrimStart(out spaceCount);
+                    text.TrimStart(out int spaceCount);
                     var hasWhiteSpaces = spaceCount > 0;
 
                     c = text.CurrentChar;
@@ -411,7 +408,7 @@ namespace Markdig.Helpers
             {
                 // Skip ')'
                 text.NextChar();
-                title = title ?? String.Empty;
+                title ??= string.Empty;
             }
 
             return isValid;
@@ -724,11 +721,8 @@ namespace Markdig.Helpers
         public static bool TryParseLinkReferenceDefinition<T>(ref T text, out string label, out string url, out string title)
             where T : ICharIterator
         {
-            SourceSpan labelSpan;
-            SourceSpan urlSpan;
-            SourceSpan titleSpan;
-            return TryParseLinkReferenceDefinition(ref text, out label, out url, out title, out labelSpan, out urlSpan,
-                out titleSpan);
+            return TryParseLinkReferenceDefinition(ref text, out label, out url, out title, out SourceSpan labelSpan, out SourceSpan urlSpan,
+                out SourceSpan titleSpan);
         }
 
         public static bool TryParseLinkReferenceDefinition<T>(ref T text, out string label, out string url, out string title, out SourceSpan labelSpan, out SourceSpan urlSpan, out SourceSpan titleSpan) where T : ICharIterator
@@ -763,8 +757,7 @@ namespace Markdig.Helpers
             urlSpan.End = text.Start - 1;
 
             var saved = text;
-            int newLineCount;
-            var hasWhiteSpaces = CharIteratorHelper.TrimStartAndCountNewLines(ref text, out newLineCount);
+            var hasWhiteSpaces = CharIteratorHelper.TrimStartAndCountNewLines(ref text, out int newLineCount);
             var c = text.CurrentChar;
             if (c == '\'' || c == '"' || c == '(')
             {
@@ -820,8 +813,7 @@ namespace Markdig.Helpers
 
         public static bool TryParseLabel<T>(T lines, out string label) where T : ICharIterator
         {
-            SourceSpan labelSpan;
-            return TryParseLabel(ref lines, false, out label, out labelSpan);
+            return TryParseLabel(ref lines, false, out label, out SourceSpan labelSpan);
         }
 
         public static bool TryParseLabel<T>(T lines, out string label, out SourceSpan labelSpan) where T : ICharIterator
@@ -831,8 +823,7 @@ namespace Markdig.Helpers
 
         public static bool TryParseLabel<T>(ref T lines, out string label) where T : ICharIterator
         {
-            SourceSpan labelSpan;
-            return TryParseLabel(ref lines, false, out label, out labelSpan);
+            return TryParseLabel(ref lines, false, out label, out SourceSpan labelSpan);
         }
 
         public static bool TryParseLabel<T>(ref T lines, out string label, out SourceSpan labelSpan) where T : ICharIterator

--- a/src/Markdig/Helpers/LinkHelper.cs
+++ b/src/Markdig/Helpers/LinkHelper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System;
 using System.Runtime.CompilerServices;
 using Markdig.Syntax;

--- a/src/Markdig/Helpers/ObjectCache.cs
+++ b/src/Markdig/Helpers/ObjectCache.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 

--- a/src/Markdig/Helpers/ObjectCache.cs
+++ b/src/Markdig/Helpers/ObjectCache.cs
@@ -54,7 +54,7 @@ namespace Markdig.Helpers
         /// Releases the specified instance.
         /// </summary>
         /// <param name="instance">The instance.</param>
-        /// <exception cref="System.ArgumentNullException">if instance is null</exception>
+        /// <exception cref="ArgumentNullException">if instance is null</exception>
         public void Release(T instance)
         {
             if (instance == null) ThrowHelper.ArgumentNullException(nameof(instance));

--- a/src/Markdig/Helpers/OrderedList.cs
+++ b/src/Markdig/Helpers/OrderedList.cs
@@ -10,7 +10,7 @@ namespace Markdig.Helpers
     /// A List that provides methods for inserting/finding before/after. See remarks.
     /// </summary>
     /// <typeparam name="T">Type of the list item</typeparam>
-    /// <seealso cref="System.Collections.Generic.List{T}" />
+    /// <seealso cref="List{T}" />
     /// <remarks>We use a typed list and don't use extension methods because it would pollute all list implements and the top level namespace.</remarks>
     public class OrderedList<T> : List<T>
     {

--- a/src/Markdig/Helpers/OrderedList.cs
+++ b/src/Markdig/Helpers/OrderedList.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
-using System;
 using System.Collections.Generic;
 
 namespace Markdig.Helpers

--- a/src/Markdig/Helpers/OrderedList.cs
+++ b/src/Markdig/Helpers/OrderedList.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
+
 using System.Collections.Generic;
 
 namespace Markdig.Helpers

--- a/src/Markdig/Helpers/StringBuilderCache.cs
+++ b/src/Markdig/Helpers/StringBuilderCache.cs
@@ -21,8 +21,8 @@ namespace Markdig.Helpers
         /// <returns></returns>
         public static StringBuilder Local()
         {
-            var sb = local ?? (local = new StringBuilder());
-            if (sb.Length > 0)
+            var sb = local ??= new StringBuilder();
+            if (sb.Length != 0)
             {
                 sb.Length = 0;
             }

--- a/src/Markdig/Helpers/StringBuilderCache.cs
+++ b/src/Markdig/Helpers/StringBuilderCache.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System;
 using System.Text;
 

--- a/src/Markdig/Helpers/StringBuilderExtensions.cs
+++ b/src/Markdig/Helpers/StringBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System.Text;
 
 namespace Markdig.Helpers

--- a/src/Markdig/Helpers/StringLine.cs
+++ b/src/Markdig/Helpers/StringLine.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 namespace Markdig.Helpers
 {
     /// <summary>

--- a/src/Markdig/Helpers/StringLine.cs
+++ b/src/Markdig/Helpers/StringLine.cs
@@ -24,6 +24,7 @@ namespace Markdig.Helpers
         /// <param name="slice">The slice.</param>
         /// <param name="line">The line.</param>
         /// <param name="column">The column.</param>
+        /// <param name="position">The position.</param>
         public StringLine(StringSlice slice, int line, int column, int position)
         {
             Slice = slice;
@@ -38,6 +39,7 @@ namespace Markdig.Helpers
         /// <param name="slice">The slice.</param>
         /// <param name="line">The line.</param>
         /// <param name="column">The column.</param>
+        /// <param name="position">The position.</param>
         public StringLine(ref StringSlice slice, int line, int column, int position)
         {
             Slice = slice;

--- a/src/Markdig/Helpers/StringLineGroup.cs
+++ b/src/Markdig/Helpers/StringLineGroup.cs
@@ -35,7 +35,7 @@ namespace Markdig.Helpers
         /// Initializes a new instance of the <see cref="StringLineGroup"/> class.
         /// </summary>
         /// <param name="text">The text.</param>
-        /// <exception cref="System.ArgumentNullException"></exception>
+        /// <exception cref="ArgumentNullException"></exception>
         public StringLineGroup(string text)
         {
             if (text == null) ThrowHelper.ArgumentNullException_text();

--- a/src/Markdig/Helpers/StringLineGroup.cs
+++ b/src/Markdig/Helpers/StringLineGroup.cs
@@ -24,7 +24,13 @@ namespace Markdig.Helpers
         /// Initializes a new instance of the <see cref="StringLineGroup"/> class.
         /// </summary>
         /// <param name="capacity"></param>
-        public StringLineGroup(int capacity, bool willRelease = false)
+        public StringLineGroup(int capacity)
+        {
+            if (capacity <= 0) ThrowHelper.ArgumentOutOfRangeException(nameof(capacity));
+            Lines = _pool.Rent(capacity);
+            Count = 0;
+        }
+        internal StringLineGroup(int capacity, bool willRelease)
         {
             if (capacity <= 0) ThrowHelper.ArgumentOutOfRangeException(nameof(capacity));
             Lines = _pool.Rent(willRelease ? Math.Max(8, capacity) : capacity);

--- a/src/Markdig/Helpers/StringSlice.cs
+++ b/src/Markdig/Helpers/StringSlice.cs
@@ -35,7 +35,7 @@ namespace Markdig.Helpers
         /// <param name="text">The text.</param>
         /// <param name="start">The start.</param>
         /// <param name="end">The end.</param>
-        /// <exception cref="System.ArgumentNullException"></exception>
+        /// <exception cref="ArgumentNullException"></exception>
         public StringSlice(string text, int start, int end)
         {
             if (text is null)

--- a/src/Markdig/Helpers/ThrowHelper.cs
+++ b/src/Markdig/Helpers/ThrowHelper.cs
@@ -1,3 +1,7 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license. 
+// See the license.txt file in the project root for more information.
+
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Markdig/Markdown.cs
+++ b/src/Markdig/Markdown.cs
@@ -47,7 +47,7 @@ namespace Markdig
         /// <returns>A normalized markdown text.</returns>
         public static MarkdownDocument Normalize(string markdown, TextWriter writer, NormalizeOptions options = null, MarkdownPipeline pipeline = null, MarkdownParserContext context = null)
         {
-            pipeline = pipeline ?? new MarkdownPipelineBuilder().Build();
+            pipeline ??= new MarkdownPipelineBuilder().Build();
             pipeline = CheckForSelfPipeline(pipeline, markdown);
 
             // We override the renderer with our own writer

--- a/src/Markdig/Markdown.cs
+++ b/src/Markdig/Markdown.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System;
 using System.IO;
 using System.Reflection;

--- a/src/Markdig/Markdown.cs
+++ b/src/Markdig/Markdown.cs
@@ -66,7 +66,7 @@ namespace Markdig
         /// <param name="markdown">A Markdown text.</param>
         /// <param name="pipeline">The pipeline used for the conversion.</param>
         /// <returns>The result of the conversion</returns>
-        /// <exception cref="System.ArgumentNullException">if markdown variable is null</exception>
+        /// <exception cref="ArgumentNullException">if markdown variable is null</exception>
         public static string ToHtml(string markdown, MarkdownPipeline pipeline = null)
         {
             if (markdown == null) ThrowHelper.ArgumentNullException_markdown();
@@ -92,7 +92,7 @@ namespace Markdig
         /// <param name="pipeline">The pipeline used for the conversion.</param>
         /// <param name="context">A parser context used for the parsing.</param>
         /// <returns>The Markdown document that has been parsed</returns>
-        /// <exception cref="System.ArgumentNullException">if reader or writer variable are null</exception>
+        /// <exception cref="ArgumentNullException">if reader or writer variable are null</exception>
         public static MarkdownDocument ToHtml(string markdown, TextWriter writer, MarkdownPipeline pipeline = null, MarkdownParserContext context = null)
         {
             if (markdown == null) ThrowHelper.ArgumentNullException_markdown();
@@ -118,7 +118,7 @@ namespace Markdig
         /// <param name="renderer">The renderer to convert Markdown to.</param>
         /// <param name="pipeline">The pipeline used for the conversion.</param>
         /// <param name="context">A parser context used for the parsing.</param>
-        /// <exception cref="System.ArgumentNullException">if markdown or writer variable are null</exception>
+        /// <exception cref="ArgumentNullException">if markdown or writer variable are null</exception>
         public static object Convert(string markdown, IMarkdownRenderer renderer, MarkdownPipeline pipeline = null, MarkdownParserContext context = null)
         {
             if (markdown == null) ThrowHelper.ArgumentNullException_markdown();
@@ -136,7 +136,7 @@ namespace Markdig
         /// </summary>
         /// <param name="markdown">The markdown text.</param>
         /// <returns>An AST Markdown document</returns>
-        /// <exception cref="System.ArgumentNullException">if markdown variable is null</exception>
+        /// <exception cref="ArgumentNullException">if markdown variable is null</exception>
         public static MarkdownDocument Parse(string markdown)
         {
             if (markdown == null) ThrowHelper.ArgumentNullException_markdown();
@@ -150,7 +150,7 @@ namespace Markdig
         /// <param name="pipeline">The pipeline used for the parsing.</param>
         /// <param name="context">A parser context used for the parsing.</param>
         /// <returns>An AST Markdown document</returns>
-        /// <exception cref="System.ArgumentNullException">if markdown variable is null</exception>
+        /// <exception cref="ArgumentNullException">if markdown variable is null</exception>
         public static MarkdownDocument Parse(string markdown, MarkdownPipeline pipeline, MarkdownParserContext context = null)
         {
             if (markdown == null) ThrowHelper.ArgumentNullException_markdown();
@@ -178,7 +178,7 @@ namespace Markdig
         /// <param name="pipeline">The pipeline used for the conversion.</param>
         /// <param name="context">A parser context used for the parsing.</param>
         /// <returns>The Markdown document that has been parsed</returns>
-        /// <exception cref="System.ArgumentNullException">if reader or writer variable are null</exception>
+        /// <exception cref="ArgumentNullException">if reader or writer variable are null</exception>
         public static MarkdownDocument ToPlainText(string markdown, TextWriter writer, MarkdownPipeline pipeline = null, MarkdownParserContext context = null)
         {
             if (markdown == null) ThrowHelper.ArgumentNullException_markdown();
@@ -209,7 +209,7 @@ namespace Markdig
         /// <param name="pipeline">The pipeline used for the conversion.</param>
         /// <param name="context">A parser context used for the parsing.</param>
         /// <returns>The result of the conversion</returns>
-        /// <exception cref="System.ArgumentNullException">if markdown variable is null</exception>
+        /// <exception cref="ArgumentNullException">if markdown variable is null</exception>
         public static string ToPlainText(string markdown, MarkdownPipeline pipeline = null, MarkdownParserContext context = null)
         {
             if (markdown == null) ThrowHelper.ArgumentNullException_markdown();

--- a/src/Markdig/MarkdownExtensions.cs
+++ b/src/Markdig/MarkdownExtensions.cs
@@ -99,6 +99,7 @@ namespace Markdig
         /// Uses this extension to enable autolinks from text `http://`, `https://`, `ftp://`, `mailto:`, `www.xxx.yyy`
         /// </summary>
         /// <param name="pipeline">The pipeline.</param>
+        /// <param name="options">The options.</param>
         /// <returns>The modified pipeline</returns>
         public static MarkdownPipelineBuilder UseAutoLinks(this MarkdownPipelineBuilder pipeline, AutoLinkOptions options = null)
         {

--- a/src/Markdig/MarkdownParserContext.cs
+++ b/src/Markdig/MarkdownParserContext.cs
@@ -1,3 +1,7 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license. 
+// See the license.txt file in the project root for more information.
+
 using System.Collections.Generic;
 
 namespace Markdig

--- a/src/Markdig/MarkdownPipeline.cs
+++ b/src/Markdig/MarkdownPipeline.cs
@@ -2,7 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 using System;
-using System.Collections.ObjectModel;
 using System.IO;
 using Markdig.Helpers;
 using Markdig.Parsers;

--- a/src/Markdig/MarkdownPipeline.cs
+++ b/src/Markdig/MarkdownPipeline.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System;
 using System.IO;
 using Markdig.Helpers;

--- a/src/Markdig/MarkdownPipelineBuilder.cs
+++ b/src/Markdig/MarkdownPipelineBuilder.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System;
 using System.IO;
 using Markdig.Helpers;

--- a/src/Markdig/MarkdownPipelineBuilder.cs
+++ b/src/Markdig/MarkdownPipelineBuilder.cs
@@ -77,7 +77,7 @@ namespace Markdig
         public TextWriter DebugLog { get; set; }
 
         /// <summary>
-        /// Occurs when a document has been processed after the <see cref="MarkdownParser.Parse"/> method.
+        /// Occurs when a document has been processed after the <see cref="MarkdownParser.Parse()"/> method.
         /// </summary>
         public event ProcessDocumentDelegate DocumentProcessed;
 

--- a/src/Markdig/MarkdownPipelineBuilder.cs
+++ b/src/Markdig/MarkdownPipelineBuilder.cs
@@ -86,7 +86,7 @@ namespace Markdig
         /// <summary>
         /// Builds a pipeline from this instance. Once the pipeline is build, it cannot be modified.
         /// </summary>
-        /// <exception cref="System.InvalidOperationException">An extension cannot be null</exception>
+        /// <exception cref="InvalidOperationException">An extension cannot be null</exception>
         public MarkdownPipeline Build()
         {
             if (pipeline != null)

--- a/src/Markdig/MarkdownPipelineBuilder.cs
+++ b/src/Markdig/MarkdownPipelineBuilder.cs
@@ -6,7 +6,6 @@ using System.IO;
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Parsers.Inlines;
-using Markdig.Renderers;
 
 namespace Markdig
 {

--- a/src/Markdig/Parsers/BlockParser.cs
+++ b/src/Markdig/Parsers/BlockParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax;
 
 namespace Markdig.Parsers

--- a/src/Markdig/Parsers/BlockParserList.cs
+++ b/src/Markdig/Parsers/BlockParserList.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
@@ -9,7 +9,7 @@ namespace Markdig.Parsers
     /// <summary>
     /// A List of <see cref="BlockParser"/>.
     /// </summary>
-    /// <seealso cref="Parsers.ParserList{Parsers.BlockParser, Parsers.BlockParserState}" />
+    /// <seealso cref="ParserList{BlockParser, BlockParserState}" />
     public class BlockParserList : ParserList<BlockParser, BlockProcessor>
     {
         /// <summary>

--- a/src/Markdig/Parsers/BlockParserList.cs
+++ b/src/Markdig/Parsers/BlockParserList.cs
@@ -9,7 +9,7 @@ namespace Markdig.Parsers
     /// <summary>
     /// A List of <see cref="BlockParser"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.ParserList{Markdig.Parsers.BlockParser, Markdig.Parsers.BlockParserState}" />
+    /// <seealso cref="Parsers.ParserList{Parsers.BlockParser, Parsers.BlockParserState}" />
     public class BlockParserList : ParserList<BlockParser, BlockProcessor>
     {
         /// <summary>

--- a/src/Markdig/Parsers/BlockProcessor.cs
+++ b/src/Markdig/Parsers/BlockProcessor.cs
@@ -558,8 +558,7 @@ namespace Markdig.Parsers
                     CurrentBlock = block;
                 }
 
-                var container = block as ContainerBlock;
-                if (container != null)
+                if (block is ContainerBlock container)
                 {
                     CurrentContainer = container;
                     LastBlock = CurrentContainer.LastChild;
@@ -630,8 +629,7 @@ namespace Markdig.Parsers
                 }
 
                 // If we have a leaf block
-                var leaf = block as LeafBlock;
-                if (leaf != null && NewBlocks.Count == 0)
+                if (block is LeafBlock leaf && NewBlocks.Count == 0)
                 {
                     ContinueProcessingLine = false;
                     if (!result.IsDiscard())
@@ -754,8 +752,7 @@ namespace Markdig.Parsers
                 // Special case for paragraph
                 UpdateLastBlockAndContainer();
 
-                var paragraph = CurrentBlock as ParagraphBlock;
-                if (isLazyParagraph && paragraph != null)
+                if (isLazyParagraph && CurrentBlock is ParagraphBlock paragraph)
                 {
                     Debug.Assert(NewBlocks.Count == 0);
 

--- a/src/Markdig/Parsers/BlockProcessor.cs
+++ b/src/Markdig/Parsers/BlockProcessor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Markdig/Parsers/BlockProcessor.cs
+++ b/src/Markdig/Parsers/BlockProcessor.cs
@@ -38,7 +38,7 @@ namespace Markdig.Parsers
         /// <param name="stringBuilders">The string builders cache.</param>
         /// <param name="document">The document to build blocks into.</param>
         /// <param name="parsers">The list of parsers.</param>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// </exception>
         public BlockProcessor(MarkdownDocument document, BlockParserList parsers, MarkdownParserContext context)
         {
@@ -388,8 +388,8 @@ namespace Markdig.Parsers
         /// Opens the specified block.
         /// </summary>
         /// <param name="block">The block.</param>
-        /// <exception cref="System.ArgumentNullException"></exception>
-        /// <exception cref="System.ArgumentException">The block must be opened</exception>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException">The block must be opened</exception>
         public void Open(Block block)
         {
             if (block == null) ThrowHelper.ArgumentNullException(nameof(block));
@@ -570,7 +570,7 @@ namespace Markdig.Parsers
         /// <summary>
         /// Tries to continue matching existing opened <see cref="Block"/>.
         /// </summary>
-        /// <exception cref="System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// A pending parser cannot add a new block when it is not the last pending block
         /// or
         /// The NewBlocks is not empty. This is happening if a LeafBlock is not the last to be pushed
@@ -792,7 +792,7 @@ namespace Markdig.Parsers
         /// </summary>
         /// <param name="result">The last result of matching.</param>
         /// <param name="allowClosing">if set to <c>true</c> the processing of a new block will close existing opened blocks].</param>
-        /// <exception cref="System.InvalidOperationException">The NewBlocks is not empty. This is happening if a LeafBlock is not the last to be pushed</exception>
+        /// <exception cref="InvalidOperationException">The NewBlocks is not empty. This is happening if a LeafBlock is not the last to be pushed</exception>
         private void ProcessNewBlocks(BlockState result, bool allowClosing)
         {
             var newBlocks = NewBlocks;

--- a/src/Markdig/Parsers/BlockProcessor.cs
+++ b/src/Markdig/Parsers/BlockProcessor.cs
@@ -36,9 +36,9 @@ namespace Markdig.Parsers
         /// <summary>
         /// Initializes a new instance of the <see cref="BlockProcessor" /> class.
         /// </summary>
-        /// <param name="stringBuilders">The string builders cache.</param>
         /// <param name="document">The document to build blocks into.</param>
         /// <param name="parsers">The list of parsers.</param>
+        /// <param name="context">A parser context used for the parsing.</param>
         /// <exception cref="ArgumentNullException">
         /// </exception>
         public BlockProcessor(MarkdownDocument document, BlockParserList parsers, MarkdownParserContext context)

--- a/src/Markdig/Parsers/BlockStateExtensions.cs
+++ b/src/Markdig/Parsers/BlockStateExtensions.cs
@@ -2,7 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 using System.Runtime.CompilerServices;
-using Markdig.Helpers;
 
 namespace Markdig.Parsers
 {

--- a/src/Markdig/Parsers/BlockStateExtensions.cs
+++ b/src/Markdig/Parsers/BlockStateExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System.Runtime.CompilerServices;
 
 namespace Markdig.Parsers

--- a/src/Markdig/Parsers/FencedBlockParserBase.cs
+++ b/src/Markdig/Parsers/FencedBlockParserBase.cs
@@ -47,7 +47,7 @@ namespace Markdig.Parsers
         {
             InfoParser = DefaultInfoParser;
             MinimumMatchCount = 3;
-            MaximumMatchCount = Int32.MaxValue;
+            MaximumMatchCount = int.MaxValue;
         }
 
         /// <summary>

--- a/src/Markdig/Parsers/FencedBlockParserBase.cs
+++ b/src/Markdig/Parsers/FencedBlockParserBase.cs
@@ -36,7 +36,7 @@ namespace Markdig.Parsers
     /// <summary>
     /// Base parser for fenced blocks (opened by 3 or more character delimiters on a first line, and closed by at least the same number of delimiters)
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.BlockParser" />
+    /// <seealso cref="BlockParser" />
     public abstract class FencedBlockParserBase<T> : FencedBlockParserBase where T : Block, IFencedBlock
     {
 

--- a/src/Markdig/Parsers/FencedBlockParserBase.cs
+++ b/src/Markdig/Parsers/FencedBlockParserBase.cs
@@ -65,6 +65,7 @@ namespace Markdig.Parsers
         /// <param name="state">The parser processor.</param>
         /// <param name="line">The line.</param>
         /// <param name="fenced">The fenced code block.</param>
+        /// <param name="openingCharacter">The opening character for this fenced code block.</param>
         /// <returns><c>true</c> if parsing of the line is successfull; <c>false</c> otherwise</returns>
         public static bool DefaultInfoParser(BlockProcessor state, ref StringSlice line, IFencedBlock fenced, char openingCharacter)
         {

--- a/src/Markdig/Parsers/FencedCodeBlockParser.cs
+++ b/src/Markdig/Parsers/FencedCodeBlockParser.cs
@@ -9,7 +9,7 @@ namespace Markdig.Parsers
     /// <summary>
     /// Parser for a <see cref="FencedCodeBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.BlockParser" />
+    /// <seealso cref="BlockParser" />
     public class FencedCodeBlockParser : FencedBlockParserBase<FencedCodeBlock>
     {
         public const string DefaultInfoPrefix = "language-";

--- a/src/Markdig/Parsers/FencedCodeBlockParser.cs
+++ b/src/Markdig/Parsers/FencedCodeBlockParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Parsers/HeadingBlockParser.cs
+++ b/src/Markdig/Parsers/HeadingBlockParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System.Diagnostics;
 using Markdig.Helpers;
 using Markdig.Syntax;

--- a/src/Markdig/Parsers/HeadingBlockParser.cs
+++ b/src/Markdig/Parsers/HeadingBlockParser.cs
@@ -84,10 +84,7 @@ namespace Markdig.Parsers
                 processor.GoToColumn(column + leadingCount + 1);
 
                 // Gives a chance to parse attributes
-                if (TryParseAttributes != null)
-                {
-                    TryParseAttributes(processor, ref processor.Line, headingBlock);
-                }
+                TryParseAttributes?.Invoke(processor, ref processor.Line, headingBlock);
 
                 // The optional closing sequence of #s must be preceded by a space and may be followed by spaces only.
                 int endState = 0;

--- a/src/Markdig/Parsers/HeadingBlockParser.cs
+++ b/src/Markdig/Parsers/HeadingBlockParser.cs
@@ -10,7 +10,7 @@ namespace Markdig.Parsers
     /// <summary>
     /// Block parser for a <see cref="HeadingBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.BlockParser" />
+    /// <seealso cref="BlockParser" />
     public class HeadingBlockParser : BlockParser, IAttributesParseable
     {
 

--- a/src/Markdig/Parsers/HtmlBlockParser.cs
+++ b/src/Markdig/Parsers/HtmlBlockParser.cs
@@ -10,7 +10,7 @@ namespace Markdig.Parsers
     /// <summary>
     /// Block parser for a <see cref="HtmlBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.BlockParser" />
+    /// <seealso cref="BlockParser" />
     public class HtmlBlockParser : BlockParser
     {
         /// <summary>

--- a/src/Markdig/Parsers/HtmlBlockParser.cs
+++ b/src/Markdig/Parsers/HtmlBlockParser.cs
@@ -136,7 +136,7 @@ namespace Markdig.Parsers
                 {
                     break;
                 }
-                tag[count] = Char.ToLowerInvariant(c);
+                tag[count] = char.ToLowerInvariant(c);
                 c = line.NextChar();
             }
 

--- a/src/Markdig/Parsers/HtmlBlockParser.cs
+++ b/src/Markdig/Parsers/HtmlBlockParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System;
 using Markdig.Helpers;
 using Markdig.Syntax;

--- a/src/Markdig/Parsers/IAttributesParseable.cs
+++ b/src/Markdig/Parsers/IAttributesParseable.cs
@@ -18,7 +18,7 @@ namespace Markdig.Parsers
         BlockProcessor processor, ref StringSlice slice, IBlock block);
 
     /// <summary>
-    /// An interface used to tag <see cref="BlockParser"/> that supports parsing <see cref="Markdig.Renderers.Html.HtmlAttributes"/>
+    /// An interface used to tag <see cref="BlockParser"/> that supports parsing <see cref="Renderers.Html.HtmlAttributes"/>
     /// </summary>
     public interface IAttributesParseable
     {

--- a/src/Markdig/Parsers/IBlockParser.cs
+++ b/src/Markdig/Parsers/IBlockParser.cs
@@ -9,7 +9,7 @@ namespace Markdig.Parsers
     /// Base interface for a <see cref="BlockParser"/>.
     /// </summary>
     /// <typeparam name="TProcessor"></typeparam>
-    /// <seealso cref="Markdig.Parsers.IMarkdownParser{T}" />
+    /// <seealso cref="IMarkdownParser{T}" />
     public interface IBlockParser<in TProcessor> : IMarkdownParser<TProcessor>
     {
         /// <summary>

--- a/src/Markdig/Parsers/IBlockParser.cs
+++ b/src/Markdig/Parsers/IBlockParser.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax;
 
 namespace Markdig.Parsers

--- a/src/Markdig/Parsers/IInlineParser.cs
+++ b/src/Markdig/Parsers/IInlineParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 
 namespace Markdig.Parsers

--- a/src/Markdig/Parsers/IMarkdownParser.cs
+++ b/src/Markdig/Parsers/IMarkdownParser.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 namespace Markdig.Parsers
 {
     /// <summary>

--- a/src/Markdig/Parsers/IPostInlineProcessor.cs
+++ b/src/Markdig/Parsers/IPostInlineProcessor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Parsers

--- a/src/Markdig/Parsers/IndentedCodeBlockParser.cs
+++ b/src/Markdig/Parsers/IndentedCodeBlockParser.cs
@@ -8,7 +8,7 @@ namespace Markdig.Parsers
     /// <summary>
     /// Block parser for an indented <see cref="CodeBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.BlockParser" />
+    /// <seealso cref="BlockParser" />
     public class IndentedCodeBlockParser : BlockParser
     {
         public override bool CanInterrupt(BlockProcessor processor, Block block)

--- a/src/Markdig/Parsers/IndentedCodeBlockParser.cs
+++ b/src/Markdig/Parsers/IndentedCodeBlockParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax;
 
 namespace Markdig.Parsers

--- a/src/Markdig/Parsers/InlineParserList.cs
+++ b/src/Markdig/Parsers/InlineParserList.cs
@@ -9,7 +9,7 @@ namespace Markdig.Parsers
     /// <summary>
     /// A list of <see cref="InlineParser"/>.
     /// </summary>
-    /// <seealso cref="Parsers.ParserList{Parsers.InlineParser, Parsers.InlineParserState}" />
+    /// <seealso cref="ParserList{InlineParser, InlineParserState}" />
     public class InlineParserList : ParserList<InlineParser, InlineProcessor>
     {
         public InlineParserList(IEnumerable<InlineParser> parsers) : base(parsers)

--- a/src/Markdig/Parsers/InlineParserList.cs
+++ b/src/Markdig/Parsers/InlineParserList.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System.Collections.Generic;
 
 namespace Markdig.Parsers

--- a/src/Markdig/Parsers/InlineParserList.cs
+++ b/src/Markdig/Parsers/InlineParserList.cs
@@ -8,7 +8,7 @@ namespace Markdig.Parsers
     /// <summary>
     /// A list of <see cref="InlineParser"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.ParserList{Markdig.Parsers.InlineParser, Markdig.Parsers.InlineParserState}" />
+    /// <seealso cref="Parsers.ParserList{Parsers.InlineParser, Parsers.InlineParserState}" />
     public class InlineParserList : ParserList<InlineParser, InlineProcessor>
     {
         public InlineParserList(IEnumerable<InlineParser> parsers) : base(parsers)

--- a/src/Markdig/Parsers/InlineParserList.cs
+++ b/src/Markdig/Parsers/InlineParserList.cs
@@ -18,8 +18,7 @@ namespace Markdig.Parsers
             var postInlineProcessors = new List<IPostInlineProcessor>();
             foreach (var parser in this)
             {
-                var delimProcessor = parser as IPostInlineProcessor;
-                if (delimProcessor != null)
+                if (parser is IPostInlineProcessor delimProcessor)
                 {
                     postInlineProcessors.Add(delimProcessor);
                 }

--- a/src/Markdig/Parsers/InlineProcessor.cs
+++ b/src/Markdig/Parsers/InlineProcessor.cs
@@ -34,7 +34,7 @@ namespace Markdig.Parsers
         /// <param name="document">The document.</param>
         /// <param name="parsers">The parsers.</param>
         /// <param name="inlineCreated">The inline created event.</param>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// </exception>
         public InlineProcessor(MarkdownDocument document, InlineParserList parsers, bool preciseSourcelocation, MarkdownParserContext context)
         {

--- a/src/Markdig/Parsers/InlineProcessor.cs
+++ b/src/Markdig/Parsers/InlineProcessor.cs
@@ -31,10 +31,10 @@ namespace Markdig.Parsers
         /// <summary>
         /// Initializes a new instance of the <see cref="InlineProcessor" /> class.
         /// </summary>
-        /// <param name="stringBuilders">The string builders.</param>
         /// <param name="document">The document.</param>
         /// <param name="parsers">The parsers.</param>
-        /// <param name="inlineCreated">The inline created event.</param>
+        /// <param name="preciseSourcelocation">A value indicating whether to provide precise source location.</param>
+        /// <param name="context">A parser context used for the parsing.</param>
         /// <exception cref="ArgumentNullException">
         /// </exception>
         public InlineProcessor(MarkdownDocument document, InlineParserList parsers, bool preciseSourcelocation, MarkdownParserContext context)
@@ -96,7 +96,7 @@ namespace Markdig.Parsers
         public int LineIndex { get; private set; }
 
         /// <summary>
-        /// Gets the parser states that can be used by <see cref="InlineParser"/> using their <see cref="InlineParser.Index"/> property.
+        /// Gets the parser states that can be used by <see cref="InlineParser"/> using their <see cref="ParserBase{Inline}.Index"/> property.
         /// </summary>
         public object[] ParserStates { get; }
 
@@ -134,6 +134,8 @@ namespace Markdig.Parsers
         /// Gets the source position for the specified offset within the current slice.
         /// </summary>
         /// <param name="sliceOffset">The slice offset.</param>
+        /// <param name="lineIndex">The line index.</param>
+        /// <param name="column">The column.</param>
         /// <returns>The source position</returns>
         public int GetSourcePosition(int sliceOffset, out int lineIndex, out int column)
         {

--- a/src/Markdig/Parsers/InlineProcessor.cs
+++ b/src/Markdig/Parsers/InlineProcessor.cs
@@ -113,9 +113,7 @@ namespace Markdig.Parsers
 
         public int GetSourcePosition(int sliceOffset)
         {
-            int column;
-            int lineIndex;
-            return GetSourcePosition(sliceOffset, out lineIndex, out column);
+            return GetSourcePosition(sliceOffset, out int lineIndex, out int column);
         }
 
         public SourceSpan GetSourcePositionFromLocalSpan(SourceSpan span)
@@ -125,9 +123,7 @@ namespace Markdig.Parsers
                 return SourceSpan.Empty;
             }
 
-            int column;
-            int lineIndex;
-            return new SourceSpan(GetSourcePosition(span.Start, out lineIndex, out column), GetSourcePosition(span.End, out lineIndex, out column));
+            return new SourceSpan(GetSourcePosition(span.Start, out int lineIndex, out int column), GetSourcePosition(span.End, out lineIndex, out column));
         }
 
         /// <summary>
@@ -313,8 +309,7 @@ namespace Markdig.Parsers
             var container = Block.Inline;
             while (true)
             {
-                var nextContainer = container.LastChild as ContainerInline;
-                if (nextContainer != null && !nextContainer.IsClosed)
+                if (container.LastChild is ContainerInline nextContainer && !nextContainer.IsClosed)
                 {
                     container = nextContainer;
                 }

--- a/src/Markdig/Parsers/InlineProcessor.cs
+++ b/src/Markdig/Parsers/InlineProcessor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Markdig/Parsers/Inlines/AutolineInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/AutolineInlineParser.cs
@@ -30,12 +30,10 @@ namespace Markdig.Parsers.Inlines
 
         public override bool Match(InlineProcessor processor, ref StringSlice slice)
         {
-            string link;
-            bool isEmail;
             var saved = slice;
             int line;
             int column;
-            if (LinkHelper.TryParseAutolink(ref slice, out link, out isEmail))
+            if (LinkHelper.TryParseAutolink(ref slice, out string link, out bool isEmail))
             {
                 processor.Inline = new AutolinkInline()
                 {
@@ -49,8 +47,7 @@ namespace Markdig.Parsers.Inlines
             else if (EnableHtmlParsing)
             {
                 slice = saved;
-                string htmlTag;
-                if (!HtmlHelper.TryParseHtmlTag(ref slice, out htmlTag))
+                if (!HtmlHelper.TryParseHtmlTag(ref slice, out string htmlTag))
                 {
                     return false;
                 }

--- a/src/Markdig/Parsers/Inlines/AutolineInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/AutolineInlineParser.cs
@@ -10,7 +10,7 @@ namespace Markdig.Parsers.Inlines
     /// <summary>
     /// An inline parser for parsing <see cref="AutolinkInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.InlineParser" />
+    /// <seealso cref="InlineParser" />
     public class AutolineInlineParser : InlineParser
     {
         /// <summary>

--- a/src/Markdig/Parsers/Inlines/AutolineInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/AutolineInlineParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;

--- a/src/Markdig/Parsers/Inlines/CodeInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/CodeInlineParser.cs
@@ -10,7 +10,7 @@ namespace Markdig.Parsers.Inlines
     /// <summary>
     /// An inline parser for a <see cref="CodeInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.InlineParser" />
+    /// <seealso cref="InlineParser" />
     public class CodeInlineParser : InlineParser
     {
         /// <summary>

--- a/src/Markdig/Parsers/Inlines/CodeInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/CodeInlineParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;

--- a/src/Markdig/Parsers/Inlines/EmphasisDescriptor.cs
+++ b/src/Markdig/Parsers/Inlines/EmphasisDescriptor.cs
@@ -3,7 +3,6 @@
 // See the license.txt file in the project root for more information.
 
 using Markdig.Helpers;
-using System;
 
 namespace Markdig.Parsers.Inlines
 {

--- a/src/Markdig/Parsers/Inlines/EscapeInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/EscapeInlineParser.cs
@@ -9,7 +9,7 @@ namespace Markdig.Parsers.Inlines
     /// <summary>
     /// An inline parser for escape characters.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.InlineParser" />
+    /// <seealso cref="InlineParser" />
     public class EscapeInlineParser : InlineParser
     {
         public EscapeInlineParser()

--- a/src/Markdig/Parsers/Inlines/EscapeInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/EscapeInlineParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 using Markdig.Syntax.Inlines;
 

--- a/src/Markdig/Parsers/Inlines/HtmlEntityParser.cs
+++ b/src/Markdig/Parsers/Inlines/HtmlEntityParser.cs
@@ -12,7 +12,7 @@ namespace Markdig.Parsers.Inlines
     /// <summary>
     /// An inline parser for HTML entities.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.InlineParser" />
+    /// <seealso cref="InlineParser" />
     public class HtmlEntityParser : InlineParser
     {
         /// <summary>

--- a/src/Markdig/Parsers/Inlines/HtmlEntityParser.cs
+++ b/src/Markdig/Parsers/Inlines/HtmlEntityParser.cs
@@ -46,9 +46,7 @@ namespace Markdig.Parsers.Inlines
 
         public override bool Match(InlineProcessor processor, ref StringSlice slice)
         {
-            int match;
-            string literal;
-            if (!TryParse(ref slice, out literal, out match))
+            if (!TryParse(ref slice, out string literal, out int match))
             {
                 return false;
             }
@@ -59,13 +57,11 @@ namespace Markdig.Parsers.Inlines
             {
                 var matched = slice;
                 matched.End = slice.Start + match - 1;
-                int line;
-                int column;
                 processor.Inline = new HtmlEntityInline()
                 {
                     Original = matched,
                     Transcoded = new StringSlice(literal),
-                    Span = new SourceSpan(processor.GetSourcePosition(startPosition, out line, out column), processor.GetSourcePosition(matched.End)),
+                    Span = new SourceSpan(processor.GetSourcePosition(startPosition, out int line, out int column), processor.GetSourcePosition(matched.End)),
                     Line = line,
                     Column = column
                 };

--- a/src/Markdig/Parsers/Inlines/LineBreakInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LineBreakInlineParser.cs
@@ -39,11 +39,9 @@ namespace Markdig.Parsers.Inlines
             var hasDoubleSpacesBefore = slice.PeekCharExtra(-1).IsSpace() && slice.PeekCharExtra(-2).IsSpace();
             slice.NextChar(); // Skip \n
 
-            int line;
-            int column;
             processor.Inline = new LineBreakInline
             {
-                Span = { Start = processor.GetSourcePosition(startPosition, out line, out column)},
+                Span = { Start = processor.GetSourcePosition(startPosition, out int line, out int column) },
                 IsHard = EnableSoftAsHard || (slice.Start != 0 && hasDoubleSpacesBefore),
                 Line = line,
                 Column = column

--- a/src/Markdig/Parsers/Inlines/LineBreakInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LineBreakInlineParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;

--- a/src/Markdig/Parsers/Inlines/LineBreakInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LineBreakInlineParser.cs
@@ -10,7 +10,7 @@ namespace Markdig.Parsers.Inlines
     /// <summary>
     /// An inline parser for <see cref="LineBreakInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.InlineParser" />
+    /// <seealso cref="InlineParser" />
     public class LineBreakInlineParser : InlineParser
     {
         /// <summary>

--- a/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;

--- a/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
@@ -10,7 +10,7 @@ namespace Markdig.Parsers.Inlines
     /// <summary>
     /// An inline parser for <see cref="LinkInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.InlineParser" />
+    /// <seealso cref="InlineParser" />
     public class LinkInlineParser : InlineParser
     {
         /// <summary>

--- a/src/Markdig/Parsers/Inlines/LiteralInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LiteralInlineParser.cs
@@ -34,9 +34,7 @@ namespace Markdig.Parsers.Inlines
         {
             var text = slice.Text;
 
-            int line;
-            int column;
-            var startPosition = processor.GetSourcePosition(slice.Start, out line, out column);
+            var startPosition = processor.GetSourcePosition(slice.Start, out int line, out int column);
 
             // Slightly faster to perform our own search for opening characters
             var nextStart = processor.Parsers.IndexOfOpeningCharacter(text, slice.Start + 1, slice.End);
@@ -66,9 +64,9 @@ namespace Markdig.Parsers.Inlines
             // The LiteralInlineParser is always matching (at least an empty string)
             var endPosition = slice.Start + length - 1;
 
-            var previousInline = processor.Inline as LiteralInline;
-            if (previousInline != null && ReferenceEquals(previousInline.Content.Text, slice.Text) &&
-                previousInline.Content.End + 1 == slice.Start)
+            if (processor.Inline is LiteralInline previousInline
+                && ReferenceEquals(previousInline.Content.Text, slice.Text)
+                && previousInline.Content.End + 1 == slice.Start)
             {
                 previousInline.Content.End = endPosition;
                 previousInline.Span.End = processor.GetSourcePosition(endPosition);

--- a/src/Markdig/Parsers/Inlines/LiteralInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LiteralInlineParser.cs
@@ -11,7 +11,7 @@ namespace Markdig.Parsers.Inlines
     /// <summary>
     /// An inline parser for parsing <see cref="LiteralInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.InlineParser" />
+    /// <seealso cref="InlineParser" />
     public sealed class LiteralInlineParser : InlineParser
     {
         public delegate void PostMatchDelegate(InlineProcessor processor, ref StringSlice slice);

--- a/src/Markdig/Parsers/ListBlockParser.cs
+++ b/src/Markdig/Parsers/ListBlockParser.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
-using System;
 using System.Collections.Generic;
 using Markdig.Helpers;
 using Markdig.Syntax;

--- a/src/Markdig/Parsers/ListBlockParser.cs
+++ b/src/Markdig/Parsers/ListBlockParser.cs
@@ -11,7 +11,7 @@ namespace Markdig.Parsers
     /// <summary>
     /// A parser for a list block and list item block.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.BlockParser" />
+    /// <seealso cref="BlockParser" />
     public class ListBlockParser : BlockParser
     {
         private CharacterMap<ListItemParser> mapItemParsers;

--- a/src/Markdig/Parsers/ListBlockParser.cs
+++ b/src/Markdig/Parsers/ListBlockParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
+
 using System.Collections.Generic;
 using Markdig.Helpers;
 using Markdig.Syntax;

--- a/src/Markdig/Parsers/MarkdownParser.cs
+++ b/src/Markdig/Parsers/MarkdownParser.cs
@@ -175,9 +175,8 @@ namespace Markdig.Parsers
                         }
                         leafBlock.OnProcessInlinesEnd(inlineProcessor);
                     }
-                    else if (block is ContainerBlock)
+                    else if (block is ContainerBlock newContainer)
                     {
-                        var newContainer = (ContainerBlock) block;
                         // If we need to remove it
                         if (newContainer.RemoveAfterProcessInlines)
                         {

--- a/src/Markdig/Parsers/MarkdownParser.cs
+++ b/src/Markdig/Parsers/MarkdownParser.cs
@@ -4,8 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Text;
 using Markdig.Helpers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Parsers/MarkdownParser.cs
+++ b/src/Markdig/Parsers/MarkdownParser.cs
@@ -38,7 +38,7 @@ namespace Markdig.Parsers
         /// <param name="text">The reader.</param>
         /// <param name="pipeline">The pipeline.</param>
         /// <param name="context">A parser context used for the parsing.</param>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// </exception>
         private MarkdownParser(string text, MarkdownPipeline pipeline, MarkdownParserContext context)
         {
@@ -72,7 +72,7 @@ namespace Markdig.Parsers
         /// <param name="pipeline">The pipeline used for the parsing.</param>
         /// <param name="context">A parser context used for the parsing.</param>
         /// <returns>An AST Markdown document</returns>
-        /// <exception cref="System.ArgumentNullException">if reader variable is null</exception>
+        /// <exception cref="ArgumentNullException">if reader variable is null</exception>
         public static MarkdownDocument Parse(string text, MarkdownPipeline pipeline = null, MarkdownParserContext context = null)
         {
             if (text == null) ThrowHelper.ArgumentNullException_text();

--- a/src/Markdig/Parsers/NumberedListItemParser.cs
+++ b/src/Markdig/Parsers/NumberedListItemParser.cs
@@ -8,7 +8,7 @@ namespace Markdig.Parsers
     /// <summary>
     /// The default parser for parsing numbered list item (e.g: 1) or 1.)
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.OrderedListItemParser" />
+    /// <seealso cref="OrderedListItemParser" />
     public class NumberedListItemParser : OrderedListItemParser
     {
         /// <summary>

--- a/src/Markdig/Parsers/NumberedListItemParser.cs
+++ b/src/Markdig/Parsers/NumberedListItemParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 
 namespace Markdig.Parsers

--- a/src/Markdig/Parsers/NumberedListItemParser.cs
+++ b/src/Markdig/Parsers/NumberedListItemParser.cs
@@ -49,8 +49,7 @@ namespace Markdig.Parsers
             }
 
             // Note that ordered list start numbers must be nine digits or less:
-            char orderedDelimiter;
-            if (countDigit > 9 || !TryParseDelimiter(state, out orderedDelimiter))
+            if (countDigit > 9 || !TryParseDelimiter(state, out char orderedDelimiter))
             {
                 return false;
             }

--- a/src/Markdig/Parsers/OrderedListItemParser.cs
+++ b/src/Markdig/Parsers/OrderedListItemParser.cs
@@ -7,7 +7,7 @@ namespace Markdig.Parsers
     /// <summary>
     /// Base class for an ordered list item parser.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.ListItemParser" />
+    /// <seealso cref="ListItemParser" />
     public abstract class OrderedListItemParser : ListItemParser
     {
         /// <summary>

--- a/src/Markdig/Parsers/ParagraphBlockParser.cs
+++ b/src/Markdig/Parsers/ParagraphBlockParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Parsers/ParserBase.cs
+++ b/src/Markdig/Parsers/ParserBase.cs
@@ -8,7 +8,7 @@ namespace Markdig.Parsers
     /// Base class for a <see cref="BlockParser"/> or <see cref="InlineParser"/>.
     /// </summary>
     /// <typeparam name="TProcessor">Type of the parser processor</typeparam>
-    /// <seealso cref="Markdig.Parsers.IMarkdownParser{TParserState}" />
+    /// <seealso cref="IMarkdownParser{TParserState}" />
     public abstract class ParserBase<TProcessor> : IMarkdownParser<TProcessor>
     {
         /// <summary>

--- a/src/Markdig/Parsers/ParserList.cs
+++ b/src/Markdig/Parsers/ParserList.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/src/Markdig/Parsers/ParserList.cs
+++ b/src/Markdig/Parsers/ParserList.cs
@@ -13,7 +13,7 @@ namespace Markdig.Parsers
     /// </summary>
     /// <typeparam name="T">Type of the parser</typeparam>
     /// <typeparam name="TState">The type of the parser state.</typeparam>
-    /// <seealso cref="Markdig.Helpers.OrderedList{T}" />
+    /// <seealso cref="OrderedList{T}" />
     public abstract class ParserList<T, TState> : OrderedList<T> where T : ParserBase<TState>
     {
         private readonly CharacterMap<T[]> charMap;
@@ -122,7 +122,7 @@ namespace Markdig.Parsers
         /// <summary>
         /// Initializes this instance with specified parser state.
         /// </summary>
-        /// <exception cref="System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// Unexpected null parser found
         /// or
         /// </exception>

--- a/src/Markdig/Parsers/ParserList.cs
+++ b/src/Markdig/Parsers/ParserList.cs
@@ -64,8 +64,7 @@ namespace Markdig.Parsers
                 {
                     foreach (var openingChar in parser.OpeningCharacters)
                     {
-                        T[] parsers;
-                        if (!tempCharMap.TryGetValue(openingChar, out parsers))
+                        if (!tempCharMap.TryGetValue(openingChar, out T[] parsers))
                         {
                             parsers = new T[charCounter[openingChar]];
                             tempCharMap[openingChar] = parsers;
@@ -118,17 +117,6 @@ namespace Markdig.Parsers
         public int IndexOfOpeningCharacter(string text, int start, int end)
         {
             return charMap.IndexOfOpeningCharacter(text, start, end);
-        }
-
-        /// <summary>
-        /// Initializes this instance with specified parser state.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// Unexpected null parser found
-        /// or
-        /// </exception>
-        private void Initialize()
-        {
         }
     }
 }

--- a/src/Markdig/Parsers/QuoteBlockParser.cs
+++ b/src/Markdig/Parsers/QuoteBlockParser.cs
@@ -9,7 +9,7 @@ namespace Markdig.Parsers
     /// <summary>
     /// A block parser for a <see cref="QuoteBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.BlockParser" />
+    /// <seealso cref="BlockParser" />
     public class QuoteBlockParser : BlockParser
     {
         /// <summary>

--- a/src/Markdig/Parsers/QuoteBlockParser.cs
+++ b/src/Markdig/Parsers/QuoteBlockParser.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Parsers/ThematicBreakParser.cs
+++ b/src/Markdig/Parsers/ThematicBreakParser.cs
@@ -9,7 +9,7 @@ namespace Markdig.Parsers
     /// <summary>
     /// A block parser for a <see cref="ThematicBreakBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.BlockParser" />
+    /// <seealso cref="BlockParser" />
     public class ThematicBreakParser : BlockParser
     {
         /// <summary>

--- a/src/Markdig/Parsers/ThematicBreakParser.cs
+++ b/src/Markdig/Parsers/ThematicBreakParser.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Parsers/UnorderedListItemParser.cs
+++ b/src/Markdig/Parsers/UnorderedListItemParser.cs
@@ -6,7 +6,7 @@ namespace Markdig.Parsers
     /// <summary>
     /// The default parser used to parse unordered list item (-, +, *)
     /// </summary>
-    /// <seealso cref="Markdig.Parsers.ListItemParser" />
+    /// <seealso cref="ListItemParser" />
     public class UnorderedListItemParser : ListItemParser
     {
         /// <summary>

--- a/src/Markdig/Parsers/UnorderedListItemParser.cs
+++ b/src/Markdig/Parsers/UnorderedListItemParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 namespace Markdig.Parsers
 {
     /// <summary>

--- a/src/Markdig/Renderers/Html/CodeBlockRenderer.cs
+++ b/src/Markdig/Renderers/Html/CodeBlockRenderer.cs
@@ -12,7 +12,7 @@ namespace Markdig.Renderers.Html
     /// <summary>
     /// An HTML renderer for a <see cref="CodeBlock"/> and <see cref="FencedCodeBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Syntax.CodeBlock}" />
+    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.CodeBlock}" />
     public class CodeBlockRenderer : HtmlObjectRenderer<CodeBlock>
     {
         /// <summary>

--- a/src/Markdig/Renderers/Html/CodeBlockRenderer.cs
+++ b/src/Markdig/Renderers/Html/CodeBlockRenderer.cs
@@ -12,7 +12,7 @@ namespace Markdig.Renderers.Html
     /// <summary>
     /// An HTML renderer for a <see cref="CodeBlock"/> and <see cref="FencedCodeBlock"/>.
     /// </summary>
-    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.CodeBlock}" />
+    /// <seealso cref="HtmlObjectRenderer{CodeBlock}" />
     public class CodeBlockRenderer : HtmlObjectRenderer<CodeBlock>
     {
         /// <summary>

--- a/src/Markdig/Renderers/Html/HeadingRenderer.cs
+++ b/src/Markdig/Renderers/Html/HeadingRenderer.cs
@@ -10,7 +10,7 @@ namespace Markdig.Renderers.Html
     /// <summary>
     /// An HTML renderer for a <see cref="HeadingBlock"/>.
     /// </summary>
-    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.HeadingBlock}" />
+    /// <seealso cref="HtmlObjectRenderer{HeadingBlock}" />
     public class HeadingRenderer : HtmlObjectRenderer<HeadingBlock>
     {
         private static readonly string[] HeadingTexts = {

--- a/src/Markdig/Renderers/Html/HeadingRenderer.cs
+++ b/src/Markdig/Renderers/Html/HeadingRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System.Globalization;
 using Markdig.Syntax;
 

--- a/src/Markdig/Renderers/Html/HeadingRenderer.cs
+++ b/src/Markdig/Renderers/Html/HeadingRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Html
     /// <summary>
     /// An HTML renderer for a <see cref="HeadingBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Syntax.HeadingBlock}" />
+    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.HeadingBlock}" />
     public class HeadingRenderer : HtmlObjectRenderer<HeadingBlock>
     {
         private static readonly string[] HeadingTexts = {

--- a/src/Markdig/Renderers/Html/HtmlAttributes.cs
+++ b/src/Markdig/Renderers/Html/HtmlAttributes.cs
@@ -102,7 +102,7 @@ namespace Markdig.Renderers.Html
         /// <param name="htmlAttributes">The HTML attributes.</param>
         /// <param name="mergeIdAndProperties">If set to <c>true</c> it will merge properties to the target htmlAttributes. Default is <c>false</c></param>
         /// <param name="shared">If set to <c>true</c> it will try to share Classes and Properties if destination don't have them, otherwise it will make a copy. Default is <c>true</c></param>
-        /// <exception cref="System.ArgumentNullException"></exception>
+        /// <exception cref="ArgumentNullException"></exception>
         public void CopyTo(HtmlAttributes htmlAttributes, bool mergeIdAndProperties = false, bool shared = true)
         {
             if (htmlAttributes == null) ThrowHelper.ArgumentNullException(nameof(htmlAttributes));

--- a/src/Markdig/Renderers/Html/HtmlAttributes.cs
+++ b/src/Markdig/Renderers/Html/HtmlAttributes.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/Markdig/Renderers/Html/HtmlBlockRenderer.cs
+++ b/src/Markdig/Renderers/Html/HtmlBlockRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Html
     /// <summary>
     /// A HTML renderer for a <see cref="HtmlBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Syntax.HtmlBlock}" />
+    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.HtmlBlock}" />
     public class HtmlBlockRenderer : HtmlObjectRenderer<HtmlBlock>
     {
         protected override void Write(HtmlRenderer renderer, HtmlBlock obj)

--- a/src/Markdig/Renderers/Html/HtmlBlockRenderer.cs
+++ b/src/Markdig/Renderers/Html/HtmlBlockRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax;
 
 namespace Markdig.Renderers.Html

--- a/src/Markdig/Renderers/Html/HtmlBlockRenderer.cs
+++ b/src/Markdig/Renderers/Html/HtmlBlockRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Html
     /// <summary>
     /// A HTML renderer for a <see cref="HtmlBlock"/>.
     /// </summary>
-    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.HtmlBlock}" />
+    /// <seealso cref="HtmlObjectRenderer{HtmlBlock}" />
     public class HtmlBlockRenderer : HtmlObjectRenderer<HtmlBlock>
     {
         protected override void Write(HtmlRenderer renderer, HtmlBlock obj)

--- a/src/Markdig/Renderers/Html/HtmlObjectRenderer.cs
+++ b/src/Markdig/Renderers/Html/HtmlObjectRenderer.cs
@@ -6,10 +6,10 @@ using Markdig.Syntax;
 namespace Markdig.Renderers.Html
 {
     /// <summary>
-    /// A base class for HTML rendering <see cref="Block"/> and <see cref="Markdig.Syntax.Inlines.Inline"/> Markdown objects.
+    /// A base class for HTML rendering <see cref="Block"/> and <see cref="Syntax.Inlines.Inline"/> Markdown objects.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
-    /// <seealso cref="Markdig.Renderers.IMarkdownObjectRenderer" />
+    /// <seealso cref="IMarkdownObjectRenderer" />
     public abstract class HtmlObjectRenderer<TObject> : MarkdownObjectRenderer<HtmlRenderer, TObject> where TObject : MarkdownObject
     {
     }

--- a/src/Markdig/Renderers/Html/HtmlObjectRenderer.cs
+++ b/src/Markdig/Renderers/Html/HtmlObjectRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax;
 
 namespace Markdig.Renderers.Html

--- a/src/Markdig/Renderers/Html/Inlines/AutolinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/AutolinkInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Html.Inlines

--- a/src/Markdig/Renderers/Html/Inlines/AutolinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/AutolinkInlineRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Html.Inlines
     /// <summary>
     /// A HTML renderer for an <see cref="AutolinkInline"/>.
     /// </summary>
-    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.Inlines.AutolinkInline}" />
+    /// <seealso cref="HtmlObjectRenderer{AutolinkInline}" />
     public class AutolinkInlineRenderer : HtmlObjectRenderer<AutolinkInline>
     {
         /// <summary>

--- a/src/Markdig/Renderers/Html/Inlines/AutolinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/AutolinkInlineRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Html.Inlines
     /// <summary>
     /// A HTML renderer for an <see cref="AutolinkInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Syntax.Inlines.AutolinkInline}" />
+    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.Inlines.AutolinkInline}" />
     public class AutolinkInlineRenderer : HtmlObjectRenderer<AutolinkInline>
     {
         /// <summary>

--- a/src/Markdig/Renderers/Html/Inlines/CodeInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/CodeInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Html.Inlines

--- a/src/Markdig/Renderers/Html/Inlines/CodeInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/CodeInlineRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Html.Inlines
     /// <summary>
     /// A HTML renderer for a <see cref="CodeInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Syntax.Inlines.CodeInline}" />
+    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.Inlines.CodeInline}" />
     public class CodeInlineRenderer : HtmlObjectRenderer<CodeInline>
     {
         protected override void Write(HtmlRenderer renderer, CodeInline obj)

--- a/src/Markdig/Renderers/Html/Inlines/CodeInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/CodeInlineRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Html.Inlines
     /// <summary>
     /// A HTML renderer for a <see cref="CodeInline"/>.
     /// </summary>
-    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.Inlines.CodeInline}" />
+    /// <seealso cref="HtmlObjectRenderer{CodeInline}" />
     public class CodeInlineRenderer : HtmlObjectRenderer<CodeInline>
     {
         protected override void Write(HtmlRenderer renderer, CodeInline obj)

--- a/src/Markdig/Renderers/Html/Inlines/DelimiterInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/DelimiterInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Html.Inlines

--- a/src/Markdig/Renderers/Html/Inlines/DelimiterInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/DelimiterInlineRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Html.Inlines
     /// <summary>
     /// A HTML renderer for a <see cref="DelimiterInline"/>.
     /// </summary>
-    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.Inlines.DelimiterInline}" />
+    /// <seealso cref="HtmlObjectRenderer{DelimiterInline}" />
     public class DelimiterInlineRenderer : HtmlObjectRenderer<DelimiterInline>
     {
         protected override void Write(HtmlRenderer renderer, DelimiterInline obj)

--- a/src/Markdig/Renderers/Html/Inlines/DelimiterInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/DelimiterInlineRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Html.Inlines
     /// <summary>
     /// A HTML renderer for a <see cref="DelimiterInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Syntax.Inlines.DelimiterInline}" />
+    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.Inlines.DelimiterInline}" />
     public class DelimiterInlineRenderer : HtmlObjectRenderer<DelimiterInline>
     {
         protected override void Write(HtmlRenderer renderer, DelimiterInline obj)

--- a/src/Markdig/Renderers/Html/Inlines/EmphasisInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/EmphasisInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 using System.Diagnostics;
 

--- a/src/Markdig/Renderers/Html/Inlines/EmphasisInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/EmphasisInlineRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Html.Inlines
     /// <summary>
     /// A HTML renderer for an <see cref="EmphasisInline"/>.
     /// </summary>
-    /// <seealso cref="Html.HtmlObjectRenderer{EmphasisInline}" />
+    /// <seealso cref="HtmlObjectRenderer{EmphasisInline}" />
     public class EmphasisInlineRenderer : HtmlObjectRenderer<EmphasisInline>
     {
         /// <summary>

--- a/src/Markdig/Renderers/Html/Inlines/HtmlEntityInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/HtmlEntityInlineRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Html.Inlines
     /// <summary>
     /// A HTML renderer for a <see cref="HtmlEntityInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Syntax.Inlines.HtmlEntityInline}" />
+    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.Inlines.HtmlEntityInline}" />
     public class HtmlEntityInlineRenderer : HtmlObjectRenderer<HtmlEntityInline>
     {
         protected override void Write(HtmlRenderer renderer, HtmlEntityInline obj)

--- a/src/Markdig/Renderers/Html/Inlines/HtmlEntityInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/HtmlEntityInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Html.Inlines

--- a/src/Markdig/Renderers/Html/Inlines/HtmlEntityInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/HtmlEntityInlineRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Html.Inlines
     /// <summary>
     /// A HTML renderer for a <see cref="HtmlEntityInline"/>.
     /// </summary>
-    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.Inlines.HtmlEntityInline}" />
+    /// <seealso cref="HtmlObjectRenderer{HtmlEntityInline}" />
     public class HtmlEntityInlineRenderer : HtmlObjectRenderer<HtmlEntityInline>
     {
         protected override void Write(HtmlRenderer renderer, HtmlEntityInline obj)

--- a/src/Markdig/Renderers/Html/Inlines/HtmlInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/HtmlInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Html.Inlines

--- a/src/Markdig/Renderers/Html/Inlines/HtmlInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/HtmlInlineRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Html.Inlines
     /// <summary>
     /// A HTML renderer for a <see cref="HtmlInline"/>.
     /// </summary>
-    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.Inlines.HtmlInline}" />
+    /// <seealso cref="HtmlObjectRenderer{HtmlInline}" />
     public class HtmlInlineRenderer : HtmlObjectRenderer<HtmlInline>
     {
         protected override void Write(HtmlRenderer renderer, HtmlInline obj)

--- a/src/Markdig/Renderers/Html/Inlines/HtmlInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/HtmlInlineRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Html.Inlines
     /// <summary>
     /// A HTML renderer for a <see cref="HtmlInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Syntax.Inlines.HtmlInline}" />
+    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.Inlines.HtmlInline}" />
     public class HtmlInlineRenderer : HtmlObjectRenderer<HtmlInline>
     {
         protected override void Write(HtmlRenderer renderer, HtmlInline obj)

--- a/src/Markdig/Renderers/Html/Inlines/LineBreakInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LineBreakInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Html.Inlines

--- a/src/Markdig/Renderers/Html/Inlines/LineBreakInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LineBreakInlineRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Html.Inlines
     /// <summary>
     /// A HTML renderer for a <see cref="LineBreakInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Syntax.Inlines.LineBreakInline}" />
+    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.Inlines.LineBreakInline}" />
     public class LineBreakInlineRenderer : HtmlObjectRenderer<LineBreakInline>
     {
         /// <summary>

--- a/src/Markdig/Renderers/Html/Inlines/LineBreakInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LineBreakInlineRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Html.Inlines
     /// <summary>
     /// A HTML renderer for a <see cref="LineBreakInline"/>.
     /// </summary>
-    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.Inlines.LineBreakInline}" />
+    /// <seealso cref="HtmlObjectRenderer{LineBreakInline}" />
     public class LineBreakInlineRenderer : HtmlObjectRenderer<LineBreakInline>
     {
         /// <summary>

--- a/src/Markdig/Renderers/Html/Inlines/LinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LinkInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Html.Inlines

--- a/src/Markdig/Renderers/Html/Inlines/LinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LinkInlineRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Html.Inlines
     /// <summary>
     /// A HTML renderer for a <see cref="LinkInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Syntax.Inlines.LinkInline}" />
+    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.Inlines.LinkInline}" />
     public class LinkInlineRenderer : HtmlObjectRenderer<LinkInline>
     {
         /// <summary>

--- a/src/Markdig/Renderers/Html/Inlines/LinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LinkInlineRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Html.Inlines
     /// <summary>
     /// A HTML renderer for a <see cref="LinkInline"/>.
     /// </summary>
-    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.Inlines.LinkInline}" />
+    /// <seealso cref="HtmlObjectRenderer{LinkInline}" />
     public class LinkInlineRenderer : HtmlObjectRenderer<LinkInline>
     {
         /// <summary>

--- a/src/Markdig/Renderers/Html/Inlines/LiteralInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LiteralInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Html.Inlines

--- a/src/Markdig/Renderers/Html/Inlines/LiteralInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LiteralInlineRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Html.Inlines
     /// <summary>
     /// A HTML renderer for a <see cref="LiteralInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Syntax.Inlines.LiteralInline}" />
+    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.Inlines.LiteralInline}" />
     public class LiteralInlineRenderer : HtmlObjectRenderer<LiteralInline>
     {
         protected override void Write(HtmlRenderer renderer, LiteralInline obj)

--- a/src/Markdig/Renderers/Html/Inlines/LiteralInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LiteralInlineRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Html.Inlines
     /// <summary>
     /// A HTML renderer for a <see cref="LiteralInline"/>.
     /// </summary>
-    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.Inlines.LiteralInline}" />
+    /// <seealso cref="HtmlObjectRenderer{LiteralInline}" />
     public class LiteralInlineRenderer : HtmlObjectRenderer<LiteralInline>
     {
         protected override void Write(HtmlRenderer renderer, LiteralInline obj)

--- a/src/Markdig/Renderers/Html/ListRenderer.cs
+++ b/src/Markdig/Renderers/Html/ListRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax;
 
 namespace Markdig.Renderers.Html

--- a/src/Markdig/Renderers/Html/ListRenderer.cs
+++ b/src/Markdig/Renderers/Html/ListRenderer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
-using System.Globalization;
 using Markdig.Syntax;
 
 namespace Markdig.Renderers.Html

--- a/src/Markdig/Renderers/Html/ListRenderer.cs
+++ b/src/Markdig/Renderers/Html/ListRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Html
     /// <summary>
     /// A HTML renderer for a <see cref="ListBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Syntax.ListBlock}" />
+    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.ListBlock}" />
     public class ListRenderer : HtmlObjectRenderer<ListBlock>
     {
         protected override void Write(HtmlRenderer renderer, ListBlock listBlock)

--- a/src/Markdig/Renderers/Html/ListRenderer.cs
+++ b/src/Markdig/Renderers/Html/ListRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Html
     /// <summary>
     /// A HTML renderer for a <see cref="ListBlock"/>.
     /// </summary>
-    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.ListBlock}" />
+    /// <seealso cref="HtmlObjectRenderer{ListBlock}" />
     public class ListRenderer : HtmlObjectRenderer<ListBlock>
     {
         protected override void Write(HtmlRenderer renderer, ListBlock listBlock)

--- a/src/Markdig/Renderers/Html/ParagraphRenderer.cs
+++ b/src/Markdig/Renderers/Html/ParagraphRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax;
 
 namespace Markdig.Renderers.Html

--- a/src/Markdig/Renderers/Html/ParagraphRenderer.cs
+++ b/src/Markdig/Renderers/Html/ParagraphRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Html
     /// <summary>
     /// A HTML renderer for a <see cref="ParagraphBlock"/>.
     /// </summary>
-    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.ParagraphBlock}" />
+    /// <seealso cref="HtmlObjectRenderer{ParagraphBlock}" />
     public class ParagraphRenderer : HtmlObjectRenderer<ParagraphBlock>
     {
         protected override void Write(HtmlRenderer renderer, ParagraphBlock obj)

--- a/src/Markdig/Renderers/Html/ParagraphRenderer.cs
+++ b/src/Markdig/Renderers/Html/ParagraphRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Html
     /// <summary>
     /// A HTML renderer for a <see cref="ParagraphBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Syntax.ParagraphBlock}" />
+    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.ParagraphBlock}" />
     public class ParagraphRenderer : HtmlObjectRenderer<ParagraphBlock>
     {
         protected override void Write(HtmlRenderer renderer, ParagraphBlock obj)

--- a/src/Markdig/Renderers/Html/QuoteBlockRenderer.cs
+++ b/src/Markdig/Renderers/Html/QuoteBlockRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Html
     /// <summary>
     /// A HTML renderer for a <see cref="QuoteBlock"/>.
     /// </summary>
-    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.QuoteBlock}" />
+    /// <seealso cref="HtmlObjectRenderer{QuoteBlock}" />
     public class QuoteBlockRenderer : HtmlObjectRenderer<QuoteBlock>
     {
         protected override void Write(HtmlRenderer renderer, QuoteBlock obj)

--- a/src/Markdig/Renderers/Html/QuoteBlockRenderer.cs
+++ b/src/Markdig/Renderers/Html/QuoteBlockRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax;
 
 namespace Markdig.Renderers.Html

--- a/src/Markdig/Renderers/Html/QuoteBlockRenderer.cs
+++ b/src/Markdig/Renderers/Html/QuoteBlockRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Html
     /// <summary>
     /// A HTML renderer for a <see cref="QuoteBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Syntax.QuoteBlock}" />
+    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.QuoteBlock}" />
     public class QuoteBlockRenderer : HtmlObjectRenderer<QuoteBlock>
     {
         protected override void Write(HtmlRenderer renderer, QuoteBlock obj)

--- a/src/Markdig/Renderers/Html/ThematicBreakRenderer.cs
+++ b/src/Markdig/Renderers/Html/ThematicBreakRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax;
 
 namespace Markdig.Renderers.Html

--- a/src/Markdig/Renderers/Html/ThematicBreakRenderer.cs
+++ b/src/Markdig/Renderers/Html/ThematicBreakRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Html
     /// <summary>
     /// A HTML renderer for a <see cref="ThematicBreakBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Html.HtmlObjectRenderer{Markdig.Syntax.ThematicBreakBlock}" />
+    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.ThematicBreakBlock}" />
     public class ThematicBreakRenderer : HtmlObjectRenderer<ThematicBreakBlock>
     {
         protected override void Write(HtmlRenderer renderer, ThematicBreakBlock obj)

--- a/src/Markdig/Renderers/Html/ThematicBreakRenderer.cs
+++ b/src/Markdig/Renderers/Html/ThematicBreakRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Html
     /// <summary>
     /// A HTML renderer for a <see cref="ThematicBreakBlock"/>.
     /// </summary>
-    /// <seealso cref="Html.HtmlObjectRenderer{Syntax.ThematicBreakBlock}" />
+    /// <seealso cref="HtmlObjectRenderer{ThematicBreakBlock}" />
     public class ThematicBreakRenderer : HtmlObjectRenderer<ThematicBreakBlock>
     {
         protected override void Write(HtmlRenderer renderer, ThematicBreakBlock obj)

--- a/src/Markdig/Renderers/HtmlRenderer.cs
+++ b/src/Markdig/Renderers/HtmlRenderer.cs
@@ -17,7 +17,7 @@ namespace Markdig.Renderers
     /// <summary>
     /// Default HTML renderer for a Markdown <see cref="MarkdownDocument"/> object.
     /// </summary>
-    /// <seealso cref="Renderers.TextRendererBase{Renderers.HtmlRenderer}" />
+    /// <seealso cref="TextRendererBase{HtmlRenderer}" />
     public class HtmlRenderer : TextRendererBase<HtmlRenderer>
     {
         /// <summary>

--- a/src/Markdig/Renderers/HtmlRenderer.cs
+++ b/src/Markdig/Renderers/HtmlRenderer.cs
@@ -17,7 +17,7 @@ namespace Markdig.Renderers
     /// <summary>
     /// Default HTML renderer for a Markdown <see cref="MarkdownDocument"/> object.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.TextRendererBase{Markdig.Renderers.HtmlRenderer}" />
+    /// <seealso cref="Renderers.TextRendererBase{Renderers.HtmlRenderer}" />
     public class HtmlRenderer : TextRendererBase<HtmlRenderer>
     {
         /// <summary>

--- a/src/Markdig/Renderers/IMarkdownObjectRenderer.cs
+++ b/src/Markdig/Renderers/IMarkdownObjectRenderer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
@@ -20,7 +20,7 @@ namespace Markdig.Renderers
         bool Accept(RendererBase renderer, MarkdownObject obj);
 
         /// <summary>
-        /// Writes the specified <see cref="MarkdownObject"/> to the <see cref="renderer"/>.
+        /// Writes the specified <see cref="MarkdownObject"/> to the <paramref name="renderer"/>.
         /// </summary>
         /// <param name="renderer">The renderer.</param>
         /// <param name="objectToRender">The object to render.</param>

--- a/src/Markdig/Renderers/MarkdownObjectRenderer.cs
+++ b/src/Markdig/Renderers/MarkdownObjectRenderer.cs
@@ -7,11 +7,11 @@ using Markdig.Syntax;
 namespace Markdig.Renderers
 {
     /// <summary>
-    /// A base class for rendering <see cref="Block" /> and <see cref="Markdig.Syntax.Inlines.Inline" /> Markdown objects.
+    /// A base class for rendering <see cref="Block" /> and <see cref="Syntax.Inlines.Inline" /> Markdown objects.
     /// </summary>
     /// <typeparam name="TRenderer">The type of the renderer.</typeparam>
     /// <typeparam name="TObject">The type of the object.</typeparam>
-    /// <seealso cref="Markdig.Renderers.IMarkdownObjectRenderer" />
+    /// <seealso cref="IMarkdownObjectRenderer" />
     public abstract class MarkdownObjectRenderer<TRenderer, TObject> : IMarkdownObjectRenderer where TRenderer : RendererBase where TObject : MarkdownObject
     {
         protected MarkdownObjectRenderer()

--- a/src/Markdig/Renderers/MarkdownObjectRenderer.cs
+++ b/src/Markdig/Renderers/MarkdownObjectRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Renderers/Normalize/CodeBlockRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/CodeBlockRenderer.cs
@@ -16,8 +16,7 @@ namespace Markdig.Renderers.Normalize
 
         protected override void Write(NormalizeRenderer renderer, CodeBlock obj)
         {
-            var fencedCodeBlock = obj as FencedCodeBlock;
-            if (fencedCodeBlock != null)
+            if (obj is FencedCodeBlock fencedCodeBlock)
             {
                 var opening = new string(fencedCodeBlock.FencedChar, fencedCodeBlock.FencedCharCount);
                 renderer.Write(opening);

--- a/src/Markdig/Renderers/Normalize/CodeBlockRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/CodeBlockRenderer.cs
@@ -2,7 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-using Markdig.Renderers.Html;
 using Markdig.Syntax;
 
 namespace Markdig.Renderers.Normalize

--- a/src/Markdig/Renderers/Normalize/CodeBlockRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/CodeBlockRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Normalize
     /// <summary>
     /// An Normalize renderer for a <see cref="CodeBlock"/> and <see cref="FencedCodeBlock"/>.
     /// </summary>
-    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.CodeBlock}" />
+    /// <seealso cref="NormalizeObjectRenderer{CodeBlock}" />
     public class CodeBlockRenderer : NormalizeObjectRenderer<CodeBlock>
     {
         public bool OutputAttributesOnPre { get; set; }

--- a/src/Markdig/Renderers/Normalize/CodeBlockRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/CodeBlockRenderer.cs
@@ -10,7 +10,7 @@ namespace Markdig.Renderers.Normalize
     /// <summary>
     /// An Normalize renderer for a <see cref="CodeBlock"/> and <see cref="FencedCodeBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Normalize.NormalizeObjectRenderer{Markdig.Syntax.CodeBlock}" />
+    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.CodeBlock}" />
     public class CodeBlockRenderer : NormalizeObjectRenderer<CodeBlock>
     {
         public bool OutputAttributesOnPre { get; set; }

--- a/src/Markdig/Renderers/Normalize/HeadingRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/HeadingRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax;
 
 namespace Markdig.Renderers.Normalize

--- a/src/Markdig/Renderers/Normalize/HeadingRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/HeadingRenderer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
-using System.Globalization;
 using Markdig.Syntax;
 
 namespace Markdig.Renderers.Normalize

--- a/src/Markdig/Renderers/Normalize/HeadingRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/HeadingRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Normalize
     /// <summary>
     /// An Normalize renderer for a <see cref="HeadingBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Normalize.NormalizeObjectRenderer{Markdig.Syntax.HeadingBlock}" />
+    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.HeadingBlock}" />
     public class HeadingRenderer : NormalizeObjectRenderer<HeadingBlock>
     {
         private static readonly string[] HeadingTexts = {

--- a/src/Markdig/Renderers/Normalize/HeadingRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/HeadingRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Normalize
     /// <summary>
     /// An Normalize renderer for a <see cref="HeadingBlock"/>.
     /// </summary>
-    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.HeadingBlock}" />
+    /// <seealso cref="NormalizeObjectRenderer{HeadingBlock}" />
     public class HeadingRenderer : NormalizeObjectRenderer<HeadingBlock>
     {
         private static readonly string[] HeadingTexts = {

--- a/src/Markdig/Renderers/Normalize/Inlines/AutolinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/AutolinkInlineRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Normalize.Inlines
     /// <summary>
     /// A Normalize renderer for an <see cref="AutolinkInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Normalize.NormalizeObjectRenderer{Markdig.Syntax.Inlines.AutolinkInline}" />
+    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.Inlines.AutolinkInline}" />
     public class AutolinkInlineRenderer : NormalizeObjectRenderer<AutolinkInline>
     {
         protected override void Write(NormalizeRenderer renderer, AutolinkInline obj)

--- a/src/Markdig/Renderers/Normalize/Inlines/AutolinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/AutolinkInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Normalize.Inlines

--- a/src/Markdig/Renderers/Normalize/Inlines/AutolinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/AutolinkInlineRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Normalize.Inlines
     /// <summary>
     /// A Normalize renderer for an <see cref="AutolinkInline"/>.
     /// </summary>
-    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.Inlines.AutolinkInline}" />
+    /// <seealso cref="NormalizeObjectRenderer{AutolinkInline}" />
     public class AutolinkInlineRenderer : NormalizeObjectRenderer<AutolinkInline>
     {
         protected override void Write(NormalizeRenderer renderer, AutolinkInline obj)

--- a/src/Markdig/Renderers/Normalize/Inlines/CodeInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/CodeInlineRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Normalize.Inlines
     /// <summary>
     /// A Normalize renderer for a <see cref="CodeInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Normalize.NormalizeObjectRenderer{Markdig.Syntax.Inlines.CodeInline}" />
+    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.Inlines.CodeInline}" />
     public class CodeInlineRenderer : NormalizeObjectRenderer<CodeInline>
     {
         protected override void Write(NormalizeRenderer renderer, CodeInline obj)

--- a/src/Markdig/Renderers/Normalize/Inlines/CodeInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/CodeInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Normalize.Inlines

--- a/src/Markdig/Renderers/Normalize/Inlines/CodeInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/CodeInlineRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Normalize.Inlines
     /// <summary>
     /// A Normalize renderer for a <see cref="CodeInline"/>.
     /// </summary>
-    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.Inlines.CodeInline}" />
+    /// <seealso cref="NormalizeObjectRenderer{CodeInline}" />
     public class CodeInlineRenderer : NormalizeObjectRenderer<CodeInline>
     {
         protected override void Write(NormalizeRenderer renderer, CodeInline obj)

--- a/src/Markdig/Renderers/Normalize/Inlines/DelimiterInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/DelimiterInlineRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Normalize.Inlines
     /// <summary>
     /// A Normalize renderer for a <see cref="DelimiterInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Normalize.NormalizeObjectRenderer{Markdig.Syntax.Inlines.DelimiterInline}" />
+    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.Inlines.DelimiterInline}" />
     public class DelimiterInlineRenderer : NormalizeObjectRenderer<DelimiterInline>
     {
         protected override void Write(NormalizeRenderer renderer, DelimiterInline obj)

--- a/src/Markdig/Renderers/Normalize/Inlines/DelimiterInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/DelimiterInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Normalize.Inlines

--- a/src/Markdig/Renderers/Normalize/Inlines/DelimiterInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/DelimiterInlineRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Normalize.Inlines
     /// <summary>
     /// A Normalize renderer for a <see cref="DelimiterInline"/>.
     /// </summary>
-    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.Inlines.DelimiterInline}" />
+    /// <seealso cref="NormalizeObjectRenderer{DelimiterInline}" />
     public class DelimiterInlineRenderer : NormalizeObjectRenderer<DelimiterInline>
     {
         protected override void Write(NormalizeRenderer renderer, DelimiterInline obj)

--- a/src/Markdig/Renderers/Normalize/Inlines/EmphasisInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/EmphasisInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Normalize.Inlines

--- a/src/Markdig/Renderers/Normalize/Inlines/EmphasisInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/EmphasisInlineRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Normalize.Inlines
     /// <summary>
     /// A Normalize renderer for an <see cref="EmphasisInline"/>.
     /// </summary>
-    /// <seealso cref="Normalize.NormalizeObjectRenderer{EmphasisInline}" />
+    /// <seealso cref="NormalizeObjectRenderer{EmphasisInline}" />
     public class EmphasisInlineRenderer : NormalizeObjectRenderer<EmphasisInline>
     {
         protected override void Write(NormalizeRenderer renderer, EmphasisInline obj)

--- a/src/Markdig/Renderers/Normalize/Inlines/LineBreakInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/LineBreakInlineRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Normalize.Inlines
     /// <summary>
     /// A Normalize renderer for a <see cref="LineBreakInline"/>.
     /// </summary>
-    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.Inlines.LineBreakInline}" />
+    /// <seealso cref="NormalizeObjectRenderer{LineBreakInline}" />
     public class LineBreakInlineRenderer : NormalizeObjectRenderer<LineBreakInline>
     {
         /// <summary>

--- a/src/Markdig/Renderers/Normalize/Inlines/LineBreakInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/LineBreakInlineRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Normalize.Inlines
     /// <summary>
     /// A Normalize renderer for a <see cref="LineBreakInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Normalize.NormalizeObjectRenderer{Markdig.Syntax.Inlines.LineBreakInline}" />
+    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.Inlines.LineBreakInline}" />
     public class LineBreakInlineRenderer : NormalizeObjectRenderer<LineBreakInline>
     {
         /// <summary>

--- a/src/Markdig/Renderers/Normalize/Inlines/LineBreakInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/LineBreakInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Normalize.Inlines

--- a/src/Markdig/Renderers/Normalize/Inlines/LinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/LinkInlineRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Normalize.Inlines
     /// <summary>
     /// A Normalize renderer for a <see cref="LinkInline"/>.
     /// </summary>
-    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.Inlines.LinkInline}" />
+    /// <seealso cref="NormalizeObjectRenderer{LinkInline}" />
     public class LinkInlineRenderer : NormalizeObjectRenderer<LinkInline>
     {
         protected override void Write(NormalizeRenderer renderer, LinkInline link)

--- a/src/Markdig/Renderers/Normalize/Inlines/LinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/LinkInlineRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Normalize.Inlines
     /// <summary>
     /// A Normalize renderer for a <see cref="LinkInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Normalize.NormalizeObjectRenderer{Markdig.Syntax.Inlines.LinkInline}" />
+    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.Inlines.LinkInline}" />
     public class LinkInlineRenderer : NormalizeObjectRenderer<LinkInline>
     {
         protected override void Write(NormalizeRenderer renderer, LinkInline link)

--- a/src/Markdig/Renderers/Normalize/Inlines/LinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/LinkInlineRenderer.cs
@@ -24,9 +24,7 @@ namespace Markdig.Renderers.Normalize.Inlines
 
             if (link.Label != null)
             {
-
-                var literal = link.FirstChild as LiteralInline;
-                if (literal != null && literal.Content.Match(link.Label) && literal.Content.Length == link.Label.Length)
+                if (link.FirstChild is LiteralInline literal && literal.Content.Length == link.Label.Length && literal.Content.Match(link.Label))
                 {
                     // collapsed reference and shortcut links
                     if (!link.IsShortcut)

--- a/src/Markdig/Renderers/Normalize/Inlines/LinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/LinkInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Normalize.Inlines

--- a/src/Markdig/Renderers/Normalize/Inlines/LiteralInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/LiteralInlineRenderer.cs
@@ -10,7 +10,7 @@ namespace Markdig.Renderers.Normalize.Inlines
     /// <summary>
     /// A Normalize renderer for a <see cref="LiteralInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Normalize.NormalizeObjectRenderer{Markdig.Syntax.Inlines.LiteralInline}" />
+    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.Inlines.LiteralInline}" />
     public class LiteralInlineRenderer : NormalizeObjectRenderer<LiteralInline>
     {
         protected override void Write(NormalizeRenderer renderer, LiteralInline obj)

--- a/src/Markdig/Renderers/Normalize/Inlines/LiteralInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/LiteralInlineRenderer.cs
@@ -10,7 +10,7 @@ namespace Markdig.Renderers.Normalize.Inlines
     /// <summary>
     /// A Normalize renderer for a <see cref="LiteralInline"/>.
     /// </summary>
-    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.Inlines.LiteralInline}" />
+    /// <seealso cref="NormalizeObjectRenderer{LiteralInline}" />
     public class LiteralInlineRenderer : NormalizeObjectRenderer<LiteralInline>
     {
         protected override void Write(NormalizeRenderer renderer, LiteralInline obj)

--- a/src/Markdig/Renderers/Normalize/Inlines/NormalizeHtmlEntityInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/NormalizeHtmlEntityInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Normalize.Inlines

--- a/src/Markdig/Renderers/Normalize/Inlines/NormalizeHtmlInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/NormalizeHtmlInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Normalize.Inlines

--- a/src/Markdig/Renderers/Normalize/LinkReferenceDefinitionRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/LinkReferenceDefinitionRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax;
 
 namespace Markdig.Renderers.Normalize

--- a/src/Markdig/Renderers/Normalize/ListRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/ListRenderer.cs
@@ -10,7 +10,7 @@ namespace Markdig.Renderers.Normalize
     /// <summary>
     /// A Normalize renderer for a <see cref="ListBlock"/>.
     /// </summary>
-    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.ListBlock}" />
+    /// <seealso cref="NormalizeObjectRenderer{ListBlock}" />
     public class ListRenderer : NormalizeObjectRenderer<ListBlock>
     {
         protected override void Write(NormalizeRenderer renderer, ListBlock listBlock)

--- a/src/Markdig/Renderers/Normalize/ListRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/ListRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Normalize
     /// <summary>
     /// A Normalize renderer for a <see cref="ListBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Normalize.NormalizeObjectRenderer{Markdig.Syntax.ListBlock}" />
+    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.ListBlock}" />
     public class ListRenderer : NormalizeObjectRenderer<ListBlock>
     {
         protected override void Write(NormalizeRenderer renderer, ListBlock listBlock)

--- a/src/Markdig/Renderers/Normalize/ListRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/ListRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System.Globalization;
 using Markdig.Syntax;
 

--- a/src/Markdig/Renderers/Normalize/NormalizeObjectRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/NormalizeObjectRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax;
 
 namespace Markdig.Renderers.Normalize

--- a/src/Markdig/Renderers/Normalize/NormalizeObjectRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/NormalizeObjectRenderer.cs
@@ -6,10 +6,10 @@ using Markdig.Syntax;
 namespace Markdig.Renderers.Normalize
 {
     /// <summary>
-    /// A base class for Normalize rendering <see cref="Block"/> and <see cref="Markdig.Syntax.Inlines.Inline"/> Markdown objects.
+    /// A base class for Normalize rendering <see cref="Block"/> and <see cref="Syntax.Inlines.Inline"/> Markdown objects.
     /// </summary>
     /// <typeparam name="TObject">The type of the object.</typeparam>
-    /// <seealso cref="Markdig.Renderers.IMarkdownObjectRenderer" />
+    /// <seealso cref="IMarkdownObjectRenderer" />
     public abstract class NormalizeObjectRenderer<TObject> : MarkdownObjectRenderer<NormalizeRenderer, TObject> where TObject : MarkdownObject
     {
     }

--- a/src/Markdig/Renderers/Normalize/NormalizeOptions.cs
+++ b/src/Markdig/Renderers/Normalize/NormalizeOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 namespace Markdig.Renderers.Normalize
 {
     /// <summary>

--- a/src/Markdig/Renderers/Normalize/NormalizeRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/NormalizeRenderer.cs
@@ -12,7 +12,7 @@ namespace Markdig.Renderers.Normalize
     /// <summary>
     /// Default HTML renderer for a Markdown <see cref="MarkdownDocument"/> object.
     /// </summary>
-    /// <seealso cref="Renderers.TextRendererBase{Normalize.NormalizeRenderer}" />
+    /// <seealso cref="TextRendererBase{NormalizeRenderer}" />
     public class NormalizeRenderer : TextRendererBase<NormalizeRenderer>
     {
         /// <summary>
@@ -127,6 +127,7 @@ namespace Markdig.Renderers.Normalize
         /// </summary>
         /// <param name="leafBlock">The leaf block.</param>
         /// <param name="writeEndOfLines">if set to <c>true</c> write end of lines.</param>
+        /// <param name="indent">Whether to write indents.</param>
         /// <returns>This instance</returns>
         public NormalizeRenderer WriteLeafRawLines(LeafBlock leafBlock, bool writeEndOfLines, bool indent = false)
         {

--- a/src/Markdig/Renderers/Normalize/NormalizeRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/NormalizeRenderer.cs
@@ -13,7 +13,7 @@ namespace Markdig.Renderers.Normalize
     /// <summary>
     /// Default HTML renderer for a Markdown <see cref="MarkdownDocument"/> object.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.TextRendererBase{Markdig.Renderers.Normalize.NormalizeRenderer}" />
+    /// <seealso cref="Renderers.TextRendererBase{Normalize.NormalizeRenderer}" />
     public class NormalizeRenderer : TextRendererBase<NormalizeRenderer>
     {
         /// <summary>

--- a/src/Markdig/Renderers/Normalize/NormalizeRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/NormalizeRenderer.cs
@@ -2,7 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-using System;
 using System.IO;
 using Markdig.Syntax;
 using Markdig.Renderers.Normalize.Inlines;

--- a/src/Markdig/Renderers/Normalize/ParagraphRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/ParagraphRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax;
 
 namespace Markdig.Renderers.Normalize

--- a/src/Markdig/Renderers/Normalize/ParagraphRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/ParagraphRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Normalize
     /// <summary>
     /// A Normalize renderer for a <see cref="ParagraphBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Normalize.NormalizeObjectRenderer{Markdig.Syntax.ParagraphBlock}" />
+    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.ParagraphBlock}" />
     public class ParagraphRenderer : NormalizeObjectRenderer<ParagraphBlock>
     {
         protected override void Write(NormalizeRenderer renderer, ParagraphBlock obj)

--- a/src/Markdig/Renderers/Normalize/ParagraphRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/ParagraphRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Normalize
     /// <summary>
     /// A Normalize renderer for a <see cref="ParagraphBlock"/>.
     /// </summary>
-    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.ParagraphBlock}" />
+    /// <seealso cref="NormalizeObjectRenderer{ParagraphBlock}" />
     public class ParagraphRenderer : NormalizeObjectRenderer<ParagraphBlock>
     {
         protected override void Write(NormalizeRenderer renderer, ParagraphBlock obj)

--- a/src/Markdig/Renderers/Normalize/QuoteBlockRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/QuoteBlockRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Normalize
     /// <summary>
     /// A Normalize renderer for a <see cref="QuoteBlock"/>.
     /// </summary>
-    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.QuoteBlock}" />
+    /// <seealso cref="NormalizeObjectRenderer{QuoteBlock}" />
     public class QuoteBlockRenderer : NormalizeObjectRenderer<QuoteBlock>
     {
         protected override void Write(NormalizeRenderer renderer, QuoteBlock obj)

--- a/src/Markdig/Renderers/Normalize/QuoteBlockRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/QuoteBlockRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax;
 
 namespace Markdig.Renderers.Normalize

--- a/src/Markdig/Renderers/Normalize/QuoteBlockRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/QuoteBlockRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Normalize
     /// <summary>
     /// A Normalize renderer for a <see cref="QuoteBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Normalize.NormalizeObjectRenderer{Markdig.Syntax.QuoteBlock}" />
+    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.QuoteBlock}" />
     public class QuoteBlockRenderer : NormalizeObjectRenderer<QuoteBlock>
     {
         protected override void Write(NormalizeRenderer renderer, QuoteBlock obj)

--- a/src/Markdig/Renderers/Normalize/ThematicBreakRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/ThematicBreakRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Syntax;
 
 namespace Markdig.Renderers.Normalize

--- a/src/Markdig/Renderers/Normalize/ThematicBreakRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/ThematicBreakRenderer.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers.Normalize
     /// <summary>
     /// A Normalize renderer for a <see cref="ThematicBreakBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Normalize.NormalizeObjectRenderer{Markdig.Syntax.ThematicBreakBlock}" />
+    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.ThematicBreakBlock}" />
     public class ThematicBreakRenderer : NormalizeObjectRenderer<ThematicBreakBlock>
     {
         protected override void Write(NormalizeRenderer renderer, ThematicBreakBlock obj)

--- a/src/Markdig/Renderers/Normalize/ThematicBreakRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/ThematicBreakRenderer.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers.Normalize
     /// <summary>
     /// A Normalize renderer for a <see cref="ThematicBreakBlock"/>.
     /// </summary>
-    /// <seealso cref="Normalize.NormalizeObjectRenderer{Syntax.ThematicBreakBlock}" />
+    /// <seealso cref="NormalizeObjectRenderer{ThematicBreakBlock}" />
     public class ThematicBreakRenderer : NormalizeObjectRenderer<ThematicBreakBlock>
     {
         protected override void Write(NormalizeRenderer renderer, ThematicBreakBlock obj)

--- a/src/Markdig/Renderers/ObjectRendererCollection.cs
+++ b/src/Markdig/Renderers/ObjectRendererCollection.cs
@@ -9,7 +9,7 @@ namespace Markdig.Renderers
     /// <summary>
     /// A collection of <see cref="IMarkdownObjectRenderer"/>.
     /// </summary>
-    /// <seealso cref="Helpers.OrderedList{Renderers.IMarkdownObjectRenderer}" />
+    /// <seealso cref="OrderedList{IMarkdownObjectRenderer}" />
     public class ObjectRendererCollection : OrderedList<IMarkdownObjectRenderer>
     {
     }

--- a/src/Markdig/Renderers/ObjectRendererCollection.cs
+++ b/src/Markdig/Renderers/ObjectRendererCollection.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 
 namespace Markdig.Renderers

--- a/src/Markdig/Renderers/ObjectRendererCollection.cs
+++ b/src/Markdig/Renderers/ObjectRendererCollection.cs
@@ -8,7 +8,7 @@ namespace Markdig.Renderers
     /// <summary>
     /// A collection of <see cref="IMarkdownObjectRenderer"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Helpers.OrderedList{Markdig.Renderers.IMarkdownObjectRenderer}" />
+    /// <seealso cref="Helpers.OrderedList{Renderers.IMarkdownObjectRenderer}" />
     public class ObjectRendererCollection : OrderedList<IMarkdownObjectRenderer>
     {
     }

--- a/src/Markdig/Renderers/RendererBase.cs
+++ b/src/Markdig/Renderers/RendererBase.cs
@@ -11,7 +11,7 @@ namespace Markdig.Renderers
     /// <summary>
     /// Base class for a <see cref="IMarkdownRenderer"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.IMarkdownRenderer" />
+    /// <seealso cref="IMarkdownRenderer" />
     public abstract class RendererBase : IMarkdownRenderer
     {
         private readonly Dictionary<Type, IMarkdownObjectRenderer> renderersPerType;

--- a/src/Markdig/Renderers/RendererBase.cs
+++ b/src/Markdig/Renderers/RendererBase.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using Markdig.Syntax;

--- a/src/Markdig/Renderers/TextRendererBase.cs
+++ b/src/Markdig/Renderers/TextRendererBase.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Markdig/Renderers/TextRendererBase.cs
+++ b/src/Markdig/Renderers/TextRendererBase.cs
@@ -14,7 +14,7 @@ namespace Markdig.Renderers
     /// <summary>
     /// A text based <see cref="IMarkdownRenderer"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.RendererBase" />
+    /// <seealso cref="RendererBase" />
     public abstract class TextRendererBase : RendererBase
     {
         private TextWriter writer;
@@ -23,7 +23,7 @@ namespace Markdig.Renderers
         /// Initializes a new instance of the <see cref="TextRendererBase"/> class.
         /// </summary>
         /// <param name="writer">The writer.</param>
-        /// <exception cref="System.ArgumentNullException"></exception>
+        /// <exception cref="ArgumentNullException"></exception>
         protected TextRendererBase(TextWriter writer)
         {
             if (writer == null) ThrowHelper.ArgumentNullException_writer();
@@ -35,7 +35,7 @@ namespace Markdig.Renderers
         /// <summary>
         /// Gets or sets the writer.
         /// </summary>
-        /// <exception cref="System.ArgumentNullException">if the value is null</exception>
+        /// <exception cref="ArgumentNullException">if the value is null</exception>
         public TextWriter Writer
         {
             get { return writer; }
@@ -66,7 +66,7 @@ namespace Markdig.Renderers
     /// Typed <see cref="TextRendererBase"/>.
     /// </summary>
     /// <typeparam name="T">Type of the renderer</typeparam>
-    /// <seealso cref="Markdig.Renderers.RendererBase" />
+    /// <seealso cref="RendererBase" />
     public abstract class TextRendererBase<T> : TextRendererBase where T : TextRendererBase<T>
     {
         private bool previousWasLine;

--- a/src/Markdig/Syntax/BlankLineBlock.cs
+++ b/src/Markdig/Syntax/BlankLineBlock.cs
@@ -6,7 +6,7 @@ namespace Markdig.Syntax
     /// <summary>
     /// A blank line, used internally by some parsers to store blank lines in a container. They are removed before the end of the document.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Block" />
+    /// <seealso cref="Block" />
     public sealed class BlankLineBlock : Block
     {
         /// <summary>

--- a/src/Markdig/Syntax/BlankLineBlock.cs
+++ b/src/Markdig/Syntax/BlankLineBlock.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 namespace Markdig.Syntax
 {
     /// <summary>

--- a/src/Markdig/Syntax/Block.cs
+++ b/src/Markdig/Syntax/Block.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 
 namespace Markdig.Syntax

--- a/src/Markdig/Syntax/Block.cs
+++ b/src/Markdig/Syntax/Block.cs
@@ -9,7 +9,7 @@ namespace Markdig.Syntax
     /// <summary>
     /// Base class for a block structure. Either a <see cref="LeafBlock"/> or a <see cref="ContainerBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.MarkdownObject" />
+    /// <seealso cref="MarkdownObject" />
     public abstract class Block : MarkdownObject, IBlock
     {
         /// <summary>

--- a/src/Markdig/Syntax/Block.cs
+++ b/src/Markdig/Syntax/Block.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
-using System;
 using Markdig.Parsers;
 
 namespace Markdig.Syntax

--- a/src/Markdig/Syntax/BlockExtensions.cs
+++ b/src/Markdig/Syntax/BlockExtensions.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 namespace Markdig.Syntax
 {
     /// <summary>

--- a/src/Markdig/Syntax/BlockExtensions.cs
+++ b/src/Markdig/Syntax/BlockExtensions.cs
@@ -14,8 +14,7 @@ namespace Markdig.Syntax
         public static Block FindBlockAtPosition(this Block rootBlock, int position)
         {
             var contains = rootBlock.CompareToPosition(position) == 0;
-            var blocks = rootBlock as ContainerBlock;
-            if (blocks == null || blocks.Count == 0 || !contains)
+            if (!(rootBlock is ContainerBlock blocks) || blocks.Count == 0 || !contains)
             {
                 return contains ? rootBlock : null;
             }
@@ -60,8 +59,7 @@ namespace Markdig.Syntax
 
         public static Block FindClosestBlock(this Block rootBlock, int line)
         {
-            var blocks = rootBlock as ContainerBlock;
-            if (blocks == null || blocks.Count == 0)
+            if (!(rootBlock is ContainerBlock blocks) || blocks.Count == 0)
             {
                 return rootBlock.Line == line ? rootBlock : null;
             }

--- a/src/Markdig/Syntax/CharIteratorHelper.cs
+++ b/src/Markdig/Syntax/CharIteratorHelper.cs
@@ -1,3 +1,7 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license. 
+// See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 
 namespace Markdig.Syntax

--- a/src/Markdig/Syntax/CodeBlock.cs
+++ b/src/Markdig/Syntax/CodeBlock.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 
 namespace Markdig.Syntax

--- a/src/Markdig/Syntax/ContainerBlock.cs
+++ b/src/Markdig/Syntax/ContainerBlock.cs
@@ -15,7 +15,7 @@ namespace Markdig.Syntax
     /// <summary>
     /// A base class for container blocks.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Block" />
+    /// <seealso cref="Block" />
     [DebuggerDisplay("{GetType().Name} Count = {Count}")]
     public abstract class ContainerBlock : Block, IList<Block>, IReadOnlyList<Block>
     {

--- a/src/Markdig/Syntax/FencedCodeBlock.cs
+++ b/src/Markdig/Syntax/FencedCodeBlock.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 
 namespace Markdig.Syntax

--- a/src/Markdig/Syntax/HeadingBlock.cs
+++ b/src/Markdig/Syntax/HeadingBlock.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
+
 using System.Diagnostics;
 using Markdig.Parsers;
 

--- a/src/Markdig/Syntax/HtmlBlock.cs
+++ b/src/Markdig/Syntax/HtmlBlock.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 
 namespace Markdig.Syntax

--- a/src/Markdig/Syntax/HtmlBlock.cs
+++ b/src/Markdig/Syntax/HtmlBlock.cs
@@ -8,7 +8,7 @@ namespace Markdig.Syntax
     /// <summary>
     /// Represents a group of lines that is treated as raw HTML (and will not be escaped in HTML output).
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.LeafBlock" />
+    /// <seealso cref="LeafBlock" />
     public class HtmlBlock : LeafBlock
     {
         /// <summary>

--- a/src/Markdig/Syntax/HtmlBlockType.cs
+++ b/src/Markdig/Syntax/HtmlBlockType.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 namespace Markdig.Syntax
 {
     /// <summary>

--- a/src/Markdig/Syntax/IBlock.cs
+++ b/src/Markdig/Syntax/IBlock.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 
 namespace Markdig.Syntax

--- a/src/Markdig/Syntax/IBlock.cs
+++ b/src/Markdig/Syntax/IBlock.cs
@@ -9,7 +9,7 @@ namespace Markdig.Syntax
     /// <summary>
     /// Base interface for a block structure. Either a <see cref="LeafBlock"/> or a <see cref="ContainerBlock"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.IMarkdownObject" />
+    /// <seealso cref="IMarkdownObject" />
     public interface IBlock : IMarkdownObject
     {
         /// <summary>

--- a/src/Markdig/Syntax/IBlock.cs
+++ b/src/Markdig/Syntax/IBlock.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
-using System;
 using Markdig.Parsers;
 
 namespace Markdig.Syntax

--- a/src/Markdig/Syntax/IFencedBlock.cs
+++ b/src/Markdig/Syntax/IFencedBlock.cs
@@ -5,7 +5,7 @@
 namespace Markdig.Syntax
 {
     /// <summary>
-    /// A common interface for fenced block (e.g: <see cref="FencedCodeBlock"/> or <see cref="Markdig.Extensions.CustomContainers.CustomContainer"/>)
+    /// A common interface for fenced block (e.g: <see cref="FencedCodeBlock"/> or <see cref="Extensions.CustomContainers.CustomContainer"/>)
     /// </summary>
     public interface IFencedBlock : IBlock
     {

--- a/src/Markdig/Syntax/IMarkdownObject.cs
+++ b/src/Markdig/Syntax/IMarkdownObject.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 namespace Markdig.Syntax
 {
     /// <summary>

--- a/src/Markdig/Syntax/Inlines/AutolinkInline.cs
+++ b/src/Markdig/Syntax/Inlines/AutolinkInline.cs
@@ -9,7 +9,7 @@ namespace Markdig.Syntax.Inlines
     /// <summary>
     /// An autolink (Section 6.7 CommonMark specs)
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Inlines.LeafInline" />
+    /// <seealso cref="LeafInline" />
     [DebuggerDisplay("<{Url}>")]
     public class AutolinkInline : LeafInline
     {

--- a/src/Markdig/Syntax/Inlines/CodeInline.cs
+++ b/src/Markdig/Syntax/Inlines/CodeInline.cs
@@ -9,7 +9,7 @@ namespace Markdig.Syntax.Inlines
     /// <summary>
     /// Represents a code span (Section 6.3 CommonMark specs)
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Inlines.LeafInline" />
+    /// <seealso cref="LeafInline" />
     [DebuggerDisplay("`{Content}`")]
     public class CodeInline : LeafInline
     {

--- a/src/Markdig/Syntax/Inlines/ContainerInline.cs
+++ b/src/Markdig/Syntax/Inlines/ContainerInline.cs
@@ -14,7 +14,7 @@ namespace Markdig.Syntax.Inlines
     /// <summary>
     /// A base class for container for <see cref="Inline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Inlines.Inline" />
+    /// <seealso cref="Inline" />
     public class ContainerInline : Inline, IEnumerable<Inline>
     {
         /// <summary>
@@ -47,8 +47,8 @@ namespace Markdig.Syntax.Inlines
         /// </summary>
         /// <param name="child">The child to append to this container..</param>
         /// <returns>This instance</returns>
-        /// <exception cref="System.ArgumentNullException">If child is null</exception>
-        /// <exception cref="System.ArgumentException">Inline has already a parent</exception>
+        /// <exception cref="ArgumentNullException">If child is null</exception>
+        /// <exception cref="ArgumentException">Inline has already a parent</exception>
         public virtual ContainerInline AppendChild(Inline child)
         {
             if (child == null) ThrowHelper.ArgumentNullException(nameof(child));
@@ -164,7 +164,7 @@ namespace Markdig.Syntax.Inlines
         /// Embraces this instance by the specified container.
         /// </summary>
         /// <param name="container">The container to use to embrace this instance.</param>
-        /// <exception cref="System.ArgumentNullException">If the container is null</exception>
+        /// <exception cref="ArgumentNullException">If the container is null</exception>
         public void EmbraceChildrenBy(ContainerInline container)
         {
             if (container == null) ThrowHelper.ArgumentNullException(nameof(container));

--- a/src/Markdig/Syntax/Inlines/DelimiterInline.cs
+++ b/src/Markdig/Syntax/Inlines/DelimiterInline.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
-using System;
 using System.Diagnostics;
 using Markdig.Helpers;
 using Markdig.Parsers;

--- a/src/Markdig/Syntax/Inlines/DelimiterInline.cs
+++ b/src/Markdig/Syntax/Inlines/DelimiterInline.cs
@@ -11,7 +11,7 @@ namespace Markdig.Syntax.Inlines
     /// <summary>
     /// Internal delimiter used by some parsers (e.g emphasis, tables).
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Inlines.ContainerInline" />
+    /// <seealso cref="ContainerInline" />
     [DebuggerDisplay("{ToLiteral()} {Type}")]
     public abstract class DelimiterInline : ContainerInline
     {

--- a/src/Markdig/Syntax/Inlines/DelimiterInline.cs
+++ b/src/Markdig/Syntax/Inlines/DelimiterInline.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System.Diagnostics;
 using Markdig.Helpers;
 using Markdig.Parsers;

--- a/src/Markdig/Syntax/Inlines/DelimiterType.cs
+++ b/src/Markdig/Syntax/Inlines/DelimiterType.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System;
 
 namespace Markdig.Syntax.Inlines

--- a/src/Markdig/Syntax/Inlines/HtmlEntityInline.cs
+++ b/src/Markdig/Syntax/Inlines/HtmlEntityInline.cs
@@ -9,7 +9,7 @@ namespace Markdig.Syntax.Inlines
     /// <summary>
     /// An entity HTML.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Inlines.LeafInline" />
+    /// <seealso cref="LeafInline" />
     [DebuggerDisplay("{Original} -> {Transcoded}")]
     public class HtmlEntityInline : LeafInline
     {

--- a/src/Markdig/Syntax/Inlines/HtmlEntityInline.cs
+++ b/src/Markdig/Syntax/Inlines/HtmlEntityInline.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System.Diagnostics;
 using Markdig.Helpers;
 

--- a/src/Markdig/Syntax/Inlines/HtmlInline.cs
+++ b/src/Markdig/Syntax/Inlines/HtmlInline.cs
@@ -9,7 +9,7 @@ namespace Markdig.Syntax.Inlines
     /// <summary>
     /// A Raw HTML (Section 6.8 CommonMark specs).
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Inlines.LeafInline" />
+    /// <seealso cref="LeafInline" />
     [DebuggerDisplay("{Tag}")]
     public class HtmlInline : LeafInline
     {

--- a/src/Markdig/Syntax/Inlines/IInline.cs
+++ b/src/Markdig/Syntax/Inlines/IInline.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 namespace Markdig.Syntax.Inlines
 {
     /// <summary>

--- a/src/Markdig/Syntax/Inlines/IInline.cs
+++ b/src/Markdig/Syntax/Inlines/IInline.cs
@@ -6,7 +6,7 @@ namespace Markdig.Syntax.Inlines
     /// <summary>
     /// Base interface for all syntax tree inlines.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.IMarkdownObject" />
+    /// <seealso cref="IMarkdownObject" />
     public interface IInline : IMarkdownObject
     {
         /// <summary>

--- a/src/Markdig/Syntax/Inlines/Inline.cs
+++ b/src/Markdig/Syntax/Inlines/Inline.cs
@@ -12,7 +12,7 @@ namespace Markdig.Syntax.Inlines
     /// <summary>
     /// Base class for all syntax tree inlines.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.MarkdownObject" />
+    /// <seealso cref="MarkdownObject" />
     public abstract class Inline : MarkdownObject, IInline
     {
         /// <summary>
@@ -39,8 +39,8 @@ namespace Markdig.Syntax.Inlines
         /// Inserts the specified inline after this instance.
         /// </summary>
         /// <param name="next">The inline to insert after this instance.</param>
-        /// <exception cref="System.ArgumentNullException"></exception>
-        /// <exception cref="System.ArgumentException">Inline has already a parent</exception>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException">Inline has already a parent</exception>
         public void InsertAfter(Inline next)
         {
             if (next == null) ThrowHelper.ArgumentNullException(nameof(next));
@@ -70,8 +70,8 @@ namespace Markdig.Syntax.Inlines
         /// Inserts the specified inline before this instance.
         /// </summary>
         /// <param name="previous">The inline previous to insert before this instance.</param>
-        /// <exception cref="System.ArgumentNullException"></exception>
-        /// <exception cref="System.ArgumentException">Inline has already a parent</exception>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException">Inline has already a parent</exception>
         public void InsertBefore(Inline previous)
         {
             if (previous == null) ThrowHelper.ArgumentNullException(nameof(previous));
@@ -127,7 +127,7 @@ namespace Markdig.Syntax.Inlines
         /// <param name="inline">The inline.</param>
         /// <param name="copyChildren">if set to <c>true</c> the children of this instance are copied to the specified inline.</param>
         /// <returns>The last children</returns>
-        /// <exception cref="System.ArgumentNullException">If inline is null</exception>
+        /// <exception cref="ArgumentNullException">If inline is null</exception>
         public Inline ReplaceBy(Inline inline, bool copyChildren = true)
         {
             if (inline == null) ThrowHelper.ArgumentNullException(nameof(inline));
@@ -269,7 +269,7 @@ namespace Markdig.Syntax.Inlines
         /// Dumps this instance to <see cref="TextWriter"/>.
         /// </summary>
         /// <param name="writer">The writer.</param>
-        /// <exception cref="System.ArgumentNullException"></exception>
+        /// <exception cref="ArgumentNullException"></exception>
         public void DumpTo(TextWriter writer)
         {
             if (writer == null) ThrowHelper.ArgumentNullException_writer();
@@ -281,7 +281,7 @@ namespace Markdig.Syntax.Inlines
         /// </summary>
         /// <param name="writer">The writer.</param>
         /// <param name="level">The level of indent.</param>
-        /// <exception cref="System.ArgumentNullException">if writer is null</exception>
+        /// <exception cref="ArgumentNullException">if writer is null</exception>
         public void DumpTo(TextWriter writer, int level)
         {
             if (writer == null) ThrowHelper.ArgumentNullException_writer();

--- a/src/Markdig/Syntax/Inlines/Inline.cs
+++ b/src/Markdig/Syntax/Inlines/Inline.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Markdig.Helpers;
-using Markdig.Parsers;
 
 namespace Markdig.Syntax.Inlines
 {

--- a/src/Markdig/Syntax/Inlines/Inline.cs
+++ b/src/Markdig/Syntax/Inlines/Inline.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Markdig/Syntax/Inlines/LeafInline.cs
+++ b/src/Markdig/Syntax/Inlines/LeafInline.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 namespace Markdig.Syntax.Inlines
 {
     /// <summary>

--- a/src/Markdig/Syntax/Inlines/LeafInline.cs
+++ b/src/Markdig/Syntax/Inlines/LeafInline.cs
@@ -6,7 +6,7 @@ namespace Markdig.Syntax.Inlines
     /// <summary>
     /// A base class for a leaf inline.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Inlines.Inline" />
+    /// <seealso cref="Inline" />
     public abstract class LeafInline : Inline
     {
     }

--- a/src/Markdig/Syntax/Inlines/LineBreakInline.cs
+++ b/src/Markdig/Syntax/Inlines/LineBreakInline.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 namespace Markdig.Syntax.Inlines
 {
     /// <summary>

--- a/src/Markdig/Syntax/Inlines/LineBreakInline.cs
+++ b/src/Markdig/Syntax/Inlines/LineBreakInline.cs
@@ -6,7 +6,7 @@ namespace Markdig.Syntax.Inlines
     /// <summary>
     /// A base class for a line break.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Inlines.LeafInline" />
+    /// <seealso cref="LeafInline" />
     public class LineBreakInline : LeafInline
     {
         public bool IsHard { get; set; }

--- a/src/Markdig/Syntax/Inlines/LinkDelimiterInline.cs
+++ b/src/Markdig/Syntax/Inlines/LinkDelimiterInline.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 
 namespace Markdig.Syntax.Inlines

--- a/src/Markdig/Syntax/Inlines/LinkDelimiterInline.cs
+++ b/src/Markdig/Syntax/Inlines/LinkDelimiterInline.cs
@@ -8,7 +8,7 @@ namespace Markdig.Syntax.Inlines
     /// <summary>
     /// A delimiter for a link.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Inlines.DelimiterInline" />
+    /// <seealso cref="DelimiterInline" />
     public class LinkDelimiterInline : DelimiterInline
     {
         public LinkDelimiterInline(InlineParser parser) : base(parser)

--- a/src/Markdig/Syntax/Inlines/LinkInline.cs
+++ b/src/Markdig/Syntax/Inlines/LinkInline.cs
@@ -9,7 +9,7 @@ namespace Markdig.Syntax.Inlines
     /// <summary>
     /// A Link inline (Section 6.5 CommonMark specs)
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Inlines.ContainerInline" />
+    /// <seealso cref="ContainerInline" />
     [DebuggerDisplay("Url: {Url} Title: {Title} Image: {IsImage}")]
     public class LinkInline : ContainerInline
     {

--- a/src/Markdig/Syntax/Inlines/LiteralInline.cs
+++ b/src/Markdig/Syntax/Inlines/LiteralInline.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System;
 using System.Diagnostics;
 using Markdig.Helpers;

--- a/src/Markdig/Syntax/Inlines/LiteralInline.cs
+++ b/src/Markdig/Syntax/Inlines/LiteralInline.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics;
 using Markdig.Helpers;
-using Markdig.Parsers;
 
 namespace Markdig.Syntax.Inlines
 {

--- a/src/Markdig/Syntax/Inlines/LiteralInline.cs
+++ b/src/Markdig/Syntax/Inlines/LiteralInline.cs
@@ -11,7 +11,7 @@ namespace Markdig.Syntax.Inlines
     /// <summary>
     /// A literal inline.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Inlines.LeafInline" />
+    /// <seealso cref="LeafInline" />
     [DebuggerDisplay("{Content}")]
     public class LiteralInline : LeafInline
     {
@@ -36,7 +36,7 @@ namespace Markdig.Syntax.Inlines
         /// Initializes a new instance of the <see cref="LiteralInline"/> class.
         /// </summary>
         /// <param name="text">The text.</param>
-        /// <exception cref="System.ArgumentNullException"></exception>
+        /// <exception cref="ArgumentNullException"></exception>
         public LiteralInline(string text)
         {
             if (text == null) ThrowHelper.ArgumentNullException_text();

--- a/src/Markdig/Syntax/LeafBlock.cs
+++ b/src/Markdig/Syntax/LeafBlock.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
+
 using System.Diagnostics;
 using Markdig.Helpers;
 using Markdig.Parsers;

--- a/src/Markdig/Syntax/LeafBlock.cs
+++ b/src/Markdig/Syntax/LeafBlock.cs
@@ -11,7 +11,7 @@ namespace Markdig.Syntax
     /// <summary>
     /// Base class for all leaf blocks.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.Block" />
+    /// <seealso cref="Block" />
     [DebuggerDisplay("{GetType().Name} Line: {Line}, {Lines}")]
     public abstract class LeafBlock : Block
     {

--- a/src/Markdig/Syntax/LinkReferenceDefinition.cs
+++ b/src/Markdig/Syntax/LinkReferenceDefinition.cs
@@ -10,7 +10,7 @@ namespace Markdig.Syntax
     /// <summary>
     /// A link reference definition (Section 4.7 CommonMark specs)
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.LeafBlock" />
+    /// <seealso cref="LeafBlock" />
     public class LinkReferenceDefinition : LeafBlock
     {
         /// <summary>

--- a/src/Markdig/Syntax/LinkReferenceDefinition.cs
+++ b/src/Markdig/Syntax/LinkReferenceDefinition.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Syntax.Inlines;

--- a/src/Markdig/Syntax/LinkReferenceDefinition.cs
+++ b/src/Markdig/Syntax/LinkReferenceDefinition.cs
@@ -93,16 +93,10 @@ namespace Markdig.Syntax
         public static bool TryParse<T>(ref T text, out LinkReferenceDefinition block) where T : ICharIterator
         {
             block = null;
-            string label;
-            string url;
-            string title;
-            SourceSpan labelSpan;
-            SourceSpan urlSpan;
-            SourceSpan titleSpan;
 
             var startSpan = text.Start;
 
-            if (!LinkHelper.TryParseLinkReferenceDefinition(ref text, out label, out url, out title, out labelSpan, out urlSpan, out titleSpan))
+            if (!LinkHelper.TryParseLinkReferenceDefinition(ref text, out string label, out string url, out string title, out SourceSpan labelSpan, out SourceSpan urlSpan, out SourceSpan titleSpan))
             {
                 return false;
             }

--- a/src/Markdig/Syntax/LinkReferenceDefinitionExtensions.cs
+++ b/src/Markdig/Syntax/LinkReferenceDefinitionExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 
 namespace Markdig.Syntax

--- a/src/Markdig/Syntax/LinkReferenceDefinitionExtensions.cs
+++ b/src/Markdig/Syntax/LinkReferenceDefinitionExtensions.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 using Markdig.Helpers;
-using System;
-using System.Collections.Generic;
 
 namespace Markdig.Syntax
 {

--- a/src/Markdig/Syntax/LinkReferenceDefinitionGroup.cs
+++ b/src/Markdig/Syntax/LinkReferenceDefinitionGroup.cs
@@ -11,7 +11,7 @@ namespace Markdig.Syntax
     /// <summary>
     /// Contains all the <see cref="LinkReferenceDefinition"/> found in a document.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.ContainerBlock" />
+    /// <seealso cref="ContainerBlock" />
     public class LinkReferenceDefinitionGroup : ContainerBlock
     {
         /// <summary>

--- a/src/Markdig/Syntax/ListBlock.cs
+++ b/src/Markdig/Syntax/ListBlock.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 
 namespace Markdig.Syntax

--- a/src/Markdig/Syntax/ListBlock.cs
+++ b/src/Markdig/Syntax/ListBlock.cs
@@ -8,7 +8,7 @@ namespace Markdig.Syntax
     /// <summary>
     /// A list (Section 5.3 CommonMark specs)
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.ContainerBlock" />
+    /// <seealso cref="ContainerBlock" />
     public class ListBlock : ContainerBlock
     {
         /// <summary>

--- a/src/Markdig/Syntax/ListItemBlock.cs
+++ b/src/Markdig/Syntax/ListItemBlock.cs
@@ -8,7 +8,7 @@ namespace Markdig.Syntax
     /// <summary>
     /// A list item (Section 5.2 CommonMark specs)
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.ContainerBlock" />
+    /// <seealso cref="ContainerBlock" />
     public class ListItemBlock : ContainerBlock
     {
         /// <summary>

--- a/src/Markdig/Syntax/ListItemBlock.cs
+++ b/src/Markdig/Syntax/ListItemBlock.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 
 namespace Markdig.Syntax

--- a/src/Markdig/Syntax/MarkdownDocument.cs
+++ b/src/Markdig/Syntax/MarkdownDocument.cs
@@ -8,7 +8,7 @@ namespace Markdig.Syntax
     /// <summary>
     /// The root Markdown document.
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.ContainerBlock" />
+    /// <seealso cref="ContainerBlock" />
     public class MarkdownDocument : ContainerBlock
     {
         /// <summary>

--- a/src/Markdig/Syntax/MarkdownDocument.cs
+++ b/src/Markdig/Syntax/MarkdownDocument.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using System.Collections.Generic;
 
 namespace Markdig.Syntax

--- a/src/Markdig/Syntax/MarkdownObject.cs
+++ b/src/Markdig/Syntax/MarkdownObject.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Helpers;
 using System;
 

--- a/src/Markdig/Syntax/MarkdownObject.cs
+++ b/src/Markdig/Syntax/MarkdownObject.cs
@@ -53,7 +53,7 @@ namespace Markdig.Syntax
         /// </summary>
         /// <param name="key">The key.</param>
         /// <param name="value">The value.</param>
-        /// <exception cref="System.ArgumentNullException">if key is null</exception>
+        /// <exception cref="ArgumentNullException">if key is null</exception>
         public void SetData(object key, object value)
         {
             if (key == null) ThrowHelper.ArgumentNullException_key();
@@ -87,7 +87,7 @@ namespace Markdig.Syntax
         /// </summary>
         /// <param name="key">The key.</param>
         /// <returns><c>true</c> if a data with the key is stored</returns>
-        /// <exception cref="System.ArgumentNullException">if key is null</exception>
+        /// <exception cref="ArgumentNullException">if key is null</exception>
         public bool ContainsData(object key)
         {
             if (key == null) ThrowHelper.ArgumentNullException_key();
@@ -111,7 +111,7 @@ namespace Markdig.Syntax
         /// </summary>
         /// <param name="key">The key.</param>
         /// <returns>The associated data or null if none</returns>
-        /// <exception cref="System.ArgumentNullException">if key is null</exception>
+        /// <exception cref="ArgumentNullException">if key is null</exception>
         public object GetData(object key)
         {
             if (key == null) ThrowHelper.ArgumentNullException_key();
@@ -134,7 +134,7 @@ namespace Markdig.Syntax
         /// </summary>
         /// <param name="key">The key.</param>
         /// <returns><c>true</c> if the data was removed; <c>false</c> otherwise</returns>
-        /// <exception cref="System.ArgumentNullException"></exception>
+        /// <exception cref="ArgumentNullException"></exception>
         public bool RemoveData(object key)
         {
             if (key == null) ThrowHelper.ArgumentNullException_key();

--- a/src/Markdig/Syntax/ParagraphBlock.cs
+++ b/src/Markdig/Syntax/ParagraphBlock.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 
 namespace Markdig.Syntax

--- a/src/Markdig/Syntax/QuoteBlock.cs
+++ b/src/Markdig/Syntax/QuoteBlock.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 
 namespace Markdig.Syntax

--- a/src/Markdig/Syntax/QuoteBlock.cs
+++ b/src/Markdig/Syntax/QuoteBlock.cs
@@ -8,7 +8,7 @@ namespace Markdig.Syntax
     /// <summary>
     /// A block quote (Section 5.1 CommonMark specs)
     /// </summary>
-    /// <seealso cref="Markdig.Syntax.ContainerBlock" />
+    /// <seealso cref="ContainerBlock" />
     public class QuoteBlock : ContainerBlock
     {
         /// <summary>

--- a/src/Markdig/Syntax/ThematicBreakBlock.cs
+++ b/src/Markdig/Syntax/ThematicBreakBlock.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
+
 using Markdig.Parsers;
 
 namespace Markdig.Syntax

--- a/src/UnicodeNormDApp/Program.cs
+++ b/src/UnicodeNormDApp/Program.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Text;
 

--- a/src/mdtoc/Program.cs
+++ b/src/mdtoc/Program.cs
@@ -37,8 +37,7 @@ namespace mdtoc
             string markdown = null;
             if (path.StartsWith("https:"))
             {
-                Uri uri;
-                if (!Uri.TryCreate(path, UriKind.Absolute, out uri))
+                if (!Uri.TryCreate(path, UriKind.Absolute, out Uri uri))
                 {
                     Error($"Unable to parse Uri `{path}`");
                     return;


### PR DESCRIPTION
Added missing license headers, removed unused usings, simplified and fixed cref/summary warnings, some pattern matching and inline variable declarations.

Build warnings: 436 => 0.

No logic changes.