### PR TITLE
Fix emoji not rendering in table cells

### DIFF
--- a/src/Markdig.Tests/Specs/EmojiSpecs.generated.cs
+++ b/src/Markdig.Tests/Specs/EmojiSpecs.generated.cs
@@ -30,10 +30,10 @@ namespace Markdig.Tests.Specs.Emoji
             // Should be rendered as:
             //     <p>This is a test with a 😃 and a 😠 smiley</p>
 
-            TestParser.TestSpec("This is a test with a :) and a :angry: smiley", "<p>This is a test with a 😃 and a 😠 smiley</p>", "emojis|advanced+emojis", context: "Example 1\nSection Extensions / Emoji\n");
+            TestParser.TestSpec("This is a test with a :) and a :angry: smiley", "<p>This is a test with a 😃 and a 😠 smiley</p>", "pipetables+emojis|advanced+emojis", context: "Example 1\nSection Extensions / Emoji\n");
         }
 
-        // An emoji needs to be preceded by a space:
+        // An emoji must not be preceded by a letter or digit:
         [Test]
         public void ExtensionsEmoji_Example002()
         {
@@ -46,7 +46,7 @@ namespace Markdig.Tests.Specs.Emoji
             // Should be rendered as:
             //     <p>These are not:) an emoji with a:) x:angry:x</p>
 
-            TestParser.TestSpec("These are not:) an emoji with a:) x:angry:x", "<p>These are not:) an emoji with a:) x:angry:x</p>", "emojis|advanced+emojis", context: "Example 2\nSection Extensions / Emoji\n");
+            TestParser.TestSpec("These are not:) an emoji with a:) x:angry:x", "<p>These are not:) an emoji with a:) x:angry:x</p>", "pipetables+emojis|advanced+emojis", context: "Example 2\nSection Extensions / Emoji\n");
         }
 
         // Emojis can be followed by close punctuation (or any other characters):
@@ -62,7 +62,7 @@ namespace Markdig.Tests.Specs.Emoji
             // Should be rendered as:
             //     <p>We all need 😃, it makes us 💪. (and 👌).</p>
 
-            TestParser.TestSpec("We all need :), it makes us :muscle:. (and :ok_hand:).", "<p>We all need 😃, it makes us 💪. (and 👌).</p>", "emojis|advanced+emojis", context: "Example 3\nSection Extensions / Emoji\n");
+            TestParser.TestSpec("We all need :), it makes us :muscle:. (and :ok_hand:).", "<p>We all need 😃, it makes us 💪. (and 👌).</p>", "pipetables+emojis|advanced+emojis", context: "Example 3\nSection Extensions / Emoji\n");
         }
 
         // Sentences can end with emojis:
@@ -80,7 +80,65 @@ namespace Markdig.Tests.Specs.Emoji
             //     <p>This is a sentence 👌
             //     and keeps going to the next line 😃</p>
 
-            TestParser.TestSpec("This is a sentence :ok_hand:\nand keeps going to the next line :)", "<p>This is a sentence 👌\nand keeps going to the next line 😃</p>", "emojis|advanced+emojis", context: "Example 4\nSection Extensions / Emoji\n");
+            TestParser.TestSpec("This is a sentence :ok_hand:\nand keeps going to the next line :)", "<p>This is a sentence 👌\nand keeps going to the next line 😃</p>", "pipetables+emojis|advanced+emojis", context: "Example 4\nSection Extensions / Emoji\n");
+        }
+
+        // Emojis are rendered inside pipe table cells with surrounding spaces:
+        [Test]
+        public void ExtensionsEmoji_Example005()
+        {
+            // Example 5
+            // Section: Extensions / Emoji
+            //
+            // The following Markdown:
+            //     | header |
+            //     |--------|
+            //     | :x: |
+            //
+            // Should be rendered as:
+            //     <table>
+            //     <thead>
+            //     <tr>
+            //     <th>header</th>
+            //     </tr>
+            //     </thead>
+            //     <tbody>
+            //     <tr>
+            //     <td>❌</td>
+            //     </tr>
+            //     </tbody>
+            //     </table>
+
+            TestParser.TestSpec("| header |\n|--------|\n| :x: |", "<table>\n<thead>\n<tr>\n<th>header</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>❌</td>\n</tr>\n</tbody>\n</table>", "pipetables+emojis|advanced+emojis", context: "Example 5\nSection Extensions / Emoji\n");
+        }
+
+        // Emojis are rendered inside pipe table cells without surrounding spaces:
+        [Test]
+        public void ExtensionsEmoji_Example006()
+        {
+            // Example 6
+            // Section: Extensions / Emoji
+            //
+            // The following Markdown:
+            //     | header |
+            //     |--------|
+            //     |:x:|
+            //
+            // Should be rendered as:
+            //     <table>
+            //     <thead>
+            //     <tr>
+            //     <th>header</th>
+            //     </tr>
+            //     </thead>
+            //     <tbody>
+            //     <tr>
+            //     <td>❌</td>
+            //     </tr>
+            //     </tbody>
+            //     </table>
+
+            TestParser.TestSpec("| header |\n|--------|\n|:x:|", "<table>\n<thead>\n<tr>\n<th>header</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>❌</td>\n</tr>\n</tbody>\n</table>", "pipetables+emojis|advanced+emojis", context: "Example 6\nSection Extensions / Emoji\n");
         }
     }
 }

--- a/src/Markdig.Tests/Specs/EmojiSpecs.md
+++ b/src/Markdig.Tests/Specs/EmojiSpecs.md
@@ -12,7 +12,7 @@ This is a test with a :) and a :angry: smiley
 <p>This is a test with a 😃 and a 😠 smiley</p>
 ````````````````````````````````
 
-An emoji needs to be preceded by a space:
+An emoji must not be preceded by a letter or digit:
 
 ```````````````````````````````` example
 These are not:) an emoji with a:) x:angry:x
@@ -36,4 +36,46 @@ and keeps going to the next line :)
 .
 <p>This is a sentence 👌
 and keeps going to the next line 😃</p>
+````````````````````````````````
+
+Emojis are rendered inside pipe table cells with surrounding spaces:
+
+```````````````````````````````` example
+| header |
+|--------|
+| :x: |
+.
+<table>
+<thead>
+<tr>
+<th>header</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>❌</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+Emojis are rendered inside pipe table cells without surrounding spaces:
+
+```````````````````````````````` example
+| header |
+|--------|
+|:x:|
+.
+<table>
+<thead>
+<tr>
+<th>header</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>❌</td>
+</tr>
+</tbody>
+</table>
 ````````````````````````````````

--- a/src/Markdig.Tests/TestCustomEmojis.cs
+++ b/src/Markdig.Tests/TestCustomEmojis.cs
@@ -121,4 +121,20 @@ public class TestCustomEmojis
         smileyToEmoji.Add("a", "c"); // "a" already exists in emojiToUnicode
         Assert.Throws<ArgumentException>(() => new EmojiMapping(emojiToUnicode, smileyToEmoji));
     }
+
+    [Test]
+    [TestCase("|test|\n|-|\n|:x:|", "<table>\n<thead>\n<tr>\n<th>test</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>❌</td>\n</tr>\n</tbody>\n</table>\n")]
+    [TestCase("|test|\n|-|\n| :x: |", "<table>\n<thead>\n<tr>\n<th>test</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>❌</td>\n</tr>\n</tbody>\n</table>\n")]
+    [TestCase("|test|\n|-|\n|1:x:|", "<table>\n<thead>\n<tr>\n<th>test</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>1:x:</td>\n</tr>\n</tbody>\n</table>\n")]
+    [TestCase("|test|\n|-|\n|w:x:y|", "<table>\n<thead>\n<tr>\n<th>test</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>w:x:y</td>\n</tr>\n</tbody>\n</table>\n")]
+    public void TestEmojiInPipeTable(string input, string expected)
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseEmojiAndSmiley()
+            .UsePipeTables()
+            .Build();
+
+        var actual = Markdown.ToHtml(input, pipeline);
+        Assert.AreEqual(expected, actual);
+    }
 }

--- a/src/Markdig/Extensions/Emoji/EmojiParser.cs
+++ b/src/Markdig/Extensions/Emoji/EmojiParser.cs
@@ -29,8 +29,9 @@ public class EmojiParser : InlineParser
     /// </summary>
     public override bool Match(InlineProcessor processor, ref StringSlice slice)
     {
-        // Previous char must be a space
-        if (!slice.PeekCharExtra(-1).IsWhiteSpaceOrZero())
+        // Previous char must be a space or non-alphanumeric.
+        var prevChar = slice.PeekCharExtra(-1);
+        if (!prevChar.IsWhiteSpaceOrZero() && char.IsLetterOrDigit(prevChar))
         {
             return false;
         }

--- a/src/Markdig/Extensions/Emoji/EmojiParser.cs
+++ b/src/Markdig/Extensions/Emoji/EmojiParser.cs
@@ -31,7 +31,7 @@ public class EmojiParser : InlineParser
     {
         // Previous char must be a space or non-alphanumeric.
         var prevChar = slice.PeekCharExtra(-1);
-        if (!prevChar.IsWhiteSpaceOrZero() && char.IsLetterOrDigit(prevChar))
+        if (char.IsLetterOrDigit(prevChar))
         {
             return false;
         }

--- a/src/SpecFileGen/Program.cs
+++ b/src/SpecFileGen/Program.cs
@@ -71,7 +71,7 @@ class Program
         new Spec("Grid Tables",         "GridTableSpecs.md",            "gridtables|advanced"),
         new Spec("Custom Containers",   "CustomContainerSpecs.md",      "customcontainers+attributes|advanced"),
         new Spec("Definition Lists",    "DefinitionListSpecs.md",       "definitionlists+attributes|advanced"),
-        new Spec("Emoji",               "EmojiSpecs.md",                "emojis|advanced+emojis"),
+        new Spec("Emoji",               "EmojiSpecs.md",                "pipetables+emojis|advanced+emojis"),
         new Spec("Abbreviations",       "AbbreviationSpecs.md",         "abbreviations|advanced"),
         new Spec("List Extras",         "ListExtraSpecs.md",            "listextras|advanced"),
         new Spec("Math",                "MathSpecs.md",                 "mathematics|advanced"),


### PR DESCRIPTION
This PR added `char.IsLetterOrDigit` to the character check in `EmojiParser.Match`.
It enables rendering for emoji patterns like `|:x:|`.
#807