### PR TITLE
Add spoiler extension

### DIFF
--- a/src/Markdig/Extensions/Spoilers/SpoilerExtension.cs
+++ b/src/Markdig/Extensions/Spoilers/SpoilerExtension.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+using Markdig.Parsers.Inlines;
+using Markdig.Renderers;
+using Markdig.Renderers.Html;
+
+namespace Markdig.Extensions.Spoilers;
+
+/// <summary>
+///     Extension for parsing inline spoilers starting and ending with an equal amount of pipe characters.
+/// </summary>
+/// <seealso cref="IMarkdownExtension"/>
+public sealed class SpoilerExtension : IMarkdownExtension
+{
+    /// <inheritdoc />
+    public void Setup(MarkdownPipelineBuilder pipeline)
+    {
+        SpoilerInlineParser? inlineParser = pipeline.InlineParsers.Find<SpoilerInlineParser>();
+        if (inlineParser == null)
+        {
+            pipeline.InlineParsers.InsertBefore<LinkInlineParser>(new SpoilerInlineParser());
+        }
+    }
+
+    /// <inheritdoc />
+    public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
+    {
+        SpoilerInlineRenderer? blockRenderer = renderer.ObjectRenderers.FindExact<SpoilerInlineRenderer>();
+        if (blockRenderer == null)
+        {
+            renderer.ObjectRenderers.InsertBefore<QuoteBlockRenderer>(new SpoilerInlineRenderer());
+        }
+    }
+}

--- a/src/Markdig/Extensions/Spoilers/SpoilerInline.cs
+++ b/src/Markdig/Extensions/Spoilers/SpoilerInline.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+using Markdig.Helpers;
+using Markdig.Syntax.Inlines;
+
+namespace Markdig.Extensions.Spoilers;
+
+/// <summary>
+///     An inline spoiler.
+/// </summary>
+/// <seealso cref="SpoilerExtension"/>
+public sealed class SpoilerInline : LeafInline
+{
+    public StringSlice Content { get; }
+
+    internal SpoilerInline(StringSlice content) => Content = content;
+}

--- a/src/Markdig/Extensions/Spoilers/SpoilerInlineParser.cs
+++ b/src/Markdig/Extensions/Spoilers/SpoilerInlineParser.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+using Markdig.Helpers;
+using Markdig.Parsers;
+using Markdig.Renderers.Html;
+using Markdig.Syntax;
+
+namespace Markdig.Extensions.Spoilers;
+
+/// <summary>
+///     The parser for inline spoilers.
+/// </summary>
+/// <seealso cref="SpoilerExtension"/>
+internal sealed class SpoilerInlineParser : InlineParser
+{
+    public SpoilerInlineParser() => OpeningCharacters = ['|'];
+
+    public override bool Match(InlineProcessor processor, ref StringSlice slice)
+    {
+        char match = slice.CurrentChar;
+        if (slice.PeekCharExtra(-1) == match)
+        {
+            return false;
+        }
+
+        slice.SkipChar();
+
+        int openPipeCount = 1;
+        while (slice.CurrentChar == match)
+        {
+            ++openPipeCount;
+            slice.SkipChar();
+        }
+
+        ReadOnlySpan<char> span = slice.AsSpan();
+        int i = span.IndexOfAny('\r', '\n', match);
+        if (i < 0 || (uint)i >= (uint)span.Length)
+        {
+            return false;
+        }
+
+        int closePipeCount = 0;
+        while ((uint)i < (uint)span.Length && span[i] == match)
+        {
+            closePipeCount++;
+            i++;
+        }
+
+        span = span.Slice(i);
+        if (openPipeCount != closePipeCount)
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> rawContent = slice.AsSpan().Slice(0, slice.Length - span.Length - openPipeCount);
+
+        StringSlice content = new(slice.Text, slice.Start, slice.Start + rawContent.Length - 1);
+
+        int startPosition = slice.Start;
+        slice.Start = startPosition + rawContent.Length + openPipeCount;
+
+        startPosition -= openPipeCount;
+
+        SpoilerInline inline = new(content)
+        {
+            Span = new SourceSpan(processor.GetSourcePosition(startPosition, out int line, out int column), processor.GetSourcePosition(slice.Start - 1)),
+            Line = line,
+            Column = column
+        };
+        HtmlAttributes attributes = inline.GetAttributes();
+        attributes.AddClass("spoiler");
+
+        processor.Inline = inline;
+        return true;
+    }
+}

--- a/src/Markdig/Extensions/Spoilers/SpoilerInlineRenderer.cs
+++ b/src/Markdig/Extensions/Spoilers/SpoilerInlineRenderer.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+using Markdig.Renderers;
+using Markdig.Renderers.Html;
+
+namespace Markdig.Extensions.Spoilers;
+
+/// <summary>
+///     The default <see cref="IMarkdownObjectRenderer"/> for <see cref="SpoilerInline"/>
+/// </summary>
+/// <seealso cref="SpoilerExtension"/>
+public sealed class SpoilerInlineRenderer : HtmlObjectRenderer<SpoilerInline>
+{
+    protected override void Write(HtmlRenderer renderer, SpoilerInline obj)
+    {
+        if (renderer.EnableHtmlForInline)
+        {
+            renderer.Write("<span");
+            renderer.WriteAttributes(obj);
+            renderer.Write('>');
+        }
+
+        renderer.Write(obj.Content);
+
+        if (renderer.EnableHtmlForInline)
+        {
+            renderer.Write("</span>");
+        }
+    }
+}


### PR DESCRIPTION
Adds inline spoilers to fix #596 (last comment as of today, which is where inlines were requested).


Need ideas from the CSS-pros here on how to nicely format this when the **bootstrap** extension is active.

The effects of following .css would surely look nice, but I'm not 100% sure how to achieve it using bootstrap and with as little code as possible.

```css
.spoiler {
  color: black;
  background-color: black;
}
.spoiler:hover {
  background-color: white;
}
```
