### PR TITLE
Autolink tel: uri

### DIFF
--- a/src/Markdig.Tests/Specs/AutoLinks.generated.cs
+++ b/src/Markdig.Tests/Specs/AutoLinks.generated.cs
@@ -1,4 +1,4 @@
-// Generated: 2019-04-05 16:06:14
+// Generated: 2020-07-21 22:02:10
 
 // --------------------------------
 //            Auto Links
@@ -23,6 +23,7 @@ namespace Markdig.Tests.Specs.AutoLinks
         // - `http://` or `https://` 
         // - `ftp://`
         // - `mailto:`
+        // - `tel:`
         // - `www.` 
         [Test]
         public void ExtensionsAutoLinks_Example001()
@@ -34,16 +35,18 @@ namespace Markdig.Tests.Specs.AutoLinks
             //     This is a http://www.google.com URL and https://www.google.com
             //     This is a ftp://test.com
             //     And a mailto:email@toto.com
+            //     And a tel:+1555123456
             //     And a plain www.google.com
             //
             // Should be rendered as:
             //     <p>This is a <a href="http://www.google.com">http://www.google.com</a> URL and <a href="https://www.google.com">https://www.google.com</a>
             //     This is a <a href="ftp://test.com">ftp://test.com</a>
             //     And a <a href="mailto:email@toto.com">email@toto.com</a>
+            //     And a <a href="tel:+1555123456">+1555123456</a>
             //     And a plain <a href="http://www.google.com">www.google.com</a></p>
 
             Console.WriteLine("Example 1\nSection Extensions / AutoLinks\n");
-            TestParser.TestSpec("This is a http://www.google.com URL and https://www.google.com\nThis is a ftp://test.com\nAnd a mailto:email@toto.com\nAnd a plain www.google.com", "<p>This is a <a href=\"http://www.google.com\">http://www.google.com</a> URL and <a href=\"https://www.google.com\">https://www.google.com</a>\nThis is a <a href=\"ftp://test.com\">ftp://test.com</a>\nAnd a <a href=\"mailto:email@toto.com\">email@toto.com</a>\nAnd a plain <a href=\"http://www.google.com\">www.google.com</a></p>", "autolinks|advanced");
+            TestParser.TestSpec("This is a http://www.google.com URL and https://www.google.com\nThis is a ftp://test.com\nAnd a mailto:email@toto.com\nAnd a tel:+1555123456\nAnd a plain www.google.com", "<p>This is a <a href=\"http://www.google.com\">http://www.google.com</a> URL and <a href=\"https://www.google.com\">https://www.google.com</a>\nThis is a <a href=\"ftp://test.com\">ftp://test.com</a>\nAnd a <a href=\"mailto:email@toto.com\">email@toto.com</a>\nAnd a <a href=\"tel:+1555123456\">+1555123456</a>\nAnd a plain <a href=\"http://www.google.com\">www.google.com</a></p>", "autolinks|advanced");
         }
 
         // But incomplete links will not be matched:

--- a/src/Markdig.Tests/Specs/AutoLinks.md
+++ b/src/Markdig.Tests/Specs/AutoLinks.md
@@ -9,17 +9,20 @@ Autolinks will format as a HTML link any string that starts by:
 - `http://` or `https://` 
 - `ftp://`
 - `mailto:`
+- `tel:`
 - `www.` 
  
 ```````````````````````````````` example
 This is a http://www.google.com URL and https://www.google.com
 This is a ftp://test.com
 And a mailto:email@toto.com
+And a tel:+1555123456
 And a plain www.google.com
 .
 <p>This is a <a href="http://www.google.com">http://www.google.com</a> URL and <a href="https://www.google.com">https://www.google.com</a>
 This is a <a href="ftp://test.com">ftp://test.com</a>
 And a <a href="mailto:email@toto.com">email@toto.com</a>
+And a <a href="tel:+1555123456">+1555123456</a>
 And a plain <a href="http://www.google.com">www.google.com</a></p>
 ````````````````````````````````
 

--- a/src/Markdig/Extensions/AutoLinks/AutoLinkParser.cs
+++ b/src/Markdig/Extensions/AutoLinks/AutoLinkParser.cs
@@ -29,6 +29,7 @@ namespace Markdig.Extensions.AutoLinks
                 'h', // for http:// and https://
                 'f', // for ftp://
                 'm', // for mailto:
+                't', // for tel:
                 'w', // for www.
             };
 
@@ -88,7 +89,13 @@ namespace Markdig.Extensions.AutoLinks
                             return false;
                         }
                         break;
-
+                    case 't':
+                        if (!slice.MatchLowercase("el:", 1))
+                        {
+                            return false;
+                        }
+                        domainOffset = 4;
+                        break;
                     case 'w':
                         if (!slice.MatchLowercase("ww.", 1)) // We won't match http:/www. or /www.xxx
                         {
@@ -98,7 +105,6 @@ namespace Markdig.Extensions.AutoLinks
                         break;
                 }
 
-                // Parse URL
                 if (!LinkHelper.TryParseUrl(ref slice, out string link, true))
                 {
                     return false;
@@ -152,7 +158,8 @@ namespace Markdig.Extensions.AutoLinks
                         break;
                 }
 
-                if (!LinkHelper.IsValidDomain(link, domainOffset))
+                // Do not need to check if a telephone number is a valid domain
+                if (c != 't' && !LinkHelper.IsValidDomain(link, domainOffset))
                 {
                     return false;
                 }
@@ -171,6 +178,7 @@ namespace Markdig.Extensions.AutoLinks
                 };
 
                 var skipFromBeginning = c == 'm' ? 7 : 0; // For mailto: skip "mailto:" for content
+                skipFromBeginning = c == 't' ? 4 : skipFromBeginning; // See above but for tel:
 
                 inline.Span.End = inline.Span.Start + link.Length - 1;
                 inline.UrlSpan = inline.Span;


### PR DESCRIPTION
This fixes [437](https://github.com/lunet-io/markdig/issues/437)

Extends autolink functionality to be able to deal with tel:+1234567890.
Includes test.