### PR TITLE
Fix NETSDK1045 CI build failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
 
     - name: Install .NET Core
       uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.0.100
 
     - name: Build (Release)
       run: dotnet build src -c Release


### PR DESCRIPTION
Remove `with` uses latest dotnet, which is now `3.1.402`

Fixes [this](https://github.com/lunet-io/markdig/pull/478/checks?check_run_id=1186626201#step:4:29) build error:

```
Error: C:\Users\runneradmin\AppData\Local\Microsoft\dotnet\sdk\3.0.100\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(127,5): error NETSDK1045: The current .NET SDK does not support targeting .NET Core 3.1.  Either target .NET Core 3.0 or lower, or use a version of the .NET SDK that supports .NET Core 3.1.
```