### PR TITLE
Fix to calculate LinkReferenceDefinition span positions from StringLineGroup.Lines

### DIFF
--- a/src/Markdig.Tests/RoundtripSpecs/TestLinkReferenceDefinition.cs
+++ b/src/Markdig.Tests/RoundtripSpecs/TestLinkReferenceDefinition.cs
@@ -214,6 +214,9 @@ public class TestLinkReferenceDefinition
     [TestCase("> [foo]: /url\n> 'the title'\n")]
     [TestCase("> [foo]:\n> /url 'the title'\n")]
     [TestCase("> [foo]:\n> /url\n> 'the title'\n")]
+    [TestCase("> [foo]:\n> /url\n>\n> [foo]\n")]
+    [TestCase("> [foo]:\n> /url 'the title'\n>\n> [foo]\n")]
+    [TestCase("> [foo]:\n> /url\n> 'the title'\n>\n> [foo]\n")]
     public void TestMultilineInBlockquote(string value)
     {
         RoundTrip(value);

--- a/src/Markdig.Tests/RoundtripSpecs/TestLinkReferenceDefinition.cs
+++ b/src/Markdig.Tests/RoundtripSpecs/TestLinkReferenceDefinition.cs
@@ -209,4 +209,13 @@ public class TestLinkReferenceDefinition
     {
         RoundTrip(value);
     }
+
+    [TestCase("> [foo]: /url 'the title'\n")]
+    [TestCase("> [foo]: /url\n> 'the title'\n")]
+    [TestCase("> [foo]:\n> /url 'the title'\n")]
+    [TestCase("> [foo]:\n> /url\n> 'the title'\n")]
+    public void TestMultilineInBlockquote(string value)
+    {
+        RoundTrip(value);
+    }
 }

--- a/src/Markdig/Helpers/StringLineGroup.cs
+++ b/src/Markdig/Helpers/StringLineGroup.cs
@@ -2,6 +2,7 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
+using Markdig.Syntax;
 using System.Collections;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -188,6 +189,33 @@ public struct StringLineGroup : IEnumerable
         {
             Lines[i].Slice.Trim();
         }
+    }
+
+    internal SourceSpan ConvertToAbsoluteSpan(SourceSpan span)
+    {
+        if (span.IsEmpty || Count == 0) return span;
+
+        var startPosition = GetAbsolutePosition(span.Start);
+        var endPosition = GetAbsolutePosition(span.End);
+
+        return new SourceSpan(startPosition, endPosition);
+    }
+
+    private int GetAbsolutePosition(int position)
+    {
+        int offset = 0;
+        for (int i = 0; i < Count; i++)
+        {
+            ref StringSlice slice = ref Lines[i].Slice;
+            var lineLength = slice.Length + slice.NewLine.Length();
+
+            if (i == Count - 1 || position < offset + lineLength)
+            {
+                return slice.Start + (position - offset);
+            }
+            offset += lineLength;
+        }
+        return Lines[Count - 1].Slice.End + 1;
     }
 
     /// <summary>

--- a/src/Markdig/Parsers/ParagraphBlockParser.cs
+++ b/src/Markdig/Parsers/ParagraphBlockParser.cs
@@ -212,13 +212,11 @@ public class ParagraphBlockParser : BlockParser
 
                 // Correct the locations of each field
                 linkReferenceDefinition.Line = lines.Lines[0].Line;
-                int startPosition = lines.Lines[0].Slice.Start;
 
-                linkReferenceDefinition.Span        = linkReferenceDefinition.Span      .MoveForward(startPosition);
-                linkReferenceDefinition.LabelSpan   = linkReferenceDefinition.LabelSpan .MoveForward(startPosition);
-                linkReferenceDefinition.UrlSpan     = linkReferenceDefinition.UrlSpan   .MoveForward(startPosition);
-                linkReferenceDefinition.TitleSpan   = linkReferenceDefinition.TitleSpan .MoveForward(startPosition);
-
+                linkReferenceDefinition.Span = ConvertToAbsoluteSpan(lines, linkReferenceDefinition.Span);
+                linkReferenceDefinition.LabelSpan = ConvertToAbsoluteSpan(lines, linkReferenceDefinition.LabelSpan);
+                linkReferenceDefinition.UrlSpan = ConvertToAbsoluteSpan(lines, linkReferenceDefinition.UrlSpan);
+                linkReferenceDefinition.TitleSpan = ConvertToAbsoluteSpan(lines, linkReferenceDefinition.TitleSpan);
                 lines = iterator.Remaining();
             }
             else
@@ -256,24 +254,23 @@ public class ParagraphBlockParser : BlockParser
                 // Correct the locations of each field
                 lrd.Line = lines.Lines[0].Line;
                 var text = lines.Lines[0].Slice.Text;
-                int startPosition = lines.Lines[0].Slice.Start;
 
-                triviaBeforeLabel = triviaBeforeLabel.MoveForward(startPosition);
-                labelWithTrivia = labelWithTrivia.MoveForward(startPosition);
-                triviaBeforeUrl = triviaBeforeUrl.MoveForward(startPosition);
-                unescapedUrl = unescapedUrl.MoveForward(startPosition);
-                triviaBeforeTitle = triviaBeforeTitle.MoveForward(startPosition);
-                unescapedTitle = unescapedTitle.MoveForward(startPosition);
-                triviaAfterTitle = triviaAfterTitle.MoveForward(startPosition);
-                lrd.Span = lrd.Span.MoveForward(startPosition);
+                triviaBeforeLabel = ConvertToAbsoluteSpan(lines, triviaBeforeLabel);
+                labelWithTrivia = ConvertToAbsoluteSpan(lines, labelWithTrivia);
+                triviaBeforeUrl = ConvertToAbsoluteSpan(lines, triviaBeforeUrl);
+                unescapedUrl = ConvertToAbsoluteSpan(lines, unescapedUrl);
+                triviaBeforeTitle = ConvertToAbsoluteSpan(lines, triviaBeforeTitle);
+                unescapedTitle = ConvertToAbsoluteSpan(lines, unescapedTitle);
+                triviaAfterTitle = ConvertToAbsoluteSpan(lines, triviaAfterTitle);
+                lrd.Span = ConvertToAbsoluteSpan(lines, lrd.Span);
                 lrd.TriviaBefore = new StringSlice(text, triviaBeforeLabel.Start, triviaBeforeLabel.End);
-                lrd.LabelSpan = lrd.LabelSpan.MoveForward(startPosition);
+                lrd.LabelSpan = ConvertToAbsoluteSpan(lines, lrd.LabelSpan);
                 lrd.LabelWithTrivia = new StringSlice(text, labelWithTrivia.Start, labelWithTrivia.End);
                 lrd.TriviaBeforeUrl = new StringSlice(text, triviaBeforeUrl.Start, triviaBeforeUrl.End);
-                lrd.UrlSpan = lrd.UrlSpan.MoveForward(startPosition);
+                lrd.UrlSpan = ConvertToAbsoluteSpan(lines, lrd.UrlSpan);
                 lrd.UnescapedUrl = new StringSlice(text, unescapedUrl.Start, unescapedUrl.End);
                 lrd.TriviaBeforeTitle = new StringSlice(text, triviaBeforeTitle.Start, triviaBeforeTitle.End);
-                lrd.TitleSpan = lrd.TitleSpan.MoveForward(startPosition);
+                lrd.TitleSpan = ConvertToAbsoluteSpan(lines, lrd.TitleSpan);
                 lrd.UnescapedTitle = new StringSlice(text, unescapedTitle.Start, unescapedTitle.End);
                 lrd.TriviaAfter = new StringSlice(text, triviaAfterTitle.Start, triviaAfterTitle.End);
                 lrd.LinesBefore = paragraph.LinesBefore;
@@ -291,5 +288,32 @@ public class ParagraphBlockParser : BlockParser
         }
 
         return atLeastOneFound;
+    }
+
+    private static SourceSpan ConvertToAbsoluteSpan(StringLineGroup lines, SourceSpan span)
+    {
+        if (span.IsEmpty) return span;
+
+        var startPosition = GetAbsolutePosition(lines, span.Start);
+        var endPosition = startPosition + span.End - span.Start;
+
+        return new SourceSpan(startPosition, endPosition);
+    }
+
+    private static int GetAbsolutePosition(StringLineGroup lines, int position)
+    {
+        int offset = 0;
+        for (int i = 0; i < lines.Count; i++)
+        {
+            ref StringSlice slice = ref lines.Lines[i].Slice;
+            var lineLength = slice.Length + slice.NewLine.Length();
+
+            if (i == lines.Count - 1 || position < offset + lineLength)
+            {
+                return slice.Start + (position - offset);
+            }
+            offset += lineLength;
+        }
+        return lines.Lines[lines.Count - 1].Slice.End + 1;
     }
 }

--- a/src/Markdig/Parsers/ParagraphBlockParser.cs
+++ b/src/Markdig/Parsers/ParagraphBlockParser.cs
@@ -295,7 +295,7 @@ public class ParagraphBlockParser : BlockParser
         if (span.IsEmpty) return span;
 
         var startPosition = GetAbsolutePosition(lines, span.Start);
-        var endPosition = startPosition + span.End - span.Start;
+        var endPosition = GetAbsolutePosition(lines, span.End);
 
         return new SourceSpan(startPosition, endPosition);
     }

--- a/src/Markdig/Parsers/ParagraphBlockParser.cs
+++ b/src/Markdig/Parsers/ParagraphBlockParser.cs
@@ -213,10 +213,10 @@ public class ParagraphBlockParser : BlockParser
                 // Correct the locations of each field
                 linkReferenceDefinition.Line = lines.Lines[0].Line;
 
-                linkReferenceDefinition.Span = ConvertToAbsoluteSpan(lines, linkReferenceDefinition.Span);
-                linkReferenceDefinition.LabelSpan = ConvertToAbsoluteSpan(lines, linkReferenceDefinition.LabelSpan);
-                linkReferenceDefinition.UrlSpan = ConvertToAbsoluteSpan(lines, linkReferenceDefinition.UrlSpan);
-                linkReferenceDefinition.TitleSpan = ConvertToAbsoluteSpan(lines, linkReferenceDefinition.TitleSpan);
+                linkReferenceDefinition.Span = lines.ConvertToAbsoluteSpan(linkReferenceDefinition.Span);
+                linkReferenceDefinition.LabelSpan = lines.ConvertToAbsoluteSpan(linkReferenceDefinition.LabelSpan);
+                linkReferenceDefinition.UrlSpan = lines.ConvertToAbsoluteSpan(linkReferenceDefinition.UrlSpan);
+                linkReferenceDefinition.TitleSpan = lines.ConvertToAbsoluteSpan(linkReferenceDefinition.TitleSpan);
                 lines = iterator.Remaining();
             }
             else
@@ -255,22 +255,22 @@ public class ParagraphBlockParser : BlockParser
                 lrd.Line = lines.Lines[0].Line;
                 var text = lines.Lines[0].Slice.Text;
 
-                triviaBeforeLabel = ConvertToAbsoluteSpan(lines, triviaBeforeLabel);
-                labelWithTrivia = ConvertToAbsoluteSpan(lines, labelWithTrivia);
-                triviaBeforeUrl = ConvertToAbsoluteSpan(lines, triviaBeforeUrl);
-                unescapedUrl = ConvertToAbsoluteSpan(lines, unescapedUrl);
-                triviaBeforeTitle = ConvertToAbsoluteSpan(lines, triviaBeforeTitle);
-                unescapedTitle = ConvertToAbsoluteSpan(lines, unescapedTitle);
-                triviaAfterTitle = ConvertToAbsoluteSpan(lines, triviaAfterTitle);
-                lrd.Span = ConvertToAbsoluteSpan(lines, lrd.Span);
+                triviaBeforeLabel = lines.ConvertToAbsoluteSpan(triviaBeforeLabel);
+                labelWithTrivia = lines.ConvertToAbsoluteSpan(labelWithTrivia);
+                triviaBeforeUrl = lines.ConvertToAbsoluteSpan(triviaBeforeUrl);
+                unescapedUrl = lines.ConvertToAbsoluteSpan(unescapedUrl);
+                triviaBeforeTitle = lines.ConvertToAbsoluteSpan(triviaBeforeTitle);
+                unescapedTitle = lines.ConvertToAbsoluteSpan(unescapedTitle);
+                triviaAfterTitle = lines.ConvertToAbsoluteSpan(triviaAfterTitle);
+                lrd.Span = lines.ConvertToAbsoluteSpan(lrd.Span);
                 lrd.TriviaBefore = new StringSlice(text, triviaBeforeLabel.Start, triviaBeforeLabel.End);
-                lrd.LabelSpan = ConvertToAbsoluteSpan(lines, lrd.LabelSpan);
+                lrd.LabelSpan = lines.ConvertToAbsoluteSpan(lrd.LabelSpan);
                 lrd.LabelWithTrivia = new StringSlice(text, labelWithTrivia.Start, labelWithTrivia.End);
                 lrd.TriviaBeforeUrl = new StringSlice(text, triviaBeforeUrl.Start, triviaBeforeUrl.End);
-                lrd.UrlSpan = ConvertToAbsoluteSpan(lines, lrd.UrlSpan);
+                lrd.UrlSpan = lines.ConvertToAbsoluteSpan(lrd.UrlSpan);
                 lrd.UnescapedUrl = new StringSlice(text, unescapedUrl.Start, unescapedUrl.End);
                 lrd.TriviaBeforeTitle = new StringSlice(text, triviaBeforeTitle.Start, triviaBeforeTitle.End);
-                lrd.TitleSpan = ConvertToAbsoluteSpan(lines, lrd.TitleSpan);
+                lrd.TitleSpan = lines.ConvertToAbsoluteSpan(lrd.TitleSpan);
                 lrd.UnescapedTitle = new StringSlice(text, unescapedTitle.Start, unescapedTitle.End);
                 lrd.TriviaAfter = new StringSlice(text, triviaAfterTitle.Start, triviaAfterTitle.End);
                 lrd.LinesBefore = paragraph.LinesBefore;
@@ -290,30 +290,4 @@ public class ParagraphBlockParser : BlockParser
         return atLeastOneFound;
     }
 
-    private static SourceSpan ConvertToAbsoluteSpan(StringLineGroup lines, SourceSpan span)
-    {
-        if (span.IsEmpty) return span;
-
-        var startPosition = GetAbsolutePosition(lines, span.Start);
-        var endPosition = GetAbsolutePosition(lines, span.End);
-
-        return new SourceSpan(startPosition, endPosition);
-    }
-
-    private static int GetAbsolutePosition(StringLineGroup lines, int position)
-    {
-        int offset = 0;
-        for (int i = 0; i < lines.Count; i++)
-        {
-            ref StringSlice slice = ref lines.Lines[i].Slice;
-            var lineLength = slice.Length + slice.NewLine.Length();
-
-            if (i == lines.Count - 1 || position < offset + lineLength)
-            {
-                return slice.Start + (position - offset);
-            }
-            offset += lineLength;
-        }
-        return lines.Lines[lines.Count - 1].Slice.End + 1;
-    }
 }

--- a/src/Markdig/Renderers/TextRendererBase.cs
+++ b/src/Markdig/Renderers/TextRendererBase.cs
@@ -320,6 +320,10 @@ public abstract class TextRendererBase<T> : TextRendererBase where T : TextRende
         {
             WriteIndent();
             WriteRaw(content);
+            if (content[content.Length - 1] == '\n')
+            {
+                previousWasLine = true;
+            }
         }
     }
 

--- a/src/Markdig/Renderers/TextRendererBase.cs
+++ b/src/Markdig/Renderers/TextRendererBase.cs
@@ -320,7 +320,7 @@ public abstract class TextRendererBase<T> : TextRendererBase where T : TextRende
         {
             WriteIndent();
             WriteRaw(content);
-            if (content[content.Length - 1] == '\n')
+            if (content[content.Length - 1] == '\n' || content[content.Length - 1] == '\r')
             {
                 previousWasLine = true;
             }

--- a/src/Markdig/Renderers/TextRendererBase.cs
+++ b/src/Markdig/Renderers/TextRendererBase.cs
@@ -320,7 +320,7 @@ public abstract class TextRendererBase<T> : TextRendererBase where T : TextRende
         {
             WriteIndent();
             WriteRaw(content);
-            if (content[content.Length - 1] == '\n' || content[content.Length - 1] == '\r')
+            if (content[content.Length - 1] == '\n')
             {
                 previousWasLine = true;
             }


### PR DESCRIPTION
This PR fixes to calculate `LinkReferenceDefinition` span positions from `StringLineGroup.Lines` instead of `lines.Lines[0].Slice.Start`.
Also fix `TextRendererBase.Write(ReadOnlySpan<char>)` to update `previousWasLine` when the content ends with newline.
#846
