### PR TITLE
Pipe Tables: Normalize using header column count

### DIFF
--- a/src/Markdig.Tests/Specs/PipeTableGfmSpecs.generated.cs
+++ b/src/Markdig.Tests/Specs/PipeTableGfmSpecs.generated.cs
@@ -1,22 +1,24 @@
-// Generated: 2020-07-30 15:32:13
+// Generated: 2020-07-30 15:47:38
 
 // --------------------------------
-//            Pipe Tables
+//          GFM Pipe Tables
 // --------------------------------
 
 using System;
 using NUnit.Framework;
 
-namespace Markdig.Tests.Specs.PipeTables
+namespace Markdig.Tests.Specs.GFMPipeTables
 {
     [TestFixture]
-    public class TestExtensionsPipeTable
+    public class TestExtensionsGfmPipeTable
     {
         // # Extensions
         // 
         // This section describes the different extensions supported:
         // 
-        // ## Pipe Table
+        // ## Gfm Pipe Table
+        // 
+        // This groups a certain set of behaviors that makes pipe tables adhere more strictly to the GitHub-flavored Markdown specification.
         // 
         // A pipe table is detected when:
         // 
@@ -31,10 +33,10 @@ namespace Markdig.Tests.Specs.PipeTables
         //  
         // Because a list has a higher precedence than a pipe table, a table header row separator requires at least 2 dashes `--` to start a header row:
         [Test]
-        public void ExtensionsPipeTable_Example001()
+        public void ExtensionsGfmPipeTable_Example001()
         {
             // Example 1
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     a | b
@@ -57,16 +59,16 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </tbody>
             //     </table>
 
-            Console.WriteLine("Example 1\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("a | b\n-- | -\n0 | 1", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 1\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("a | b\n-- | -\n0 | 1", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "gfm-pipetables");
         }
 
         // The following is also considered as a table, even if the second line starts like a list:
         [Test]
-        public void ExtensionsPipeTable_Example002()
+        public void ExtensionsGfmPipeTable_Example002()
         {
             // Example 2
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     a | b
@@ -89,16 +91,16 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </tbody>
             //     </table>
 
-            Console.WriteLine("Example 2\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("a | b\n- | -\n0 | 1", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 2\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("a | b\n- | -\n0 | 1", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "gfm-pipetables");
         }
 
         // A pipe table with only one header row is allowed:
         [Test]
-        public void ExtensionsPipeTable_Example003()
+        public void ExtensionsGfmPipeTable_Example003()
         {
             // Example 3
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     a | b
@@ -114,16 +116,16 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </thead>
             //     </table>
 
-            Console.WriteLine("Example 3\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("a | b\n-- | --", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 3\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("a | b\n-- | --", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n</table>", "gfm-pipetables");
         }
 
         // After a row separator header, they will be interpreted as plain column:
         [Test]
-        public void ExtensionsPipeTable_Example004()
+        public void ExtensionsGfmPipeTable_Example004()
         {
             // Example 4
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     a | b
@@ -146,16 +148,16 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </tbody>
             //     </table>
 
-            Console.WriteLine("Example 4\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("a | b\n-- | --\n-- | --", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>--</td>\n<td>--</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 4\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("a | b\n-- | --\n-- | --", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>--</td>\n<td>--</td>\n</tr>\n</tbody>\n</table>", "gfm-pipetables");
         }
 
         // But if a table doesn't start with a column delimiter, it is not interpreted as a table, even if following lines have a column delimiter
         [Test]
-        public void ExtensionsPipeTable_Example005()
+        public void ExtensionsGfmPipeTable_Example005()
         {
             // Example 5
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     a b
@@ -167,16 +169,16 @@ namespace Markdig.Tests.Specs.PipeTables
             //     c | d
             //     e | f</p>
 
-            Console.WriteLine("Example 5\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("a b\nc | d\ne | f", "<p>a b\nc | d\ne | f</p>", "pipetables|advanced");
+            Console.WriteLine("Example 5\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("a b\nc | d\ne | f", "<p>a b\nc | d\ne | f</p>", "gfm-pipetables");
         }
 
         // If a line doesn't have a column delimiter `|` the table is not detected
         [Test]
-        public void ExtensionsPipeTable_Example006()
+        public void ExtensionsGfmPipeTable_Example006()
         {
             // Example 6
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     a | b
@@ -186,16 +188,16 @@ namespace Markdig.Tests.Specs.PipeTables
             //     <p>a | b
             //     c no d</p>
 
-            Console.WriteLine("Example 6\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("a | b\nc no d", "<p>a | b\nc no d</p>", "pipetables|advanced");
+            Console.WriteLine("Example 6\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("a | b\nc no d", "<p>a | b\nc no d</p>", "gfm-pipetables");
         }
 
-        // If a row contains more column than the header row, it will still be added as a column:
+        // If a row contains more columns than the header row, the extra columns will be ignored:
         [Test]
-        public void ExtensionsPipeTable_Example007()
+        public void ExtensionsGfmPipeTable_Example007()
         {
             // Example 7
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     a  | b 
@@ -210,30 +212,26 @@ namespace Markdig.Tests.Specs.PipeTables
             //     <tr>
             //     <th>a</th>
             //     <th>b</th>
-            //     <th></th>
             //     </tr>
             //     </thead>
             //     <tbody>
             //     <tr>
             //     <td>0</td>
             //     <td>1</td>
-            //     <td>2</td>
             //     </tr>
             //     <tr>
             //     <td>3</td>
             //     <td>4</td>
-            //     <td></td>
             //     </tr>
             //     <tr>
             //     <td>5</td>
-            //     <td></td>
             //     <td></td>
             //     </tr>
             //     </tbody>
             //     </table>
 
-            Console.WriteLine("Example 7\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("a  | b \n-- | --\n0  | 1 | 2\n3  | 4\n5  |", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n<th></th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n<td>2</td>\n</tr>\n<tr>\n<td>3</td>\n<td>4</td>\n<td></td>\n</tr>\n<tr>\n<td>5</td>\n<td></td>\n<td></td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 7\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("a  | b \n-- | --\n0  | 1 | 2\n3  | 4\n5  |", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n<tr>\n<td>3</td>\n<td>4</td>\n</tr>\n<tr>\n<td>5</td>\n<td></td>\n</tr>\n</tbody>\n</table>", "gfm-pipetables");
         }
 
         // **Rule #2**
@@ -242,10 +240,10 @@ namespace Markdig.Tests.Specs.PipeTables
         // **Rule #3**
         // A cell content is trimmed (start and end) from white-spaces.
         [Test]
-        public void ExtensionsPipeTable_Example008()
+        public void ExtensionsGfmPipeTable_Example008()
         {
             // Example 8
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     a          | b              |
@@ -268,17 +266,17 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </tbody>
             //     </table>
 
-            Console.WriteLine("Example 8\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("a          | b              |\n-- | --\n0      | 1       |", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 8\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("a          | b              |\n-- | --\n0      | 1       |", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "gfm-pipetables");
         }
 
         // **Rule #4**
         // Column delimiters `|` at the very beginning of a line or just before a line ending with only spaces and/or terminated by a newline can be omitted
         [Test]
-        public void ExtensionsPipeTable_Example009()
+        public void ExtensionsGfmPipeTable_Example009()
         {
             // Example 9
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //       a     | b     |
@@ -311,16 +309,16 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </tbody>
             //     </table>
 
-            Console.WriteLine("Example 9\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("  a     | b     |\n--      | --\n| 0     | 1\n| 2     | 3     |\n  4     | 5 ", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n<tr>\n<td>2</td>\n<td>3</td>\n</tr>\n<tr>\n<td>4</td>\n<td>5</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 9\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("  a     | b     |\n--      | --\n| 0     | 1\n| 2     | 3     |\n  4     | 5 ", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n<tr>\n<td>2</td>\n<td>3</td>\n</tr>\n<tr>\n<td>4</td>\n<td>5</td>\n</tr>\n</tbody>\n</table>", "gfm-pipetables");
         }
 
         // A pipe may be present at both the beginning/ending of each line:
         [Test]
-        public void ExtensionsPipeTable_Example010()
+        public void ExtensionsGfmPipeTable_Example010()
         {
             // Example 10
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     |a|b|
@@ -343,16 +341,16 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </tbody>
             //     </table>
 
-            Console.WriteLine("Example 10\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("|a|b|\n|-|-|\n|0|1|", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 10\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("|a|b|\n|-|-|\n|0|1|", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "gfm-pipetables");
         }
 
         // Or may be omitted on one side:
         [Test]
-        public void ExtensionsPipeTable_Example011()
+        public void ExtensionsGfmPipeTable_Example011()
         {
             // Example 11
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     a|b|
@@ -375,15 +373,15 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </tbody>
             //     </table>
 
-            Console.WriteLine("Example 11\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("a|b|\n-|-|\n0|1|", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 11\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("a|b|\n-|-|\n0|1|", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "gfm-pipetables");
         }
 
         [Test]
-        public void ExtensionsPipeTable_Example012()
+        public void ExtensionsGfmPipeTable_Example012()
         {
             // Example 12
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     |a|b
@@ -406,16 +404,16 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </tbody>
             //     </table>
 
-            Console.WriteLine("Example 12\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("|a|b\n|-|-\n|0|1", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 12\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("|a|b\n|-|-\n|0|1", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "gfm-pipetables");
         }
 
         // Single column table can be declared with lines starting only by a column delimiter: 
         [Test]
-        public void ExtensionsPipeTable_Example013()
+        public void ExtensionsGfmPipeTable_Example013()
         {
             // Example 13
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     | a
@@ -440,8 +438,8 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </tbody>
             //     </table>
 
-            Console.WriteLine("Example 13\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("| a\n| --\n| b\n| c ", "<table>\n<thead>\n<tr>\n<th>a</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>b</td>\n</tr>\n<tr>\n<td>c</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 13\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("| a\n| --\n| b\n| c ", "<table>\n<thead>\n<tr>\n<th>a</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>b</td>\n</tr>\n<tr>\n<td>c</td>\n</tr>\n</tbody>\n</table>", "gfm-pipetables");
         }
 
         // **Rule #5**
@@ -454,10 +452,10 @@ namespace Markdig.Tests.Specs.PipeTables
         // - followed by an optional `:` to specify right align (or center align if left align is also defined)
         // - ending by optional spaces
         [Test]
-        public void ExtensionsPipeTable_Example014()
+        public void ExtensionsGfmPipeTable_Example014()
         {
             // Example 14
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //      a     | b 
@@ -485,18 +483,18 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </tbody>
             //     </table>
 
-            Console.WriteLine("Example 14\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec(" a     | b \n-------|-------\n 0     | 1 \n 2     | 3 ", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n<tr>\n<td>2</td>\n<td>3</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 14\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec(" a     | b \n-------|-------\n 0     | 1 \n 2     | 3 ", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n<tr>\n<td>2</td>\n<td>3</td>\n</tr>\n</tbody>\n</table>", "gfm-pipetables");
         }
 
         // The text alignment is defined by default to be center for header and left for cells. If the left alignment is applied, it will force the column heading to be left aligned.
         // There is no way to define a different alignment for heading and cells (apart from the default).
         // The text alignment can be changed by using the character `:` with the header column separator:
         [Test]
-        public void ExtensionsPipeTable_Example015()
+        public void ExtensionsGfmPipeTable_Example015()
         {
             // Example 15
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //      a     | b       | c 
@@ -527,16 +525,16 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </tbody>
             //     </table>
 
-            Console.WriteLine("Example 15\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec(" a     | b       | c \n:------|:-------:| ----:\n 0     | 1       | 2 \n 3     | 4       | 5 ", "<table>\n<thead>\n<tr>\n<th style=\"text-align: left;\">a</th>\n<th style=\"text-align: center;\">b</th>\n<th style=\"text-align: right;\">c</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: left;\">0</td>\n<td style=\"text-align: center;\">1</td>\n<td style=\"text-align: right;\">2</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\">3</td>\n<td style=\"text-align: center;\">4</td>\n<td style=\"text-align: right;\">5</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 15\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec(" a     | b       | c \n:------|:-------:| ----:\n 0     | 1       | 2 \n 3     | 4       | 5 ", "<table>\n<thead>\n<tr>\n<th style=\"text-align: left;\">a</th>\n<th style=\"text-align: center;\">b</th>\n<th style=\"text-align: right;\">c</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: left;\">0</td>\n<td style=\"text-align: center;\">1</td>\n<td style=\"text-align: right;\">2</td>\n</tr>\n<tr>\n<td style=\"text-align: left;\">3</td>\n<td style=\"text-align: center;\">4</td>\n<td style=\"text-align: right;\">5</td>\n</tr>\n</tbody>\n</table>", "gfm-pipetables");
         }
 
         // Test alignment with starting and ending pipes:
         [Test]
-        public void ExtensionsPipeTable_Example016()
+        public void ExtensionsGfmPipeTable_Example016()
         {
             // Example 16
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     | abc | def | ghi |
@@ -561,16 +559,16 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </tbody>
             //     </table>
 
-            Console.WriteLine("Example 16\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("| abc | def | ghi |\n|:---:|-----|----:|\n|  1  | 2   | 3   |", "<table>\n<thead>\n<tr>\n<th style=\"text-align: center;\">abc</th>\n<th>def</th>\n<th style=\"text-align: right;\">ghi</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: center;\">1</td>\n<td>2</td>\n<td style=\"text-align: right;\">3</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 16\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("| abc | def | ghi |\n|:---:|-----|----:|\n|  1  | 2   | 3   |", "<table>\n<thead>\n<tr>\n<th style=\"text-align: center;\">abc</th>\n<th>def</th>\n<th style=\"text-align: right;\">ghi</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align: center;\">1</td>\n<td>2</td>\n<td style=\"text-align: right;\">3</td>\n</tr>\n</tbody>\n</table>", "gfm-pipetables");
         }
 
         // The following example shows a non matching header column separator:
         [Test]
-        public void ExtensionsPipeTable_Example017()
+        public void ExtensionsGfmPipeTable_Example017()
         {
             // Example 17
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //      a     | b
@@ -584,18 +582,18 @@ namespace Markdig.Tests.Specs.PipeTables
             //     0     | 1
             //     2     | 3</p> 
 
-            Console.WriteLine("Example 17\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec(" a     | b\n-------|---x---\n 0     | 1\n 2     | 3 ", "<p>a     | b\n-------|---x---\n0     | 1\n2     | 3</p> ", "pipetables|advanced");
+            Console.WriteLine("Example 17\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec(" a     | b\n-------|---x---\n 0     | 1\n 2     | 3 ", "<p>a     | b\n-------|---x---\n0     | 1\n2     | 3</p> ", "gfm-pipetables");
         }
 
         // **Rule #6**
         // 
         // A column delimiter has a higher priority than emphasis delimiter
         [Test]
-        public void ExtensionsPipeTable_Example018()
+        public void ExtensionsGfmPipeTable_Example018()
         {
             // Example 18
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //      *a*   | b
@@ -623,18 +621,18 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </tbody>
             //     </table>
 
-            Console.WriteLine("Example 18\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec(" *a*   | b\n-----  |-----\n 0     | _1_\n _2    | 3* ", "<table>\n<thead>\n<tr>\n<th><em>a</em></th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td><em>1</em></td>\n</tr>\n<tr>\n<td>_2</td>\n<td>3*</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 18\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec(" *a*   | b\n-----  |-----\n 0     | _1_\n _2    | 3* ", "<table>\n<thead>\n<tr>\n<th><em>a</em></th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td><em>1</em></td>\n</tr>\n<tr>\n<td>_2</td>\n<td>3*</td>\n</tr>\n</tbody>\n</table>", "gfm-pipetables");
         }
 
         // **Rule #7**
         // 
         // A backtick/code delimiter has a higher precedence than a column delimiter `|`:
         [Test]
-        public void ExtensionsPipeTable_Example019()
+        public void ExtensionsGfmPipeTable_Example019()
         {
             // Example 19
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     a | b `
@@ -643,18 +641,18 @@ namespace Markdig.Tests.Specs.PipeTables
             // Should be rendered as:
             //     <p>a | b <code>0 |</code></p> 
 
-            Console.WriteLine("Example 19\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("a | b `\n0 | ` ", "<p>a | b <code>0 |</code></p> ", "pipetables|advanced");
+            Console.WriteLine("Example 19\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("a | b `\n0 | ` ", "<p>a | b <code>0 |</code></p> ", "gfm-pipetables");
         }
 
         // **Rule #8**
         // 
         // A HTML inline has a higher precedence than a column delimiter `|`: 
         [Test]
-        public void ExtensionsPipeTable_Example020()
+        public void ExtensionsGfmPipeTable_Example020()
         {
             // Example 20
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     a <a href="" title="|"></a> | b
@@ -677,18 +675,18 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </tbody>
             //     </table>
 
-            Console.WriteLine("Example 20\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("a <a href=\"\" title=\"|\"></a> | b\n-- | --\n0  | 1", "<table>\n<thead>\n<tr>\n<th>a <a href=\"\" title=\"|\"></a></th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 20\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("a <a href=\"\" title=\"|\"></a> | b\n-- | --\n0  | 1", "<table>\n<thead>\n<tr>\n<th>a <a href=\"\" title=\"|\"></a></th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "gfm-pipetables");
         }
 
         // **Rule #9**
         // 
         // Links have a higher precedence than the column delimiter character `|`:
         [Test]
-        public void ExtensionsPipeTable_Example021()
+        public void ExtensionsGfmPipeTable_Example021()
         {
             // Example 21
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     a  | b
@@ -711,18 +709,18 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </tbody>
             //     </table>
 
-            Console.WriteLine("Example 21\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("a  | b\n-- | --\n[This is a link with a | inside the label](http://google.com) | 1", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td><a href=\"http://google.com\">This is a link with a | inside the label</a></td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 21\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("a  | b\n-- | --\n[This is a link with a | inside the label](http://google.com) | 1", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td><a href=\"http://google.com\">This is a link with a | inside the label</a></td>\n<td>1</td>\n</tr>\n</tbody>\n</table>", "gfm-pipetables");
         }
 
         // **Rule #10**
         // 
         // It is possible to have a single row header only:
         [Test]
-        public void ExtensionsPipeTable_Example022()
+        public void ExtensionsGfmPipeTable_Example022()
         {
             // Example 22
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     a  | b
@@ -738,15 +736,15 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </thead>
             //     </table>
 
-            Console.WriteLine("Example 22\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("a  | b\n-- | --", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 22\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("a  | b\n-- | --", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n</table>", "gfm-pipetables");
         }
 
         [Test]
-        public void ExtensionsPipeTable_Example023()
+        public void ExtensionsGfmPipeTable_Example023()
         {
             // Example 23
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     |a|b|c
@@ -763,18 +761,18 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </thead>
             //     </table>
 
-            Console.WriteLine("Example 23\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("|a|b|c\n|---|---|---|", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n<th>c</th>\n</tr>\n</thead>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 23\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("|a|b|c\n|---|---|---|", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n<th>c</th>\n</tr>\n</thead>\n</table>", "gfm-pipetables");
         }
 
         // **Tests**
         // 
         // Tests trailing spaces after pipes
         [Test]
-        public void ExtensionsPipeTable_Example024()
+        public void ExtensionsGfmPipeTable_Example024()
         {
             // Example 24
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     | abc | def | 
@@ -812,23 +810,25 @@ namespace Markdig.Tests.Specs.PipeTables
             //     </tbody>
             //     </table>
 
-            Console.WriteLine("Example 24\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("| abc | def | \n|---|---|\n| cde| ddd| \n| eee| fff|\n| fff | fffff   | \n|gggg  | ffff | ", "<table>\n<thead>\n<tr>\n<th>abc</th>\n<th>def</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>cde</td>\n<td>ddd</td>\n</tr>\n<tr>\n<td>eee</td>\n<td>fff</td>\n</tr>\n<tr>\n<td>fff</td>\n<td>fffff</td>\n</tr>\n<tr>\n<td>gggg</td>\n<td>ffff</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 24\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("| abc | def | \n|---|---|\n| cde| ddd| \n| eee| fff|\n| fff | fffff   | \n|gggg  | ffff | ", "<table>\n<thead>\n<tr>\n<th>abc</th>\n<th>def</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>cde</td>\n<td>ddd</td>\n</tr>\n<tr>\n<td>eee</td>\n<td>fff</td>\n</tr>\n<tr>\n<td>fff</td>\n<td>fffff</td>\n</tr>\n<tr>\n<td>gggg</td>\n<td>ffff</td>\n</tr>\n</tbody>\n</table>", "gfm-pipetables");
         }
 
         // **Normalized columns count**
         // 
-        // The tables are normalized to the maximum number of columns found in a table
+        // The tables are normalized to the number of columns found in the table header.
+        // Extra columns will be ignored, missing columns will be inserted.
         [Test]
-        public void ExtensionsPipeTable_Example025()
+        public void ExtensionsGfmPipeTable_Example025()
         {
             // Example 25
-            // Section: Extensions / Pipe Table
+            // Section: Extensions / Gfm Pipe Table
             //
             // The following Markdown:
             //     a | b
             //     -- | - 
             //     0 | 1 | 2
+            //     3 |
             //
             // Should be rendered as:
             //     <table>
@@ -836,20 +836,22 @@ namespace Markdig.Tests.Specs.PipeTables
             //     <tr>
             //     <th>a</th>
             //     <th>b</th>
-            //     <th></th>
             //     </tr>
             //     </thead>
             //     <tbody>
             //     <tr>
             //     <td>0</td>
             //     <td>1</td>
-            //     <td>2</td>
+            //     </tr>
+            //     <tr>
+            //     <td>3</td>
+            //     <td></td>
             //     </tr>
             //     </tbody>
             //     </table>
 
-            Console.WriteLine("Example 25\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("a | b\n-- | - \n0 | 1 | 2", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n<th></th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n<td>2</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            Console.WriteLine("Example 25\nSection Extensions / Gfm Pipe Table\n");
+            TestParser.TestSpec("a | b\n-- | - \n0 | 1 | 2\n3 |", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n<tr>\n<td>3</td>\n<td></td>\n</tr>\n</tbody>\n</table>", "gfm-pipetables");
         }
     }
 }

--- a/src/Markdig.Tests/Specs/PipeTableGfmSpecs.md
+++ b/src/Markdig.Tests/Specs/PipeTableGfmSpecs.md
@@ -2,7 +2,9 @@
 
 This section describes the different extensions supported:
 
-## Pipe Table
+## Gfm Pipe Table
+
+This groups a certain set of behaviors that makes pipe tables adhere more strictly to the GitHub-flavored Markdown specification.
 
 A pipe table is detected when:
 
@@ -122,7 +124,7 @@ c no d
 c no d</p>
 ````````````````````````````````
 
-If a row contains more column than the header row, it will still be added as a column:
+If a row contains more columns than the header row, the extra columns will be ignored:
 
 ```````````````````````````````` example
 a  | b 
@@ -136,23 +138,19 @@ a  | b
 <tr>
 <th>a</th>
 <th>b</th>
-<th></th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td>0</td>
 <td>1</td>
-<td>2</td>
 </tr>
 <tr>
 <td>3</td>
 <td>4</td>
-<td></td>
 </tr>
 <tr>
 <td>5</td>
-<td></td>
 <td></td>
 </tr>
 </tbody>
@@ -588,27 +586,31 @@ Tests trailing spaces after pipes
 
 **Normalized columns count**
 
-The tables are normalized to the maximum number of columns found in a table
+The tables are normalized to the number of columns found in the table header.
+Extra columns will be ignored, missing columns will be inserted.
 
 
 ```````````````````````````````` example
 a | b
 -- | - 
 0 | 1 | 2
+3 |
 .
 <table>
 <thead>
 <tr>
 <th>a</th>
 <th>b</th>
-<th></th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td>0</td>
 <td>1</td>
-<td>2</td>
+</tr>
+<tr>
+<td>3</td>
+<td></td>
 </tr>
 </tbody>
 </table>

--- a/src/Markdig.Tests/Specs/PipeTableSpecs.generated.cs
+++ b/src/Markdig.Tests/Specs/PipeTableSpecs.generated.cs
@@ -1,4 +1,4 @@
-// Generated: 2020-07-30 12:13:52
+// Generated: 2020-07-30 12:54:54
 
 // --------------------------------
 //            Pipe Tables
@@ -190,7 +190,7 @@ namespace Markdig.Tests.Specs.PipeTables
             TestParser.TestSpec("a | b\nc no d", "<p>a | b\nc no d</p>", "pipetables|advanced");
         }
 
-        // If a row contains more column than the header row, it will still be added as a column:
+        // If a row contains more columns than the header row, the extra columns will be ignored:
         [Test]
         public void ExtensionsPipeTable_Example007()
         {
@@ -210,30 +210,26 @@ namespace Markdig.Tests.Specs.PipeTables
             //     <tr>
             //     <th>a</th>
             //     <th>b</th>
-            //     <th></th>
             //     </tr>
             //     </thead>
             //     <tbody>
             //     <tr>
             //     <td>0</td>
             //     <td>1</td>
-            //     <td>2</td>
             //     </tr>
             //     <tr>
             //     <td>3</td>
             //     <td>4</td>
-            //     <td></td>
             //     </tr>
             //     <tr>
             //     <td>5</td>
-            //     <td></td>
             //     <td></td>
             //     </tr>
             //     </tbody>
             //     </table>
 
             Console.WriteLine("Example 7\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("a  | b \n-- | --\n0  | 1 | 2\n3  | 4\n5  |", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n<th></th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n<td>2</td>\n</tr>\n<tr>\n<td>3</td>\n<td>4</td>\n<td></td>\n</tr>\n<tr>\n<td>5</td>\n<td></td>\n<td></td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            TestParser.TestSpec("a  | b \n-- | --\n0  | 1 | 2\n3  | 4\n5  |", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n<tr>\n<td>3</td>\n<td>4</td>\n</tr>\n<tr>\n<td>5</td>\n<td></td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
 
         // **Rule #2**

--- a/src/Markdig.Tests/Specs/PipeTableSpecs.generated.cs
+++ b/src/Markdig.Tests/Specs/PipeTableSpecs.generated.cs
@@ -1,4 +1,4 @@
-// Generated: 2020-04-20 07:21:20
+// Generated: 2020-07-30 12:13:52
 
 // --------------------------------
 //            Pipe Tables
@@ -818,7 +818,8 @@ namespace Markdig.Tests.Specs.PipeTables
 
         // **Normalized columns count**
         // 
-        // The tables are normalized to the maximum number of columns found in a table
+        // The tables are normalized to the number of columns found in the table header.
+        // Extra columns will be ignored, missing columns will be inserted.
         [Test]
         public void ExtensionsPipeTable_Example025()
         {
@@ -829,6 +830,7 @@ namespace Markdig.Tests.Specs.PipeTables
             //     a | b
             //     -- | - 
             //     0 | 1 | 2
+            //     3 |
             //
             // Should be rendered as:
             //     <table>
@@ -836,20 +838,22 @@ namespace Markdig.Tests.Specs.PipeTables
             //     <tr>
             //     <th>a</th>
             //     <th>b</th>
-            //     <th></th>
             //     </tr>
             //     </thead>
             //     <tbody>
             //     <tr>
             //     <td>0</td>
             //     <td>1</td>
-            //     <td>2</td>
+            //     </tr>
+            //     <tr>
+            //     <td>3</td>
+            //     <td></td>
             //     </tr>
             //     </tbody>
             //     </table>
 
             Console.WriteLine("Example 25\nSection Extensions / Pipe Table\n");
-            TestParser.TestSpec("a | b\n-- | - \n0 | 1 | 2", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n<th></th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n<td>2</td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
+            TestParser.TestSpec("a | b\n-- | - \n0 | 1 | 2\n3 |", "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n<tr>\n<td>3</td>\n<td></td>\n</tr>\n</tbody>\n</table>", "pipetables|advanced");
         }
     }
 }

--- a/src/Markdig.Tests/Specs/PipeTableSpecs.md
+++ b/src/Markdig.Tests/Specs/PipeTableSpecs.md
@@ -122,7 +122,7 @@ c no d
 c no d</p>
 ````````````````````````````````
 
-If a row contains more column than the header row, it will still be added as a column:
+If a row contains more columns than the header row, the extra columns will be ignored:
 
 ```````````````````````````````` example
 a  | b 
@@ -136,23 +136,19 @@ a  | b
 <tr>
 <th>a</th>
 <th>b</th>
-<th></th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td>0</td>
 <td>1</td>
-<td>2</td>
 </tr>
 <tr>
 <td>3</td>
 <td>4</td>
-<td></td>
 </tr>
 <tr>
 <td>5</td>
-<td></td>
 <td></td>
 </tr>
 </tbody>

--- a/src/Markdig.Tests/Specs/PipeTableSpecs.md
+++ b/src/Markdig.Tests/Specs/PipeTableSpecs.md
@@ -588,27 +588,31 @@ Tests trailing spaces after pipes
 
 **Normalized columns count**
 
-The tables are normalized to the maximum number of columns found in a table
+The tables are normalized to the number of columns found in the table header.
+Extra columns will be ignored, missing columns will be inserted.
 
 
 ```````````````````````````````` example
 a | b
 -- | - 
 0 | 1 | 2
+3 |
 .
 <table>
 <thead>
 <tr>
 <th>a</th>
 <th>b</th>
-<th></th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td>0</td>
 <td>1</td>
-<td>2</td>
+</tr>
+<tr>
+<td>3</td>
+<td></td>
 </tr>
 </tbody>
 </table>

--- a/src/Markdig/Extensions/Tables/PipeTableOptions.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableOptions.cs
@@ -15,7 +15,7 @@ namespace Markdig.Extensions.Tables
         public PipeTableOptions()
         {
             RequireHeaderSeparator = true;
-            UseHeaderForColumnCount = true;
+            UseHeaderForColumnCount = false;
         }
 
         /// <summary>

--- a/src/Markdig/Extensions/Tables/PipeTableOptions.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableOptions.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
-// This file is licensed under the BSD-Clause 2 license. 
+// This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
 namespace Markdig.Extensions.Tables
@@ -15,11 +15,23 @@ namespace Markdig.Extensions.Tables
         public PipeTableOptions()
         {
             RequireHeaderSeparator = true;
+            UseHeaderForColumnCount = true;
         }
 
         /// <summary>
         /// Gets or sets a value indicating whether to require header separator. <c>true</c> by default (Kramdown is using <c>false</c>)
         /// </summary>
         public bool RequireHeaderSeparator { get; set; }
+
+        /// <summary>
+        /// Defines whether table should be normalized to the amount of columns as defined in the table header.
+        /// <c>false</c> by default
+        ///
+        /// If <c>true</c>, this will insert empty cells in rows with fewer tables than the header row and remove cells
+        /// that are exceeding the header column count.
+        /// If <c>false</c>, this will use the row with the most columns to determine how many cells should be inserted
+        /// in all other rows (default behavior).
+        /// </summary>
+        public bool UseHeaderForColumnCount { get; set; }
     }
 }

--- a/src/Markdig/Extensions/Tables/PipeTableParser.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableParser.cs
@@ -457,7 +457,14 @@ namespace Markdig.Extensions.Tables
             cells.Clear();
 
             // Normalize the table
-            table.Normalize();
+            if (Options.UseHeaderForColumnCount)
+            {
+                table.NormalizeUsingHeaderRow();
+            }
+            else
+            {
+                table.NormalizeUsingMaxWidth();
+            }
 
             // We don't want to continue procesing delimiters, as we are already processing them here
             return false;

--- a/src/Markdig/Extensions/Tables/Table.cs
+++ b/src/Markdig/Extensions/Tables/Table.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
-// This file is licensed under the BSD-Clause 2 license. 
+// This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
 using System.Collections.Generic;
@@ -76,10 +76,38 @@ namespace Markdig.Extensions.Tables
         }
 
         /// <summary>
+        /// Normalizes the number of columns of this table by taking the maximum columns and appending empty cells.
+        /// </summary>
+        public void NormalizeUsingMaxWidth()
+        {
+            var maxColumn = 0;
+            for (int i = 0; i < this.Count; i++)
+            {
+                var row = this[i] as TableRow;
+                if (row != null && row.Count > maxColumn)
+                {
+                    maxColumn = row.Count;
+                }
+            }
+
+            for (int i = 0; i < this.Count; i++)
+            {
+                var row = this[i] as TableRow;
+                if (row != null)
+                {
+                    for (int j = row.Count; j < maxColumn; j++)
+                    {
+                        row.Add(new TableCell());
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Normalizes the number of columns of this table by taking the amount of columns defined in the header
         /// and appending empty cells or removing extra cells as needed.
         /// </summary>
-        public void Normalize()
+        public void NormalizeUsingHeaderRow()
         {
             if (this.Count == 0)
             {
@@ -87,6 +115,7 @@ namespace Markdig.Extensions.Tables
             }
 
             var maxColumn = 0;
+
             var headerRow = this[0] as TableRow;
             if (headerRow != null)
             {

--- a/src/Markdig/Extensions/Tables/Table.cs
+++ b/src/Markdig/Extensions/Tables/Table.cs
@@ -76,18 +76,21 @@ namespace Markdig.Extensions.Tables
         }
 
         /// <summary>
-        /// Normalizes the number of columns of this table by taking the maximum columns and appending empty cells.
+        /// Normalizes the number of columns of this table by taking the amount of columns defined in the header
+        /// and appending empty cells or removing extra cells as needed.
         /// </summary>
         public void Normalize()
         {
-            var maxColumn = 0;
-            for (int i = 0; i < this.Count; i++)
+            if (this.Count == 0)
             {
-                var row = this[i] as TableRow;
-                if (row != null && row.Count > maxColumn)
-                {
-                    maxColumn = row.Count;
-                }
+                return;
+            }
+
+            var maxColumn = 0;
+            var headerRow = this[0] as TableRow;
+            if (headerRow != null)
+            {
+                maxColumn = headerRow.Count;
             }
 
             for (int i = 0; i < this.Count; i++)
@@ -98,6 +101,11 @@ namespace Markdig.Extensions.Tables
                     for (int j = row.Count; j < maxColumn; j++)
                     {
                         row.Add(new TableCell());
+                    }
+
+                    for (int j = maxColumn; j < row.Count; j++)
+                    {
+                        row.RemoveAt(j);
                     }
                 }
             }

--- a/src/Markdig/MarkdownExtensions.cs
+++ b/src/Markdig/MarkdownExtensions.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
-// This file is licensed under the BSD-Clause 2 license. 
+// This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
 using System;
@@ -536,6 +536,9 @@ namespace Markdig
                         break;
                     case "pipetables":
                         pipeline.UsePipeTables();
+                        break;
+                    case "gfm-pipetables":
+                        pipeline.UsePipeTables(new PipeTableOptions { UseHeaderForColumnCount = true });
                         break;
                     case "emphasisextras":
                         pipeline.UseEmphasisExtras();

--- a/src/SpecFileGen/Program.cs
+++ b/src/SpecFileGen/Program.cs
@@ -58,6 +58,7 @@ namespace SpecFileGen
         {
             new Spec("CommonMark v. 0.29",  "CommonMark.md",                ""),
             new Spec("Pipe Tables",         "PipeTableSpecs.md",            "pipetables|advanced"),
+            new Spec("GFM Pipe Tables",     "PipeTableGfmSpecs.md",         "gfm-pipetables"),
             new Spec("Footnotes",           "FootnotesSpecs.md",            "footnotes|advanced"),
             new Spec("Generic Attributes",  "GenericAttributesSpecs.md",    "attributes|advanced"),
             new Spec("Emphasis Extra",      "EmphasisExtraSpecs.md",        "emphasisextras|advanced"),


### PR DESCRIPTION
This is a potential fix for #454.

In this PR I'm introducing `PipeTableOptions.UseHeaderForColumnCount`, an option that allows switching the PipeTables extension's normalization behavior. It's defaulting to the current behavior (find the row with the most columns and make sure all other rows have the same amount of cells). When setting this option to `true`, the normalization will follow the [example in GitHub's spec](https://github.github.com/gfm/#example-202) and remove/add cells in all rows until they match the number of cells in the header row.

I'm adding this as a draft PR for now since I need some guidance around the test suite:

Right now, I've changed the markdown example specs to conform to the new behavior and made the new behavior the default. Ideally, we'd have tests for both, the current and the new behavior - I just don't know how to do this. Does the markdown spec notation allow us to specify certain options to be used for the `MarkdownPipeline`? 