### PR TITLE
Add opt-in support for nested alert blocks

### DIFF
--- a/src/Markdig.Tests/MiscTests.cs
+++ b/src/Markdig.Tests/MiscTests.cs
@@ -337,7 +337,7 @@ $$
 ";
         TestParser.TestSpec(input, expected, new MarkdownPipelineBuilder().UseGridTables().Build());
     }
-  
+
     [Test]
     public void TestDefinitionListInListItemWithBlankLine()
     {
@@ -387,6 +387,91 @@ Also not a note.</p>
         TestParser.TestSpec(input, expected, new MarkdownPipelineBuilder().UseAlertBlocks().Build());
     }
 
+    [Test]
+    public void TestNestedAlertInsideBlockquote()
+    {
+        // >>[!NOTE] should become a blockquote wrapping an alert when AllowNestedAlerts is enabled
+        var input = @">>[!NOTE]
+Also a note.
+";
+
+        var expected = @"<blockquote>
+<div class=""markdown-alert markdown-alert-note"">
+<p class=""markdown-alert-title""><svg viewBox=""0 0 16 16"" version=""1.1"" width=""16"" height=""16"" aria-hidden=""true""><path d=""M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z""></path></svg>Note</p>
+<p>Also a note.</p>
+</div>
+</blockquote>
+";
+        TestParser.TestSpec(input, expected, new MarkdownPipelineBuilder().UseAlertBlocks(allowNestedAlerts: true).Build());
+    }
+
+    [Test]
+    public void TestNestedAlertInsideAlert()
+    {
+        // An alert inside another alert is never recognized, even with AllowNestedAlerts
+        var input = @">[!NOTE]
+> >[!TIP]
+> > A tip inside a note
+";
+
+        var expected = @"<div class=""markdown-alert markdown-alert-note"">
+<p class=""markdown-alert-title""><svg viewBox=""0 0 16 16"" version=""1.1"" width=""16"" height=""16"" aria-hidden=""true""><path d=""M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z""></path></svg>Note</p>
+<p></p>
+<blockquote>
+<p>[!TIP]
+A tip inside a note</p>
+</blockquote>
+</div>
+";
+        TestParser.TestSpec(input, expected, new MarkdownPipelineBuilder().UseAlertBlocks(allowNestedAlerts: true).Build());
+    }
+
+    [Test]
+    public void TestAlertInsideListItem()
+    {
+        // Alerts inside list items require AllowNestedAlerts
+        var input = @"- > [!NOTE]
+  > A note inside a list item
+";
+
+        var expected = @"<ul>
+<li>
+<div class=""markdown-alert markdown-alert-note"">
+<p class=""markdown-alert-title""><svg viewBox=""0 0 16 16"" version=""1.1"" width=""16"" height=""16"" aria-hidden=""true""><path d=""M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z""></path></svg>Note</p>
+<p>A note inside a list item</p>
+</div>
+</li>
+</ul>
+";
+        TestParser.TestSpec(input, expected, new MarkdownPipelineBuilder().UseAlertBlocks(allowNestedAlerts: true).Build());
+    }
+
+    [Test]
+    public void TestAlertInsideNestedListItem()
+    {
+        // Alert inside a nested list item (list item indented under another list item) requires AllowNestedAlerts
+        var input = @"- list item 1
+- list item 2
+  - > [!NOTE]
+    > A note inside a nested list item
+";
+
+        var expected = @"<ul>
+<li>list item 1</li>
+<li>list item 2
+<ul>
+<li>
+<div class=""markdown-alert markdown-alert-note"">
+<p class=""markdown-alert-title""><svg viewBox=""0 0 16 16"" version=""1.1"" width=""16"" height=""16"" aria-hidden=""true""><path d=""M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z""></path></svg>Note</p>
+<p>A note inside a nested list item</p>
+</div>
+</li>
+</ul>
+</li>
+</ul>
+";
+        TestParser.TestSpec(input, expected, new MarkdownPipelineBuilder().UseAlertBlocks(allowNestedAlerts: true).Build());
+    }
 
     [Test]
     public void TestIssue845ListItemBlankLine()

--- a/src/Markdig/Extensions/Alerts/AlertExtension.cs
+++ b/src/Markdig/Extensions/Alerts/AlertExtension.cs
@@ -19,13 +19,24 @@ public class AlertExtension : IMarkdownExtension
     /// </summary>
     public Action<HtmlRenderer, StringSlice>? RenderKind { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether alerts can be nested inside other blocks (e.g. inside a blockquote or a list item).
+    /// Alerts are never allowed inside another alert block regardless of this setting.
+    /// Default is <c>false</c>.
+    /// </summary>
+    public bool AllowNestedAlerts { get; set; }
+
     /// <inheritdoc />
     public void Setup(MarkdownPipelineBuilder pipeline)
     {
         var inlineParser = pipeline.InlineParsers.Find<AlertInlineParser>();
         if (inlineParser == null)
         {
-            pipeline.InlineParsers.InsertBefore<LinkInlineParser>(new AlertInlineParser());
+            pipeline.InlineParsers.InsertBefore<LinkInlineParser>(new AlertInlineParser() { AllowNestedAlerts = AllowNestedAlerts });
+        }
+        else
+        {
+            inlineParser.AllowNestedAlerts = AllowNestedAlerts;
         }
     }
 

--- a/src/Markdig/Extensions/Alerts/AlertInlineParser.cs
+++ b/src/Markdig/Extensions/Alerts/AlertInlineParser.cs
@@ -27,6 +27,13 @@ public class AlertInlineParser : InlineParser
     }
 
     /// <summary>
+    /// Gets or sets a value indicating whether alerts can be nested inside other blocks (e.g. inside a blockquote or a list item).
+    /// Alerts are never allowed inside another alert block regardless of this setting.
+    /// Default is <c>false</c>.
+    /// </summary>
+    public bool AllowNestedAlerts { get; set; }
+
+    /// <summary>
     /// Attempts to match the parser at the current position.
     /// </summary>
     public override bool Match(InlineProcessor processor, ref StringSlice slice)
@@ -43,7 +50,8 @@ public class AlertInlineParser : InlineParser
             paragraphBlock.Parent is not QuoteBlock quoteBlock ||
             paragraphBlock.Inline?.FirstChild != null ||
             quoteBlock is AlertBlock ||
-            quoteBlock.Parent is not MarkdownDocument)
+            IsInsideAlertBlock(quoteBlock) ||
+            (!AllowNestedAlerts && quoteBlock.Parent is not MarkdownDocument))
         {
             return false;
         }
@@ -120,5 +128,21 @@ public class AlertInlineParser : InlineParser
         processor.ReplaceParentContainer(quoteBlock, alertBlock);
 
         return true;
+    }
+
+    private static bool IsInsideAlertBlock(Block block)
+    {
+        var parent = block.Parent;
+        while (parent != null)
+        {
+            if (parent is AlertBlock)
+            {
+                return true;
+            }
+
+            parent = parent.Parent;
+        }
+
+        return false;
     }
 }

--- a/src/Markdig/MarkdownExtensions.cs
+++ b/src/Markdig/MarkdownExtensions.cs
@@ -101,11 +101,12 @@ public static class MarkdownExtensions
     /// Uses this extension to enable alert blocks.
     /// </summary>
     /// <param name="pipeline">The pipeline.</param>
-    /// <param name="renderKind">Replace the default renderer for the kind with a custom renderer</param>
+    /// <param name="renderKind">Replace the default renderer for the kind with a custom renderer.</param>
+    /// <param name="allowNestedAlerts">Allow alerts to be nested inside other blocks (e.g. inside a blockquote or a list item). Alerts inside another alert are never allowed. Default is <c>false</c>.</param>
     /// <returns>The modified pipeline</returns>
-    public static MarkdownPipelineBuilder UseAlertBlocks(this MarkdownPipelineBuilder pipeline, Action<HtmlRenderer, StringSlice>? renderKind = null)
+    public static MarkdownPipelineBuilder UseAlertBlocks(this MarkdownPipelineBuilder pipeline, Action<HtmlRenderer, StringSlice>? renderKind = null, bool allowNestedAlerts = false)
     {
-        pipeline.Extensions.ReplaceOrAdd<AlertExtension>(new AlertExtension() { RenderKind = renderKind });
+        pipeline.Extensions.ReplaceOrAdd<AlertExtension>(new AlertExtension() { RenderKind = renderKind, AllowNestedAlerts = allowNestedAlerts });
         return pipeline;
     }
 


### PR DESCRIPTION
Introduces AllowNestedAlerts on AlertExtension and AlertInlineParser
(default: false) to allow alert blocks inside blockquotes or list items.

The UseAlertBlocks() pipeline extension method exposes the new option
via an allowNestedAlerts parameter.

Resolves #853