### PR TITLE
Write custom rel into links 

### DIFF
--- a/src/Markdig.Tests/TestReferralLinks.cs
+++ b/src/Markdig.Tests/TestReferralLinks.cs
@@ -1,0 +1,71 @@
+using NUnit.Framework;
+
+namespace Markdig.Tests
+{
+    [TestFixture]
+    public class TestReferralLinks
+    {
+        [Test]
+        public void TestLinksWithNoFollowRel()
+        {
+            var markdown = "[world](http://example.com)";
+            var expected = "nofollow";
+
+#pragma warning disable 0618
+            var pipeline = new MarkdownPipelineBuilder()
+                .UseNoFollowLinks()
+#pragma warning restore 0618
+                .Build();
+            var html = Markdown.ToHtml(markdown, pipeline);
+
+            Assert.That(html, Contains.Substring($"rel=\"{expected}\""));
+        }
+
+        [Test]
+        [TestCase(new[] { "nofollow" }, "nofollow")]
+        [TestCase(new[] { "noopener" }, "noopener")]
+        [TestCase(new[] { "nofollow", "noopener"}, "nofollow noopener")]
+        public void TestLinksWithCustomRel(string[] rels, string expected)
+        {
+            var markdown = "[world](http://example.com)";
+
+            var pipeline = new MarkdownPipelineBuilder()
+                .UseReferralLinks(rels)
+                .Build();
+            var html = Markdown.ToHtml(markdown, pipeline);
+
+            Assert.That(html, Contains.Substring($"rel=\"{expected}\""));
+        }
+
+
+        [Test]
+        public void TestLinksWithNullRel()
+        {
+            var markdown = "[world](http://example.com)";
+
+            var pipeline = new MarkdownPipelineBuilder()
+                .UseReferralLinks(null)
+                .Build();
+            var html = Markdown.ToHtml(markdown, pipeline);
+
+            Assert.That(html, !Contains.Substring("rel="));
+        }
+
+        [Test]
+        [TestCase(new[] { "noopener" }, "noopener")]
+        [TestCase(new[] { "nofollow" }, "nofollow")]
+        [TestCase(new[] { "nofollow", "noopener" }, "nofollow noopener")]
+        public void TestAutoLinksWithCustomRel(string[] rels, string expected)
+        {
+            var markdown = "http://example.com";
+
+            var pipeline = new MarkdownPipelineBuilder()
+                .UseAutoLinks()
+                .UseReferralLinks(rels)
+                .Build();
+            var html = Markdown.ToHtml(markdown, pipeline);
+
+            Assert.That(html, Contains.Substring($"rel=\"{expected}\""));
+        }
+    }
+}

--- a/src/Markdig/Extensions/NoRefLinks/NoFollowLinksExtension.cs
+++ b/src/Markdig/Extensions/NoRefLinks/NoFollowLinksExtension.cs
@@ -1,34 +1,33 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
+using Markdig.Extensions.ReferralLinks;
 using Markdig.Renderers;
-using Markdig.Renderers.Html.Inlines;
+using System;
 
 namespace Markdig.Extensions.NoRefLinks
 {
     /// <summary>
     /// Extension to automatically render rel=nofollow to all links in an HTML output.
     /// </summary>
+    [Obsolete("Use ReferralLinksExtension class instead")]
     public class NoFollowLinksExtension : IMarkdownExtension
     {
+        private ReferralLinksExtension _referralLinksExtension;
+
+        public NoFollowLinksExtension()
+        {
+            _referralLinksExtension = new ReferralLinksExtension(new[] { "nofollow" });
+        }
         public void Setup(MarkdownPipelineBuilder pipeline)
         {
+            _referralLinksExtension.Setup(pipeline);
         }
 
         public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
         {
-            var linkRenderer = renderer.ObjectRenderers.Find<LinkInlineRenderer>();
-            if (linkRenderer != null)
-            {
-                linkRenderer.AutoRelNoFollow = true;
-            }
-
-            var autolinkRenderer = renderer.ObjectRenderers.Find<AutolinkInlineRenderer>();
-            if (autolinkRenderer != null)
-            {
-                autolinkRenderer.AutoRelNoFollow = true;
-            }
+            _referralLinksExtension.Setup(pipeline, renderer);
         }
     }
 }

--- a/src/Markdig/Extensions/ReferralLinks/ReferralLinksExtension.cs
+++ b/src/Markdig/Extensions/ReferralLinks/ReferralLinksExtension.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+using Markdig.Renderers;
+using Markdig.Renderers.Html.Inlines;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Markdig.Extensions.ReferralLinks
+{
+    public class ReferralLinksExtension : IMarkdownExtension
+    {
+        public ReferralLinksExtension(string[] rels)
+        {
+            Rels = rels?.ToList();
+        }
+
+        public List<string> Rels { get; }
+
+        public void Setup(MarkdownPipelineBuilder pipeline)
+        {
+        }
+
+        public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
+        {
+            string relString = Rels == null? null :
+                string.Join(" ", Rels.Where(r => !string.IsNullOrEmpty(r)));
+
+            var linkRenderer = renderer.ObjectRenderers.Find<LinkInlineRenderer>();
+            if (linkRenderer != null)
+            {
+                linkRenderer.Rel = relString;
+            }
+
+            var autolinkRenderer = renderer.ObjectRenderers.Find<AutolinkInlineRenderer>();
+            if (autolinkRenderer != null)
+            {
+                autolinkRenderer.Rel = relString;
+            }
+        }
+    }
+}

--- a/src/Markdig/MarkdownExtensions.cs
+++ b/src/Markdig/MarkdownExtensions.cs
@@ -22,7 +22,6 @@ using Markdig.Extensions.JiraLinks;
 using Markdig.Extensions.ListExtras;
 using Markdig.Extensions.Mathematics;
 using Markdig.Extensions.MediaLinks;
-using Markdig.Extensions.NoRefLinks;
 using Markdig.Extensions.PragmaLines;
 using Markdig.Extensions.SelfPipeline;
 using Markdig.Extensions.SmartyPants;
@@ -35,6 +34,7 @@ using Markdig.Parsers;
 using Markdig.Parsers.Inlines;
 using Markdig.Extensions.Globalization;
 using Markdig.Helpers;
+using Markdig.Extensions.ReferralLinks;
 
 namespace Markdig
 {
@@ -457,9 +457,29 @@ namespace Markdig
         /// </summary>
         /// <param name="pipeline"></param>
         /// <returns></returns>
+        [Obsolete("Call `UseReferralLinks(\"nofollow\")` instead")]
         public static MarkdownPipelineBuilder UseNoFollowLinks(this MarkdownPipelineBuilder pipeline)
         {
-            pipeline.Extensions.AddIfNotAlready<NoFollowLinksExtension>();
+            return pipeline.UseReferralLinks("nofollow");
+        }
+
+        public static MarkdownPipelineBuilder UseReferralLinks(this MarkdownPipelineBuilder pipeline, params string[] rels)
+        {
+            if (!pipeline.Extensions.Contains<ReferralLinksExtension>())
+            {
+                pipeline.Extensions.Add(new ReferralLinksExtension(rels));
+            }
+            else
+            {
+                var referralLinksExtension = pipeline.Extensions.Find<ReferralLinksExtension>();
+                foreach(string rel in rels)
+                {
+                    if (!referralLinksExtension.Rels.Contains(rel))
+                    {
+                        referralLinksExtension.Rels.Add(rel);
+                    }
+                }
+            }
             return pipeline;
         }
 
@@ -601,7 +621,13 @@ namespace Markdig
                         pipeline.UseDiagrams();
                         break;
                     case "nofollowlinks":
-                        pipeline.UseNoFollowLinks();
+                        pipeline.UseReferralLinks("nofollow");
+                        break;
+                    case "noopenerlinks":
+                        pipeline.UseReferralLinks("noopener");
+                        break;
+                    case "noreferrerlinks":
+                        pipeline.UseReferralLinks("noreferrer");
                         break;
                     case "nohtml":
                         pipeline.DisableHtml();

--- a/src/Markdig/Renderers/Html/Inlines/AutolinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/AutolinkInlineRenderer.cs
@@ -3,6 +3,7 @@
 // See the license.txt file in the project root for more information.
 
 using Markdig.Syntax.Inlines;
+using System;
 
 namespace Markdig.Renderers.Html.Inlines
 {
@@ -15,7 +16,31 @@ namespace Markdig.Renderers.Html.Inlines
         /// <summary>
         /// Gets or sets a value indicating whether to always add rel="nofollow" for links or not.
         /// </summary>
-        public bool AutoRelNoFollow { get; set; }
+        [Obsolete("AutoRelNoFollow is obsolete. Please write \"nofollow\" into Property Rel.")]
+        public bool AutoRelNoFollow
+        {
+            get
+            {
+                return Rel.Contains("nofollow");
+            }
+            set
+            {
+                string rel = "nofollow";
+                if (value && !Rel.Contains(rel))
+                {
+                    Rel = string.IsNullOrEmpty(Rel) ? rel : Rel + $" {rel}";
+                }
+                else if(!value && Rel.Contains(rel))
+                {
+                    Rel = Rel.Replace(rel, string.Empty);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the literal string in property rel for links
+        /// </summary>
+        public string Rel { get; set; }
 
         protected override void Write(HtmlRenderer renderer, AutolinkInline obj)
         {
@@ -30,9 +55,9 @@ namespace Markdig.Renderers.Html.Inlines
                 renderer.Write('"');
                 renderer.WriteAttributes(obj);
 
-                if (!obj.IsEmail && AutoRelNoFollow)
+                if (!obj.IsEmail && !string.IsNullOrWhiteSpace(Rel))
                 {
-                    renderer.Write(" rel=\"nofollow\"");
+                    renderer.Write($" rel=\"{Rel}\"");
                 }
 
                 renderer.Write(">");

--- a/src/Markdig/Renderers/Html/Inlines/LinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LinkInlineRenderer.cs
@@ -3,6 +3,7 @@
 // See the license.txt file in the project root for more information.
 
 using Markdig.Syntax.Inlines;
+using System;
 
 namespace Markdig.Renderers.Html.Inlines
 {
@@ -15,7 +16,31 @@ namespace Markdig.Renderers.Html.Inlines
         /// <summary>
         /// Gets or sets a value indicating whether to always add rel="nofollow" for links or not.
         /// </summary>
-        public bool AutoRelNoFollow { get; set; }
+        [Obsolete("AutoRelNoFollow is obsolete. Please write \"nofollow\" into Property Rel.")]
+        public bool AutoRelNoFollow
+        {
+            get
+            {
+                return Rel.Contains("nofollow");
+            }
+            set
+            {
+                string rel = "nofollow";
+                if (value && !Rel.Contains(rel))
+                {
+                    Rel = string.IsNullOrEmpty(Rel) ? rel : Rel + $" {rel}";
+                }
+                else if (!value && Rel.Contains(rel))
+                {
+                    Rel = Rel.Replace(rel, string.Empty);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the literal string in property rel for links
+        /// </summary>
+        public string Rel { get; set; }
 
         protected override void Write(HtmlRenderer renderer, LinkInline link)
         {
@@ -60,9 +85,9 @@ namespace Markdig.Renderers.Html.Inlines
             {
                 if (renderer.EnableHtmlForInline)
                 {
-                    if (AutoRelNoFollow)
+                    if (!string.IsNullOrWhiteSpace(Rel))
                     {
-                        renderer.Write(" rel=\"nofollow\"");
+                        renderer.Write($" rel=\"{Rel}\"");
                     }
                     renderer.Write(">");
                 }


### PR DESCRIPTION
This fixes #456 .

It allows writing custom rel into links. More tests are added.

I think there are two things that needs to be confirmed.

1. I consider that the name `RelXXX` is much suitable than `ReferralXXX` mentioned in #456 . For example, `UseRelLinks` has a straightfoward meaning to set rel property in links. If so, I will make another change.

2. Considering compatibility, I didn't remove the parts related to "nofollow" rel in links. Instead, I marked the parts as obsolete, such as `NoFollowLinksExtension`. I don't know whether it is an acceptable way. 