### PR TITLE
Fix issue 469

### DIFF
--- a/src/Markdig.Tests/TestEmphasisExtended.cs
+++ b/src/Markdig.Tests/TestEmphasisExtended.cs
@@ -124,6 +124,7 @@ namespace Markdig.Tests
         [TestCase(",,foo,,",        "<extra-comma>foo</extra-comma>")]
         [TestCase(",foo,,",         "<comma>foo</comma>,")]
         [TestCase(",,,foo,,,",      "<comma><extra-comma>foo</extra-comma></comma>")]
+        [TestCase("*foo*&_foo_",     "<em>foo</em>&amp;<em>foo</em>")]
         [TestCase("!1!",            "!1!")]
         [TestCase("!!2!!",          "<warning>2</warning>")]
         [TestCase("!!!3!!!",        "<error>3</error>")]

--- a/src/Markdig/Helpers/CharHelper.cs
+++ b/src/Markdig/Helpers/CharHelper.cs
@@ -168,7 +168,7 @@ namespace Markdig.Helpers
             return IsZero(c) || IsWhitespace(c);
         }
 
-        // Check if a char is a pace or a punctuation
+        // Check if a char is a space or a punctuation
         public static void CheckUnicodeCategory(this char c, out bool space, out bool punctuation)
         {
             // Credits: code from CommonMark.NET

--- a/src/Markdig/Helpers/CharHelper.cs
+++ b/src/Markdig/Helpers/CharHelper.cs
@@ -168,9 +168,7 @@ namespace Markdig.Helpers
             return IsZero(c) || IsWhitespace(c);
         }
 
-        // Note that we are not considering the character & as a punctuation in HTML
-        // as it is used for HTML entities, print unicode, so we assume that when we have a `&` 
-        // it is more likely followed by a valid HTML Entity that represents a non punctuation
+        // Check if a char is a pace or a punctuation
         public static void CheckUnicodeCategory(this char c, out bool space, out bool punctuation)
         {
             // Credits: code from CommonMark.NET
@@ -179,7 +177,7 @@ namespace Markdig.Helpers
             if (c <= 'ÿ')
             {
                 space = c == '\0' || c == ' ' || (c >= '\t' && c <= '\r') || c == '\u00a0' || c == '\u0085';
-                punctuation = c == '\0' || (c >= 33 && c <= 47 && c != 38) || (c >= 58 && c <= 64) || (c >= 91 && c <= 96) || (c >= 123 && c <= 126);
+                punctuation = c == '\0' || (c >= 33 && c <= 47) || (c >= 58 && c <= 64) || (c >= 91 && c <= 96) || (c >= 123 && c <= 126);
             }
             else
             {


### PR DESCRIPTION
Fix issue #469 . `&` can be a punctuation in function `CheckUnicodeCategory` of `CharHelper`. If `&` is a  beginner of a html entity or print unicode, it would be parsed by `HtmlEntityParser`.