### PR TITLE
Bug/parsing math

### DIFF
--- a/src/Markdig.WebApp/ApiController.cs
+++ b/src/Markdig.WebApp/ApiController.cs
@@ -13,7 +13,7 @@ namespace Markdig.WebApp
             return string.Empty;
         }
 
-        // GET api/to_html?text=xxx&extensions=advanced
+        // GET api/to_html?text=xxx&extension=advanced
         [Route("api/to_html")]
         [HttpGet()]
         public object Get([FromQuery] string text, [FromQuery] string extension)

--- a/src/Markdig/Extensions/Mathematics/MathInlineParser.cs
+++ b/src/Markdig/Extensions/Mathematics/MathInlineParser.cs
@@ -50,14 +50,12 @@ namespace Markdig.Extensions.Mathematics
                 c = slice.NextChar();
             }
 
-            bool openNextIsDigit = c.IsDigit();
             pc.CheckUnicodeCategory(out bool openPrevIsWhiteSpace, out bool openPrevIsPunctuation);
             c.CheckUnicodeCategory(out bool openNextIsWhiteSpace, out _);
 
             // Check that opening $/$$ is correct, using the different heuristics than for emphasis delimiters
-            // If a $/$$ is not preceded by a whitespace or punctuation, or followed by a digit
-            // this is a not a math block
-            if ((!openPrevIsWhiteSpace && !openPrevIsPunctuation) || openNextIsDigit)
+            // If a $/$$ is not preceded by a whitespace or punctuation, this is a not a math block
+            if ((!openPrevIsWhiteSpace && !openPrevIsPunctuation))
             {
                 return false;
             }


### PR DESCRIPTION
This fixes [#451](https://github.com/lunet-io/markdig/issues/451)

Before my change the parser would look to see if the next character after the $ or $$ was a digit. It would then fail to match if it _was_ a digit, which means that `$x$` would be a valid math block but `$2x$` would not be. 

I simply removed this check as `$2x$` should be valid, but it still allows `$ 2x $` in order to be backwards compatible.

I also changed the WebApi project comment that specified that the second parameter should be **extensions**, where as actually it should just be **extension** as per the controller method definition. This confused me when I was trying to replicate the bug.