### PR TITLE
Markdig 1.0

### DIFF
--- a/src/Markdig/Markdig.targets
+++ b/src/Markdig/Markdig.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Description>A fast, powerful, CommonMark compliant, extensible Markdown processor for .NET with 20+ builtin extensions (pipetables, footnotes, definition lists... etc.)</Description>
+    <Description>Markdig is a fast, powerful, CommonMark compliant, extensible Markdown processor for .NET.</Description>
     <Copyright>Alexandre Mutel</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Authors>Alexandre Mutel</Authors>
@@ -12,7 +12,7 @@
     <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
     <PackageIcon>markdig.png</PackageIcon>
-    <PackageProjectUrl>https://github.com/xoofx/markdig</PackageProjectUrl>
+    <PackageProjectUrl>https://xoofx.github.io/markdig</PackageProjectUrl>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Markdig API has been relatively stable for the past years. The version 0.x was kept around for the main reason that I was hoping the CommonMark specs to settle to 1.0 but it never came, so it's probably time to move on.

This PR is empty, just forcing a modification to create it.

I have added several commits today to make it ready for 1.0, in particular to make all the internal API currently used by parsers public so users have same access.

The API is not amazing, but this is what was developed 10 years ago. It has been made a bit more complicated after the support for roundtrip, but it has proven to be quite solid despite some parts being ugly.

If we have the courage, we can revisit it for 2.0 ☺️ 

I don't know if we expect more changes for 1.0 but I'm letting this PR opened until we do.

A draft website is now available at https://xoofx.github.io/markdig

I will perform a pass tomorrow to verify all the documentation, and might add changes to this PR.

cc: @MihaZupan 