### PR TITLE
Fix build warnings

### DIFF
--- a/src/Markdig.Tests/Markdig.Tests.csproj
+++ b/src/Markdig.Tests/Markdig.Tests.csproj
@@ -9,6 +9,7 @@
     <StartupObject>Markdig.Tests.Program</StartupObject>
     <SpecExecutable>$(MSBuildProjectDirectory)\..\SpecFileGen\bin\$(Configuration)\$(TargetFramework)\SpecFileGen.dll</SpecExecutable>
     <SpecTimestamp>$(MSBuildProjectDirectory)\..\SpecFileGen\bin\$(Configuration)\$(TargetFramework)\SpecFileGen.timestamp</SpecTimestamp>
+    <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markdig/Extensions/Tables/TableHelper.cs
+++ b/src/Markdig/Extensions/Tables/TableHelper.cs
@@ -47,6 +47,7 @@ public static class TableHelper
     /// <param name="slice">The text slice.</param>
     /// <param name="delimiterChar">The delimiter character (either `-` or `=`). If `\0`, it will detect the character (either `-` or `=`)</param>
     /// <param name="align">The alignment of the column.</param>
+    /// <param name="delimiterCount">The number of times <paramref name="delimiterChar"/> appeared in the column header.</param>
     /// <returns>
     ///   <c>true</c> if parsing was successful
     /// </returns>

--- a/src/SpecFileGen/SpecFileGen.csproj
+++ b/src/SpecFileGen/SpecFileGen.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
NETSDK1138 is "The target framework is out of support" which we don't care about for test projects - we're intentionally targetting 6.0 there so we have some coverage of netstandard code paths.