### PR TITLE
Fix incorrect emphasis span calculation.

### DIFF
--- a/src/Markdig.Tests/TestSourcePosition.cs
+++ b/src/Markdig.Tests/TestSourcePosition.cs
@@ -161,6 +161,17 @@ literal      ( 0, 8)  8-8
     }
 
     [Test]
+    public void TestEmphasis4()
+    {
+        Check("**foo*", @"
+paragraph    ( 0, 0)  0-5
+literal      ( 0, 0)  0-0
+emphasis     ( 0, 1)  1-5
+literal      ( 0, 2)  2-4
+");
+    }
+
+    [Test]
     public void TestEmphasisFalse()
     {
         Check("0123456789**0123", @"

--- a/src/Markdig/Parsers/Inlines/EmphasisInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/EmphasisInlineParser.cs
@@ -302,14 +302,13 @@ public class EmphasisInlineParser : InlineParser, IPostInlineProcessor
                         var openDelimitercount = openDelimiter.DelimiterCount;
                         var closeDelimitercount = closeDelimiter.DelimiterCount;
 
-                        emphasis!.Span.Start = openDelimiter.Span.Start;
+                        emphasis!.Span.Start = openDelimiter.Span.Start + openDelimitercount - delimiterDelta;
                         emphasis.Line = openDelimiter.Line;
-                        emphasis.Column = openDelimiter.Column;
+                        emphasis.Column = openDelimiter.Column + openDelimitercount - delimiterDelta;
                         emphasis.Span.End = closeDelimiter.Span.End - closeDelimitercount + delimiterDelta;
 
-                        openDelimiter.Content.Start += delimiterDelta;
-                        openDelimiter.Span.Start += delimiterDelta;
-                        openDelimiter.Column += delimiterDelta;
+                        openDelimiter.Span.End -= delimiterDelta;
+                        openDelimiter.Content.End -= delimiterDelta;
                         closeDelimiter.Content.Start += delimiterDelta;
                         closeDelimiter.Span.Start += delimiterDelta;
                         closeDelimiter.Column += delimiterDelta;


### PR DESCRIPTION
`EmphasisInlineParser` did not take into account the case of extra delimiter characters before the emphasis. For example:

`**foo*`

The supplied test produces the following result in the current version:
```````````````````Source
**foo*
```````````````````Result
paragraph    ( 0, 0)  0-5
literal      ( 0, 1)  1-1
emphasis     ( 0, 0)  0-5
literal      ( 0, 2)  2-4
```````````````````Expected
paragraph    ( 0, 0)  0-5
literal      ( 0, 0)  0-0
emphasis     ( 0, 1)  1-5
literal      ( 0, 2)  2-4
```````````````````

The emphasis intersects with the literal before it - obviously wrong. The effect of this can be seen in the Visual Studio editor: it displays the first asterisk as italics.