### PR TITLE
Support escaped quotes in generic attribute values

### DIFF
--- a/src/Markdig.Tests/Specs/GenericAttributesSpecs.generated.cs
+++ b/src/Markdig.Tests/Specs/GenericAttributesSpecs.generated.cs
@@ -116,4 +116,109 @@ namespace Markdig.Tests.Specs.GenericAttributes
             TestParser.TestSpec("{.center}\nA paragraph", "<p class=\"center\">A paragraph</p>", "attributes|advanced", context: "Example 4\nSection Extensions / Generic Attributes\n");
         }
     }
+
+    [TestFixture]
+    public class TestExtensionsEscapedQuotesInAttributeValues
+    {
+        // ## Escaped Quotes in Attribute Values
+        // 
+        // Backslash escapes are supported in quoted attribute values, following CommonMark conventions.
+        // Escaped quotes (\") allow including quote characters within quoted values.
+        // 
+        // Escaped double quotes inside double-quoted value:
+        [Test]
+        public void ExtensionsEscapedQuotesInAttributeValues_Example005()
+        {
+            // Example 5
+            // Section: Extensions / Escaped Quotes in Attribute Values
+            //
+            // The following Markdown:
+            //     [Link](url){data-value="hello \"world\""}
+            //
+            // Should be rendered as:
+            //     <p><a href="url" data-value="hello &quot;world&quot;">Link</a></p>
+
+            TestParser.TestSpec("[Link](url){data-value=\"hello \\\"world\\\"\"}", "<p><a href=\"url\" data-value=\"hello &quot;world&quot;\">Link</a></p>", "attributes|advanced", context: "Example 5\nSection Extensions / Escaped Quotes in Attribute Values\n");
+        }
+
+        // Escaped single quotes inside single-quoted value:
+        [Test]
+        public void ExtensionsEscapedQuotesInAttributeValues_Example006()
+        {
+            // Example 6
+            // Section: Extensions / Escaped Quotes in Attribute Values
+            //
+            // The following Markdown:
+            //     [Link](url){data-value='hello \'world\''}
+            //
+            // Should be rendered as:
+            //     <p><a href="url" data-value="hello 'world'">Link</a></p>
+
+            TestParser.TestSpec("[Link](url){data-value='hello \\'world\\''}", "<p><a href=\"url\" data-value=\"hello 'world'\">Link</a></p>", "attributes|advanced", context: "Example 6\nSection Extensions / Escaped Quotes in Attribute Values\n");
+        }
+
+        // Mixed quotes (no escaping needed, existing behavior):
+        [Test]
+        public void ExtensionsEscapedQuotesInAttributeValues_Example007()
+        {
+            // Example 7
+            // Section: Extensions / Escaped Quotes in Attribute Values
+            //
+            // The following Markdown:
+            //     [Link](url){data-value='hello "world"'}
+            //
+            // Should be rendered as:
+            //     <p><a href="url" data-value="hello &quot;world&quot;">Link</a></p>
+
+            TestParser.TestSpec("[Link](url){data-value='hello \"world\"'}", "<p><a href=\"url\" data-value=\"hello &quot;world&quot;\">Link</a></p>", "attributes|advanced", context: "Example 7\nSection Extensions / Escaped Quotes in Attribute Values\n");
+        }
+
+        // Escaped backslash followed by quote (backslash is escaped, quote closes the value):
+        [Test]
+        public void ExtensionsEscapedQuotesInAttributeValues_Example008()
+        {
+            // Example 8
+            // Section: Extensions / Escaped Quotes in Attribute Values
+            //
+            // The following Markdown:
+            //     [Link](url){data-value="path\\"}
+            //
+            // Should be rendered as:
+            //     <p><a href="url" data-value="path\">Link</a></p>
+
+            TestParser.TestSpec("[Link](url){data-value=\"path\\\\\"}", "<p><a href=\"url\" data-value=\"path\\\">Link</a></p>", "attributes|advanced", context: "Example 8\nSection Extensions / Escaped Quotes in Attribute Values\n");
+        }
+
+        // Backslash not followed by escapable character (preserved as-is):
+        [Test]
+        public void ExtensionsEscapedQuotesInAttributeValues_Example009()
+        {
+            // Example 9
+            // Section: Extensions / Escaped Quotes in Attribute Values
+            //
+            // The following Markdown:
+            //     [Link](url){data-value="hello\nworld"}
+            //
+            // Should be rendered as:
+            //     <p><a href="url" data-value="hello\nworld">Link</a></p>
+
+            TestParser.TestSpec("[Link](url){data-value=\"hello\\nworld\"}", "<p><a href=\"url\" data-value=\"hello\\nworld\">Link</a></p>", "attributes|advanced", context: "Example 9\nSection Extensions / Escaped Quotes in Attribute Values\n");
+        }
+
+        // Complex escape sequence (Word field code use case):
+        [Test]
+        public void ExtensionsEscapedQuotesInAttributeValues_Example010()
+        {
+            // Example 10
+            // Section: Extensions / Escaped Quotes in Attribute Values
+            //
+            // The following Markdown:
+            //     [Date](){field="DATE \\@ \"MMMM d, yyyy\""}
+            //
+            // Should be rendered as:
+            //     <p><a href="" field="DATE \@ &quot;MMMM d, yyyy&quot;">Date</a></p>
+
+            TestParser.TestSpec("[Date](){field=\"DATE \\\\@ \\\"MMMM d, yyyy\\\"\"}", "<p><a href=\"\" field=\"DATE \\@ &quot;MMMM d, yyyy&quot;\">Date</a></p>", "attributes|advanced", context: "Example 10\nSection Extensions / Escaped Quotes in Attribute Values\n");
+        }
+    }
 }

--- a/src/Markdig.Tests/Specs/GenericAttributesSpecs.md
+++ b/src/Markdig.Tests/Specs/GenericAttributesSpecs.md
@@ -70,3 +70,56 @@ A paragraph
 .
 <p class="center">A paragraph</p>
 ````````````````````````````````
+
+## Escaped Quotes in Attribute Values
+
+Backslash escapes are supported in quoted attribute values, following CommonMark conventions.
+Escaped quotes (\") allow including quote characters within quoted values.
+
+Escaped double quotes inside double-quoted value:
+
+```````````````````````````````` example
+[Link](url){data-value="hello \"world\""}
+.
+<p><a href="url" data-value="hello &quot;world&quot;">Link</a></p>
+````````````````````````````````
+
+Escaped single quotes inside single-quoted value:
+
+```````````````````````````````` example
+[Link](url){data-value='hello \'world\''}
+.
+<p><a href="url" data-value="hello 'world'">Link</a></p>
+````````````````````````````````
+
+Mixed quotes (no escaping needed, existing behavior):
+
+```````````````````````````````` example
+[Link](url){data-value='hello "world"'}
+.
+<p><a href="url" data-value="hello &quot;world&quot;">Link</a></p>
+````````````````````````````````
+
+Escaped backslash followed by quote (backslash is escaped, quote closes the value):
+
+```````````````````````````````` example
+[Link](url){data-value="path\\"}
+.
+<p><a href="url" data-value="path\">Link</a></p>
+````````````````````````````````
+
+Backslash not followed by escapable character (preserved as-is):
+
+```````````````````````````````` example
+[Link](url){data-value="hello\nworld"}
+.
+<p><a href="url" data-value="hello\nworld">Link</a></p>
+````````````````````````````````
+
+Complex escape sequence (Word field code use case):
+
+```````````````````````````````` example
+[Date](){field="DATE \\@ \"MMMM d, yyyy\""}
+.
+<p><a href="" field="DATE \@ &quot;MMMM d, yyyy&quot;">Date</a></p>
+````````````````````````````````


### PR DESCRIPTION
Hi! I've been using Markdig and it's been great. Wanted to contribute back with this small feature.

This is my first PR here so happy to make any revisions or tweaks as necessary. And also, if this isn't something wanted by the maintainers, feel free to close.

  ## Summary

  - Add backslash escape handling for quoted attribute values following kramdown's approach
  - This allows including quote characters within attribute values using backslash escapes (e.g. `data-value="hello \"world\""`)
  - It also works with single-quotes

  ## Motivation

  This was discovered when using markdown to generate Word documents from the Markdig AST. Word field codes use quoted strings:

  ```markdown
  [January 15, 2026](){field="DATE @ \"MMMM d, yyyy\""}
```

  This can work if the outer quotes are changed to single-quotes but escape sequences are useful for our context (and we preprocess the markdown so it works with Markdig today).

## Implementation

  Follows the same `hasEscape` pattern used in `LinkHelper.TryParseTitle`, using `IsAsciiPunctuation()` for escaping.

  This matches kramdown's behavior for inline attribute lists:

  > "If you need to use the value delimiter (a single or a double quote) inside the value, you need to escape it with a backslash."

  See: https://kramdown.gettalong.org/syntax.html

  ## Test plan

  - [x] Added 6 test cases covering escaped double/single quotes, escaped backslashes, and complex escape sequences