### PR TITLE
Fix Setext headings in block quotes

### DIFF
--- a/src/Markdig.Tests/Specs/CommonMark.generated.cs
+++ b/src/Markdig.Tests/Specs/CommonMark.generated.cs
@@ -1,4 +1,4 @@
-// Generated: 2019-04-12 15:26:42
+// Generated: 2020-08-28 11:05:04
 
 // --------------------------------
 //        CommonMark v. 0.29
@@ -14924,6 +14924,29 @@ namespace Markdig.Tests.Specs.CommonMarkV_0_29
 
             Console.WriteLine("Example 649\nSection Inlines / Textual content\n");
             TestParser.TestSpec("Multiple     spaces", "<p>Multiple     spaces</p>", "");
+        }
+
+        // Within a blockquote a setext heading takes precedence
+        // over a thematic break:
+        [Test]
+        public void InlinesTextualContent_Example650()
+        {
+            // Example 650
+            // Section: Inlines / Textual content
+            //
+            // The following Markdown:
+            //     > Foo
+            //     > ---
+            //     > bar
+            //
+            // Should be rendered as:
+            //     <blockquote>
+            //     <h2>Foo</h2>
+            //     <p>bar</p>
+            //     </blockquote>
+
+            Console.WriteLine("Example 650\nSection Inlines / Textual content\n");
+            TestParser.TestSpec("> Foo\n> ---\n> bar", "<blockquote>\n<h2>Foo</h2>\n<p>bar</p>\n</blockquote>", "");
         }
         // <!-- END TESTS -->
         // 

--- a/src/Markdig.Tests/Specs/CommonMark.md
+++ b/src/Markdig.Tests/Specs/CommonMark.md
@@ -9368,6 +9368,20 @@ Multiple     spaces
 <p>Multiple     spaces</p>
 ````````````````````````````````
 
+Within a blockquote a setext heading takes precedence
+over a thematic break:
+
+```````````````````````````````` example
+> Foo
+> ---
+> bar
+.
+<blockquote>
+<h2>Foo</h2>
+<p>bar</p>
+</blockquote>
+````````````````````````````````
+
 
 <!-- END TESTS -->
 

--- a/src/Markdig/Parsers/ParagraphBlockParser.cs
+++ b/src/Markdig/Parsers/ParagraphBlockParser.cs
@@ -38,7 +38,7 @@ namespace Markdig.Parsers
                 return BlockState.BreakDiscard;
             }
 
-            if (ParseSetexHeadings && !processor.IsCodeIndent && !(block.Parent is QuoteBlock))
+            if (ParseSetexHeadings && !processor.IsCodeIndent)
             {
                 return TryParseSetexHeading(processor, block);
             }

--- a/src/Markdig/Parsers/ThematicBreakParser.cs
+++ b/src/Markdig/Parsers/ThematicBreakParser.cs
@@ -74,7 +74,7 @@ namespace Markdig.Parsers
             if (isSetexHeading)
             {
                 var parent = previousParagraph.Parent;
-                if (parent is QuoteBlock || (parent is ListItemBlock && previousParagraph.Column != processor.Column))
+                if ((parent is QuoteBlock && processor.CurrentLineStartPosition > parent.Span.End) || (parent is ListItemBlock && previousParagraph.Column != processor.Column))
                 {
                     isSetexHeading = false;
                 }


### PR DESCRIPTION
This PR attempts to fix #465 (spoiler alert: I've introduced another problem).

I've added a new test that makes sure that this markdown

```
> Hello
> ----
> this is some other text
```

is parsed as a block quote containing a `h2`. I made the test pass but introduced another regression around lazy continuations of block quotes. This is quite a head-scratcher for me so I'm getting this out with the failing test, maybe we can start discussing intermediate results and another pair of eyes helps fixing the remaining regression (or making sense of my overall approach)