### PR TITLE
Bring back net45 target

### DIFF
--- a/src/Markdig.Tests/Markdig.Tests.csproj
+++ b/src/Markdig.Tests/Markdig.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-  	<TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+  	<TargetFrameworks>net452;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Markdig.Tests/TestDescendantsOrder.cs
+++ b/src/Markdig.Tests/TestDescendantsOrder.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
+using Markdig.Helpers;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
-using System;
 using System.Linq;
 using System.Collections.Generic;
 
@@ -33,9 +33,9 @@ namespace Markdig.Tests
 
                 foreach (LiteralInline literalInline in syntaxTree.Descendants<LiteralInline>())
                 {
-                    Assert.AreSame(Array.Empty<ListBlock>(), literalInline.Descendants<ListBlock>());
-                    Assert.AreSame(Array.Empty<ParagraphBlock>(), literalInline.Descendants<ParagraphBlock>());
-                    Assert.AreSame(Array.Empty<ContainerInline>(), literalInline.Descendants<ContainerInline>());
+                    Assert.AreSame(ArrayHelper.Empty<ListBlock>(), literalInline.Descendants<ListBlock>());
+                    Assert.AreSame(ArrayHelper.Empty<ParagraphBlock>(), literalInline.Descendants<ParagraphBlock>());
+                    Assert.AreSame(ArrayHelper.Empty<ContainerInline>(), literalInline.Descendants<ContainerInline>());
                 }
 
                 foreach (ContainerInline containerInline in syntaxTree.Descendants<ContainerInline>())
@@ -50,13 +50,13 @@ namespace Markdig.Tests
 
                     if (containerInline.FirstChild is null)
                     {
-                        Assert.AreSame(Array.Empty<LiteralInline>(), containerInline.Descendants<LiteralInline>());
-                        Assert.AreSame(Array.Empty<LiteralInline>(), containerInline.FindDescendants<LiteralInline>());
-                        Assert.AreSame(Array.Empty<LiteralInline>(), (containerInline as MarkdownObject).Descendants<LiteralInline>());
+                        Assert.AreSame(ArrayHelper.Empty<LiteralInline>(), containerInline.Descendants<LiteralInline>());
+                        Assert.AreSame(ArrayHelper.Empty<LiteralInline>(), containerInline.FindDescendants<LiteralInline>());
+                        Assert.AreSame(ArrayHelper.Empty<LiteralInline>(), (containerInline as MarkdownObject).Descendants<LiteralInline>());
                     }
 
-                    Assert.AreSame(Array.Empty<ListBlock>(), containerInline.Descendants<ListBlock>());
-                    Assert.AreSame(Array.Empty<ParagraphBlock>(), containerInline.Descendants<ParagraphBlock>());
+                    Assert.AreSame(ArrayHelper.Empty<ListBlock>(), containerInline.Descendants<ListBlock>());
+                    Assert.AreSame(ArrayHelper.Empty<ParagraphBlock>(), containerInline.Descendants<ParagraphBlock>());
                 }
 
                 foreach (ParagraphBlock paragraphBlock in syntaxTree.Descendants<ParagraphBlock>())
@@ -65,7 +65,7 @@ namespace Markdig.Tests
                         (paragraphBlock as MarkdownObject).Descendants<LiteralInline>(),
                         paragraphBlock.Descendants<LiteralInline>());
 
-                    Assert.AreSame(Array.Empty<ParagraphBlock>(), paragraphBlock.Descendants<ParagraphBlock>());
+                    Assert.AreSame(ArrayHelper.Empty<ParagraphBlock>(), paragraphBlock.Descendants<ParagraphBlock>());
                 }
 
                 foreach (ContainerBlock containerBlock in syntaxTree.Descendants<ContainerBlock>())
@@ -80,9 +80,9 @@ namespace Markdig.Tests
 
                     if (containerBlock.Count == 0)
                     {
-                        Assert.AreSame(Array.Empty<LiteralInline>(), containerBlock.Descendants<LiteralInline>());
-                        Assert.AreSame(Array.Empty<LiteralInline>(), (containerBlock as Block).Descendants<LiteralInline>());
-                        Assert.AreSame(Array.Empty<LiteralInline>(), (containerBlock as MarkdownObject).Descendants<LiteralInline>());
+                        Assert.AreSame(ArrayHelper.Empty<LiteralInline>(), containerBlock.Descendants<LiteralInline>());
+                        Assert.AreSame(ArrayHelper.Empty<LiteralInline>(), (containerBlock as Block).Descendants<LiteralInline>());
+                        Assert.AreSame(ArrayHelper.Empty<LiteralInline>(), (containerBlock as MarkdownObject).Descendants<LiteralInline>());
                     }
                 }
             }

--- a/src/Markdig/Helpers/ArrayHelper.cs
+++ b/src/Markdig/Helpers/ArrayHelper.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license. 
+// See the license.txt file in the project root for more information.
+namespace Markdig.Helpers
+{
+    /// <summary>
+    /// Helper class for defining Empty arrays.
+    /// </summary>
+    public static class ArrayHelper
+    {
+        /// <summary>
+        /// An empty array.
+        /// </summary>
+#if NET452
+        public static T[] Empty<T>() => EmptyArray<T>.Value;
+
+        private static class EmptyArray<T>
+        {
+            public static readonly T[] Value = new T[0];
+        }
+#else
+        public static T[] Empty<T>() => System.Array.Empty<T>();
+#endif
+    }
+}

--- a/src/Markdig/Markdig.targets
+++ b/src/Markdig/Markdig.targets
@@ -6,7 +6,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>0.20.0</VersionPrefix>
     <Authors>Alexandre Mutel</Authors>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <PackageTags>Markdown CommonMark md html md2html</PackageTags>
     <PackageReleaseNotes>https://github.com/lunet-io/markdig/blob/master/changelog.md</PackageReleaseNotes>
     <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
@@ -19,6 +19,10 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+  </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Memory" Version="4.5.4" />

--- a/src/Markdig/Syntax/ContainerBlock.cs
+++ b/src/Markdig/Syntax/ContainerBlock.cs
@@ -27,11 +27,7 @@ namespace Markdig.Syntax
         /// <param name="parser">The parser used to create this block.</param>
         protected ContainerBlock(BlockParser parser) : base(parser)
         {
-#if NET452
-            children = new Block[0];
-#else
-            children = Array.Empty<Block>();
-#endif
+            children = ArrayHelper.Empty<Block>();
         }
 
         /// <summary>

--- a/src/Markdig/Syntax/ContainerBlock.cs
+++ b/src/Markdig/Syntax/ContainerBlock.cs
@@ -27,7 +27,11 @@ namespace Markdig.Syntax
         /// <param name="parser">The parser used to create this block.</param>
         protected ContainerBlock(BlockParser parser) : base(parser)
         {
+#if NET452
+            children = new Block[0];
+#else
             children = Array.Empty<Block>();
+#endif
         }
 
         /// <summary>

--- a/src/Markdig/Syntax/Inlines/ContainerInline.cs
+++ b/src/Markdig/Syntax/Inlines/ContainerInline.cs
@@ -99,11 +99,7 @@ namespace Markdig.Syntax.Inlines
         {
             if (FirstChild is null)
             {
-#if NET452
-                return new T[0];
-#else
-                return Array.Empty<T>();
-#endif
+                return ArrayHelper.Empty<T>();
             }
             else
             {

--- a/src/Markdig/Syntax/Inlines/ContainerInline.cs
+++ b/src/Markdig/Syntax/Inlines/ContainerInline.cs
@@ -99,7 +99,11 @@ namespace Markdig.Syntax.Inlines
         {
             if (FirstChild is null)
             {
+#if NET452
+                return new T[0];
+#else
                 return Array.Empty<T>();
+#endif
             }
             else
             {

--- a/src/Markdig/Syntax/MarkdownObjectExtensions.cs
+++ b/src/Markdig/Syntax/MarkdownObjectExtensions.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Markdig.Helpers;
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Syntax
@@ -94,11 +95,7 @@ namespace Markdig.Syntax
                 }
             }
 
-#if NET452
-            return new T[0];
-#else
-            return Array.Empty<T>();
-#endif
+            return ArrayHelper.Empty<T>();
         }
 
         /// <summary>
@@ -128,11 +125,7 @@ namespace Markdig.Syntax
             }
             else
             {
-#if NET452
-                return new T[0];
-#else
-                return Array.Empty<T>();
-#endif
+                return ArrayHelper.Empty<T>();
             }
         }
 

--- a/src/Markdig/Syntax/MarkdownObjectExtensions.cs
+++ b/src/Markdig/Syntax/MarkdownObjectExtensions.cs
@@ -94,7 +94,11 @@ namespace Markdig.Syntax
                 }
             }
 
+#if NET452
+            return new T[0];
+#else
             return Array.Empty<T>();
+#endif
         }
 
         /// <summary>
@@ -124,7 +128,11 @@ namespace Markdig.Syntax
             }
             else
             {
+#if NET452
+                return new T[0];
+#else
                 return Array.Empty<T>();
+#endif
             }
         }
 


### PR DESCRIPTION
I am the author of [Markdig.Wpf](https://github.com/Kryptos-FR/markdig.wpf) and recently support for .NET framework was dropped in Markdig (https://github.com/lunet-io/markdig/pull/416). That is a huge breaking change for me since it means my library cannot be used anymore in traditional WPF appplication (i.e. not using netcore3.1 or later).

I propose to bring back at least net45 support since it doesn't need to many changes (only `Array.Empty<T>` need special care as of now).

I was also supporting net40 but it seems that it is already a done deal here. It was requested by the Visual Studio setup team since they are using my library (https://github.com/Kryptos-FR/markdig.wpf/issues/25). I have opened a discussion on my own repo to decide what to do for that net40 support (https://github.com/Kryptos-FR/markdig.wpf/issues/41).

*Note: `net452` is part of Windows 8.1 and will be supported until at least January 2023 (see https://support.microsoft.com/en-sg/lifecycle/search?alpha=Windows%208.1 and https://docs.microsoft.com/en-sg/lifecycle/faq/dotnet-framework#what-is-the-lifecycle-policy-for-different-versions-of-the-net-framework).*