### PR TITLE
Replace null checks with IsEmpty property for ReadOnlySpan<char>

### DIFF
--- a/src/Markdig/Helpers/LinkHelper.cs
+++ b/src/Markdig/Helpers/LinkHelper.cs
@@ -60,12 +60,12 @@ public static class LinkHelper
             }
             else
             {
-                normalized = allowOnlyAscii ? CharNormalizer.ConvertToAscii(c) : null;
+                normalized = allowOnlyAscii ? CharNormalizer.ConvertToAscii(c) : ReadOnlySpan<char>.Empty;
             }
 
             for (int j = 0; j < (normalized.Length < 1 ? 1 : normalized.Length); j++)
             {
-                if (normalized != null)
+                if (!normalized.IsEmpty)
                 {
                     c = normalized[j];
                 }


### PR DESCRIPTION
This PR replace null checks with `IsEmpty` property for `ReadOnlySpan<char>`. 
The change suppresses [CA2265](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2265) warnings.

