### PR TITLE
Make Inline.FirstParentOfType public

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.0.100
+        dotnet-version: 3.1.402
 
     - name: Build (Release)
       run: dotnet build src -c Release

--- a/src/Markdig/Syntax/Inlines/Inline.cs
+++ b/src/Markdig/Syntax/Inlines/Inline.cs
@@ -224,7 +224,7 @@ namespace Markdig.Syntax.Inlines
             }
         }
 
-        internal T FirstParentOfType<T>() where T : Inline
+        public T FirstParentOfType<T>() where T : Inline
         {
             var inline = this;
             while (inline != null)


### PR DESCRIPTION
`Inline.FirstParentOfType()` is protected. It is handy (for extensions) to have the method outside of the `Markdig.Syntax.Inlines` namespace.