### PR TITLE
Lazily allocate storage for ProcessInlinesBegin/End delegates on Blocks

### DIFF
--- a/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
@@ -73,8 +73,6 @@ public class AbbreviationParser : BlockParser
 
     private void DocumentOnProcessInlinesBegin(InlineProcessor inlineProcessor, Inline? inline)
     {
-        inlineProcessor.Document.ProcessInlinesBegin -= DocumentOnProcessInlinesBegin;
-
         var abbreviations = inlineProcessor.Document.GetAbbreviations();
         // Should not happen, but another extension could decide to remove them, so...
         if (abbreviations is null)

--- a/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierExtension.cs
+++ b/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierExtension.cs
@@ -101,7 +101,6 @@ public class AutoIdentifierExtension : IMarkdownExtension
     private void DocumentOnProcessInlinesBegin(InlineProcessor processor, Inline? inline)
     {
         var doc = processor.Document;
-        doc.ProcessInlinesBegin -= _processInlinesBegin;
         var dictionary = (Dictionary<string, HeadingLinkReferenceDefinition>)doc.GetData(this)!;
         foreach (var keyPair in dictionary)
         {

--- a/src/Markdig/Extensions/Footnotes/FootnoteParser.cs
+++ b/src/Markdig/Extensions/Footnotes/FootnoteParser.cs
@@ -134,9 +134,6 @@ public class FootnoteParser : BlockParser
     /// <param name="inline">The inline.</param>
     private void Document_ProcessInlinesEnd(InlineProcessor state, Inline? inline)
     {
-        // Unregister
-        state.Document.ProcessInlinesEnd -= Document_ProcessInlinesEnd;
-
         var footnotes = (FootnoteGroup)state.Document.GetData(DocumentKey)!;
         // Remove the footnotes from the document and readd them at the end
         state.Document.Remove(footnotes);

--- a/src/Markdig/Extensions/SmartyPants/SmartyPantsInlineParser.cs
+++ b/src/Markdig/Extensions/SmartyPants/SmartyPantsInlineParser.cs
@@ -204,8 +204,6 @@ public class SmartyPantsInlineParser : InlineParser, IPostInlineProcessor
 
     private void BlockOnProcessInlinesEnd(InlineProcessor processor, Inline? inline)
     {
-        processor.Block!.ProcessInlinesEnd -= BlockOnProcessInlinesEnd;
-
         var pants = (ListSmartyPants) processor.ParserStates[Index];
 
         var openers = new Stack<Opener>(4);

--- a/src/Markdig/Extensions/Tables/PipeTableParser.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableParser.cs
@@ -497,13 +497,10 @@ public class PipeTableParser : InlineParser, IPostInlineProcessor
 
             ContainerBlock parent = leadingParagraph.Parent!;
 
-            ProcessInlineDelegate insertTableDelegate = null!;
-            insertTableDelegate = (processor, _) =>
+            parent.ProcessInlinesEnd += (_, _) =>
             {
-                parent.ProcessInlinesEnd -= insertTableDelegate;
                 parent.Insert(parent.IndexOf(leadingParagraph) + 1, table);
             };
-            parent.ProcessInlinesEnd += insertTableDelegate;
         }
         else
         {

--- a/src/Markdig/Renderers/RendererBase.cs
+++ b/src/Markdig/Renderers/RendererBase.cs
@@ -85,12 +85,12 @@ public abstract class RendererBase : IMarkdownRenderer
     public bool IsLastInContainer { get; private set; }
 
     /// <summary>
-    /// Occurs when before writing an object.
+    /// Occurs before writing an object.
     /// </summary>
     public event Action<IMarkdownRenderer, MarkdownObject>? ObjectWriteBefore;
 
     /// <summary>
-    /// Occurs when after writing an object.
+    /// Occurs after writing an object.
     /// </summary>
     public event Action<IMarkdownRenderer, MarkdownObject>? ObjectWriteAfter;
 


### PR DESCRIPTION
Reduces parsing allocations by ~2% by reducing the size of each block by 16 bytes.
It does increase the cost when these delegates are used, but that's usually very rare (e.g. only for the top-level `MarkdownDocument` block).